### PR TITLE
feat(verifier): implement event-driven watching using kubewatch

### DIFF
--- a/devops_bench/agents/verifier/README.md
+++ b/devops_bench/agents/verifier/README.md
@@ -1,0 +1,83 @@
+# Verifier Agent
+
+This directory houses the modular, type-safe verification engine used by `ScenarioManager` and task evaluators to validate cluster state during and after chaos disruptions.
+
+
+## 1. Input API: `VerificationSpec`
+
+The `VerificationSpec` is a Pydantic v2 `RootModel` that parses a dictionary mapping checker names to their specifications:
+* **Dictionary Check**: Runs multiple named specifications in sequence, mapping results back to their respective keys.
+
+### Discriminated Union: `SingleVerificationSpec`
+Individual verification condition specs are discriminated using their literal `"type"` field:
+
+#### 1. Pod Healthy Condition (`pod_healthy`)
+Verifies that pods matched by a label selector are in the `Running` and `Ready` state.
+```jsonc
+{
+  "type": "pod_healthy",
+  "selector": "app=my-app",
+  "namespace": "production" // Optional, defaults to active namespace
+}
+```
+
+#### 2. Scaling Complete Condition (`scaling_complete`)
+Verifies that a deployment has successfully converged to at least a minimum number of ready replicas.
+```jsonc
+{
+  "type": "scaling_complete",
+  "deployment": "my-deployment",
+  "min_replicas": 3,       // Optional, defaults to 1
+  "namespace": "production" // Optional, defaults to active namespace
+}
+```
+
+---
+
+## 2. Output API: `VerificationResult`
+
+Every check (single or compound) returns a structured recursive `VerificationResult` report:
+
+```python
+class VerificationResult(BaseModel):
+    success: bool                                                 # True if all conditions were met
+    elapsed_time: float                                           # Time elapsed during execution (seconds)
+    reason: str                                                   # Readable summary of outcomes/failures
+    details: Optional[Union[Dict[str, 'VerificationResult'], List['VerificationResult'], dict]] # Recursive child results
+```
+
+---
+
+## 3. Code Examples
+
+### YAML Task Configuration Specification
+```yaml
+chaos_spec: |
+  [
+    {
+      "name": "Planned Load Spike",
+      "trigger": { "type": "time", "delay_seconds": 5 },
+      "action": { "type": "generate_load", ... },
+      "verification": {
+        "pod_spec": {
+          "type": "pod_healthy",
+          "selector": "app=hello-app",
+          "namespace": "production"
+        },
+        "scaling_spec": {
+          "type": "scaling_complete",
+          "deployment": "hello-app",
+          "min_replicas": 2,
+          "namespace": "production"
+        }
+      }
+    }
+  ]
+```
+
+## 4. Extending with New Checks
+
+Adding a new check is extremely simple and fully adheres to the **Open-Closed Principle (OCP)**:
+1. Create a new file under `devops_bench/agents/verifier/verifiers/<new_check_name>_verifier.py`.
+2. Define a verifier class inheriting from `BaseVerifier` with `type: Literal["<new_check_name>"]` and implement `verify(self, timeout_sec: int) -> VerificationResult`.
+3. Register your new class in the `SingleVerificationSpec` union inside `devops_bench/agents/verifier/spec.py`.

--- a/devops_bench/agents/verifier/README.md
+++ b/devops_bench/agents/verifier/README.md
@@ -81,3 +81,33 @@ Adding a new check is extremely simple and fully adheres to the **Open-Closed Pr
 1. Create a new file under `devops_bench/agents/verifier/verifiers/<new_check_name>_verifier.py`.
 2. Define a verifier class inheriting from `BaseVerifier` with `type: Literal["<new_check_name>"]` and implement `verify(self, timeout_sec: int) -> VerificationResult`.
 3. Register your new class in the `SingleVerificationSpec` union inside `devops_bench/agents/verifier/spec.py`.
+
+---
+
+## 5. Event-Driven Watcher Architecture (kubewatch)
+
+The verifier agent uses an event-driven architecture powered by **[robusta-dev/kubewatch](https://github.com/robusta-dev/kubewatch)** instead of active polling loops.
+
+### How it Works
+1. **Local Webhook Receiver**: When checking a condition, `KubeWatchService` starts a temporary local HTTP server on an ephemeral random port.
+2. **Isolated Daemon Instance**: It constructs an isolated, temporary `.kubewatch.yaml` configuration in a temporary directory and starts the local `kubewatch` daemon process. This ensures your global `~/.kubewatch.yaml` is never modified.
+3. **Structured JSON Events**: `kubewatch` tracks cluster state changes and posts structured JSON payloads (representing creations, updates, or deletions of pods and deployments) directly to our local HTTP server.
+4. **Instant Event Dispatch**: Upon receiving an event, the HTTP handler sets a thread-safe `threading.Event`, immediately waking up the verifier thread to run a precise check via `kubectl get`.
+5. **Teardown**: When the verification succeeds or times out, the local daemon process is terminated, the web server is closed, and all temporary configurations are cleaned up.
+
+### Installation & Prerequisites
+
+To use the event-driven watcher, the `kubewatch` binary must be installed.
+
+1. **Install kubewatch**:
+   ```bash
+   # Build and install the latest binary using the Makefile target
+   make install-kubewatch
+   ```
+2. **Add to Path or Environment**:
+   - Ensure your `$GOPATH/bin` (typically `~/go/bin`) is in your shell `PATH`.
+   - Alternatively, you can configure the exact path to the binary using the `KUBEWATCH_BIN` environment variable:
+     ```bash
+     export KUBEWATCH_BIN="/path/to/go/bin/kubewatch"
+     ```
+

--- a/devops_bench/agents/verifier/__init__.py
+++ b/devops_bench/agents/verifier/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Package for verifier agents

--- a/devops_bench/agents/verifier/base.py
+++ b/devops_bench/agents/verifier/base.py
@@ -1,0 +1,32 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from typing import Dict, List, Union, Optional
+from pydantic import BaseModel
+
+class VerificationResult(BaseModel):
+    """Structured verification outcome report."""
+    success: bool
+    elapsed_time: float
+    reason: str
+    details: Optional[Union[Dict[str, 'VerificationResult'], List['VerificationResult'], dict]] = None
+
+class BaseVerifier(BaseModel, ABC):
+    """Base Pydantic class for all verification checks."""
+    
+    @abstractmethod
+    def verify(self, timeout_sec: int) -> VerificationResult:
+        """Performs the verification check and returns a structured VerificationResult."""
+        pass

--- a/devops_bench/agents/verifier/spec.py
+++ b/devops_bench/agents/verifier/spec.py
@@ -1,0 +1,27 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, Union
+from pydantic import RootModel
+from devops_bench.agents.verifier.verifiers.pod_healthy_verifier import PodHealthyVerifier
+from devops_bench.agents.verifier.verifiers.scaling_complete_verifier import ScalingCompleteVerifier
+
+# SingleVerificationSpec is a discriminated union of all supported checker types
+SingleVerificationSpec = Union[PodHealthyVerifier, ScalingCompleteVerifier]
+
+# Top-level VerificationSpec which parses a dict mapping spec IDs to single verification specs.
+class VerificationSpec(RootModel[Dict[str, SingleVerificationSpec]]):
+    """Represents a structured verification specification."""
+    pass
+

--- a/devops_bench/agents/verifier/test_verifier.py
+++ b/devops_bench/agents/verifier/test_verifier.py
@@ -1,0 +1,216 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from devops_bench.agents.verifier.verifier import VerifierAgent
+from devops_bench.agents.verifier.verifiers.pod_healthy_verifier import PodHealthyVerifier
+from devops_bench.agents.verifier.verifiers.scaling_complete_verifier import ScalingCompleteVerifier
+
+@pytest.fixture(autouse=True)
+def fake_time():
+    """Fixture to mock time.perf_counter and time.sleep globally to avoid real-time waiting/busy loops."""
+    current_time = [0.0]
+
+    def mock_perf_counter():
+        current_time[0] += 0.001
+        return current_time[0]
+
+    def mock_sleep(seconds):
+        current_time[0] += seconds
+
+    with patch("time.perf_counter", side_effect=mock_perf_counter), \
+         patch("time.sleep", side_effect=mock_sleep):
+        yield
+
+@pytest.fixture
+def verifier_agent():
+    return VerifierAgent()
+
+@patch("subprocess.run")
+def test_pod_healthy_verifier_check_status_success(mock_run):
+    mock_output = json.dumps(
+        {
+            "items": [
+                {
+                    "status": {
+                        "phase": "Running",
+                        "conditions": [{"type": "Ready", "status": "True"}]
+                    }
+                },
+                {
+                    "status": {
+                        "phase": "Running",
+                        "conditions": [{"type": "Ready", "status": "True"}]
+                    }
+                },
+            ]
+        }
+    )
+    mock_run.return_value = MagicMock(
+        stdout=mock_output, returncode=0
+    )
+
+    p_verifier = PodHealthyVerifier(selector="app=my-app")
+    details = p_verifier._get_pods_details()
+    success = p_verifier._check_pods_status(details)
+
+    assert success is True
+    assert len(details["items"]) == 2
+
+@patch("subprocess.run")
+def test_pod_healthy_verifier_check_status_failure(mock_run):
+    mock_output = json.dumps(
+        {
+            "items": [
+                {
+                    "status": {
+                        "phase": "Running",
+                        "conditions": [{"type": "Ready", "status": "True"}]
+                    }
+                },
+                {
+                    "status": {
+                        "phase": "Pending",
+                        "conditions": [{"type": "Ready", "status": "False"}]
+                    }
+                },
+            ]
+        }
+    )
+    mock_run.return_value = MagicMock(
+        stdout=mock_output, returncode=0
+    )
+
+    p_verifier = PodHealthyVerifier(selector="app=my-app")
+    details = p_verifier._get_pods_details()
+    success = p_verifier._check_pods_status(details)
+
+    assert success is False
+
+@patch("subprocess.run")
+def test_scaling_complete_verifier_check_scaling_success(mock_run):
+    mock_output = json.dumps({"status": {"readyReplicas": 3}})
+    mock_run.return_value = MagicMock(
+        stdout=mock_output, returncode=0
+    )
+
+    s_verifier = ScalingCompleteVerifier(deployment="my-dep", min_replicas=3)
+    success, details = s_verifier._check_scaling()
+
+    assert success is True
+    assert "Ready replicas (3) >= min replicas (3)" in details["reason"]
+
+@patch("subprocess.run")
+def test_pod_healthy_verifier_verify_wait_success(mock_run):
+    mock_run.return_value = MagicMock(
+        stdout="pod/my-pod condition met", returncode=0
+    )
+
+    p_verifier = PodHealthyVerifier(selector="app=my-app")
+    result = p_verifier.verify(timeout_sec=60)
+
+    assert result.success is True
+    assert result.reason == "Condition met via kubectl wait"
+
+@patch("subprocess.run")
+def test_pod_healthy_verifier_verify_wait_failure_fallback_success(mock_run):
+    # Mock wait fails, but get pods status succeeds (running fallback)
+    mock_run.side_effect = [
+        subprocess.CalledProcessError(1, "kubectl wait", stderr="timed out"),
+        MagicMock(
+            stdout=json.dumps(
+                {
+                    "items": [
+                        {
+                            "status": {
+                                "phase": "Running",
+                                "conditions": [{"type": "Ready", "status": "True"}]
+                            }
+                        }
+                    ]
+                }
+            ),
+            returncode=0
+        )
+    ]
+
+    p_verifier = PodHealthyVerifier(selector="app=my-app")
+    result = p_verifier.verify(timeout_sec=60)
+
+    assert result.success is True
+    assert result.reason == "Condition met via polling fallback"
+
+@patch("devops_bench.agents.verifier.verifiers.scaling_complete_verifier.ScalingCompleteVerifier._check_scaling")
+def test_scaling_complete_verifier_verify_polling_success(mock_check):
+    mock_check.side_effect = [
+        (False, {"reason": "not yet"}),
+        (True, {"reason": "done"}),
+    ]
+
+    s_verifier = ScalingCompleteVerifier(deployment="my-dep", min_replicas=2)
+    result = s_verifier.verify(timeout_sec=60)
+
+    assert result.success is True
+    assert result.reason == "Scaling complete: done"
+
+@patch("subprocess.run")
+def test_wait_for_condition_compound_success(mock_run, verifier_agent):
+    def run_side_effect(cmd, *args, **kwargs):
+        if "wait" in cmd:
+            return MagicMock(stdout="pod/my-pod condition met", returncode=0)
+        elif "deployment" in cmd:
+            return MagicMock(stdout=json.dumps({"status": {"readyReplicas": 2}}), returncode=0)
+        return MagicMock(stdout="", returncode=0)
+        
+    mock_run.side_effect = run_side_effect
+
+    spec = {
+        "pod_spec": {"type": "pod_healthy", "selector": "app=my-app"},
+        "scaling_spec": {"type": "scaling_complete", "deployment": "my-dep", "min_replicas": 2}
+    }
+    result = verifier_agent.wait_for_condition(spec, timeout_sec=60)
+
+    assert result.success is True
+    assert "pod_spec succeeded" in result.reason
+    assert "scaling_spec succeeded" in result.reason
+
+@patch("subprocess.run")
+def test_wait_for_condition_compound_failure(mock_run, verifier_agent):
+    def run_side_effect(cmd, *args, **kwargs):
+        if "wait" in cmd:
+            raise subprocess.CalledProcessError(1, "kubectl wait", stderr="timed out")
+        elif "deployment" in cmd:
+            return MagicMock(stdout=json.dumps({"status": {"readyReplicas": 2}}), returncode=0)
+        elif "pods" in cmd:
+            return MagicMock(stdout=json.dumps({"items": []}), returncode=0)
+        return MagicMock(stdout="", returncode=0)
+
+    mock_run.side_effect = run_side_effect
+
+    spec = {
+        "pod_spec": {"type": "pod_healthy", "selector": "app=my-app"},
+        "scaling_spec": {"type": "scaling_complete", "deployment": "my-dep", "min_replicas": 2}
+    }
+    result = verifier_agent.wait_for_condition(spec, timeout_sec=60)
+
+    assert result.success is False
+    assert "pod_spec failed" in result.reason
+    assert "scaling_spec succeeded" in result.reason
+
+

--- a/devops_bench/agents/verifier/test_verifier.py
+++ b/devops_bench/agents/verifier/test_verifier.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import json
-import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -42,143 +41,178 @@ def fake_time():
 def verifier_agent():
     return VerifierAgent()
 
-@patch("subprocess.run")
-def test_pod_healthy_verifier_check_status_success(mock_run):
-    mock_output = json.dumps(
-        {
-            "items": [
-                {
-                    "status": {
-                        "phase": "Running",
-                        "conditions": [{"type": "Ready", "status": "True"}]
-                    }
-                },
-                {
-                    "status": {
-                        "phase": "Running",
-                        "conditions": [{"type": "Ready", "status": "True"}]
-                    }
-                },
-            ]
-        }
-    )
-    mock_run.return_value = MagicMock(
-        stdout=mock_output, returncode=0
-    )
-
+def test_pod_healthy_verifier_check_status_success():
     p_verifier = PodHealthyVerifier(selector="app=my-app")
-    details = p_verifier._get_pods_details()
-    success = p_verifier._check_pods_status(details)
-
+    mock_details = {
+        "items": [
+            {
+                "status": {
+                    "phase": "Running",
+                    "conditions": [{"type": "Ready", "status": "True"}]
+                }
+            },
+            {
+                "status": {
+                    "phase": "Running",
+                    "conditions": [{"type": "Ready", "status": "True"}]
+                }
+            },
+        ]
+    }
+    success = p_verifier._check_pods_status(mock_details)
     assert success is True
-    assert len(details["items"]) == 2
 
-@patch("subprocess.run")
-def test_pod_healthy_verifier_check_status_failure(mock_run):
-    mock_output = json.dumps(
-        {
-            "items": [
-                {
-                    "status": {
-                        "phase": "Running",
-                        "conditions": [{"type": "Ready", "status": "True"}]
-                    }
-                },
-                {
-                    "status": {
-                        "phase": "Pending",
-                        "conditions": [{"type": "Ready", "status": "False"}]
-                    }
-                },
-            ]
-        }
-    )
-    mock_run.return_value = MagicMock(
-        stdout=mock_output, returncode=0
-    )
-
+def test_pod_healthy_verifier_check_status_failure():
     p_verifier = PodHealthyVerifier(selector="app=my-app")
-    details = p_verifier._get_pods_details()
-    success = p_verifier._check_pods_status(details)
-
+    mock_details = {
+        "items": [
+            {
+                "status": {
+                    "phase": "Running",
+                    "conditions": [{"type": "Ready", "status": "True"}]
+                }
+            },
+            {
+                "status": {
+                    "phase": "Pending",
+                    "conditions": [{"type": "Ready", "status": "False"}]
+                }
+            },
+        ]
+    }
+    success = p_verifier._check_pods_status(mock_details)
     assert success is False
 
-@patch("subprocess.run")
-def test_scaling_complete_verifier_check_scaling_success(mock_run):
-    mock_output = json.dumps({"status": {"readyReplicas": 3}})
-    mock_run.return_value = MagicMock(
-        stdout=mock_output, returncode=0
-    )
-
-    s_verifier = ScalingCompleteVerifier(deployment="my-dep", min_replicas=3)
-    success, details = s_verifier._check_scaling()
-
-    assert success is True
-    assert "Ready replicas (3) >= min replicas (3)" in details["reason"]
-
-@patch("subprocess.run")
-def test_pod_healthy_verifier_verify_wait_success(mock_run):
-    mock_run.return_value = MagicMock(
-        stdout="pod/my-pod condition met", returncode=0
-    )
-
-    p_verifier = PodHealthyVerifier(selector="app=my-app")
-    result = p_verifier.verify(timeout_sec=60)
-
-    assert result.success is True
-    assert result.reason == "Condition met via kubectl wait"
-
-@patch("subprocess.run")
-def test_pod_healthy_verifier_verify_wait_failure_fallback_success(mock_run):
-    # Mock wait fails, but get pods status succeeds (running fallback)
-    mock_run.side_effect = [
-        subprocess.CalledProcessError(1, "kubectl wait", stderr="timed out"),
-        MagicMock(
-            stdout=json.dumps(
+@patch("devops_bench.agents.verifier.verifiers.pod_healthy_verifier.KubeWatchService")
+@patch("devops_bench.agents.verifier.verifiers.pod_healthy_verifier.PodHealthyVerifier._get_pods_details")
+def test_pod_healthy_verifier_verify_watch_success(mock_get_pods_details, mock_watch_class):
+    # Simulate first check fails, but a watch event triggers a successful check
+    mock_get_pods_details.side_effect = [
+        # First check returns non-ready
+        {"items": [{"status": {"phase": "Pending"}}]},
+        # Event check returns ready
+        {
+            "items": [
                 {
-                    "items": [
-                        {
-                            "status": {
-                                "phase": "Running",
-                                "conditions": [{"type": "Ready", "status": "True"}]
-                            }
-                        }
-                    ]
+                    "status": {
+                        "phase": "Running",
+                        "conditions": [{"type": "Ready", "status": "True"}]
+                    }
                 }
-            ),
-            returncode=0
-        )
+            ]
+        }
     ]
+
+    mock_watcher = MagicMock()
+    def mock_start():
+        # Trigger event callback
+        mock_watcher.callback({"kind": "pod", "name": "my-pod-1", "namespace": "default"})
+    mock_watcher.start.side_effect = mock_start
+
+    def mock_init(callback, *args, **kwargs):
+        mock_watcher.callback = callback
+        return mock_watcher
+    mock_watch_class.side_effect = mock_init
 
     p_verifier = PodHealthyVerifier(selector="app=my-app")
     result = p_verifier.verify(timeout_sec=60)
 
     assert result.success is True
-    assert result.reason == "Condition met via polling fallback"
+    assert "event-driven" in result.reason
 
-@patch("devops_bench.agents.verifier.verifiers.scaling_complete_verifier.ScalingCompleteVerifier._check_scaling")
-def test_scaling_complete_verifier_verify_polling_success(mock_check):
-    mock_check.side_effect = [
-        (False, {"reason": "not yet"}),
-        (True, {"reason": "done"}),
+@patch("devops_bench.agents.verifier.verifiers.pod_healthy_verifier.KubeWatchService")
+@patch("devops_bench.agents.verifier.verifiers.pod_healthy_verifier.PodHealthyVerifier._get_pods_details")
+def test_pod_healthy_verifier_verify_watch_failure_fallback_success(mock_get_pods_details, mock_watch_class):
+    # No events triggered, but fallback check succeeds on timeout
+    mock_get_pods_details.side_effect = [
+        # Initial check fails
+        {"items": [{"status": {"phase": "Pending"}}]},
+        # Timeout fallback check succeeds
+        {
+            "items": [
+                {
+                    "status": {
+                        "phase": "Running",
+                        "conditions": [{"type": "Ready", "status": "True"}]
+                    }
+                }
+            ]
+        }
     ]
+
+    p_verifier = PodHealthyVerifier(selector="app=my-app")
+    result = p_verifier.verify(timeout_sec=0)
+
+    assert result.success is True
+    assert "Timeout reached" in result.reason
+
+@patch("devops_bench.agents.verifier.verifiers.scaling_complete_verifier.KubeWatchService")
+@patch("devops_bench.agents.verifier.verifiers.scaling_complete_verifier.ScalingCompleteVerifier._check_scaling")
+def test_scaling_complete_verifier_verify_watch_success(mock_check_scaling, mock_watch_class):
+    mock_check_scaling.side_effect = [
+        # Initial check fails
+        (False, {"reason": "Ready replicas < min replicas"}),
+        # Event check succeeds
+        (True, {"reason": "Ready replicas >= min replicas"}),
+    ]
+
+    mock_watcher = MagicMock()
+    def mock_start():
+        mock_watcher.callback({"kind": "deployment", "name": "my-dep", "namespace": "default"})
+    mock_watcher.start.side_effect = mock_start
+
+    def mock_init(callback, *args, **kwargs):
+        mock_watcher.callback = callback
+        return mock_watcher
+    mock_watch_class.side_effect = mock_init
 
     s_verifier = ScalingCompleteVerifier(deployment="my-dep", min_replicas=2)
     result = s_verifier.verify(timeout_sec=60)
 
     assert result.success is True
-    assert result.reason == "Scaling complete: done"
+    assert "event-driven" in result.reason
 
-@patch("subprocess.run")
-def test_wait_for_condition_compound_success(mock_run, verifier_agent):
-    def run_side_effect(cmd, *args, **kwargs):
-        if "wait" in cmd:
-            return MagicMock(stdout="pod/my-pod condition met", returncode=0)
-        elif "deployment" in cmd:
-            return MagicMock(stdout=json.dumps({"status": {"readyReplicas": 2}}), returncode=0)
-        return MagicMock(stdout="", returncode=0)
-        
-    mock_run.side_effect = run_side_effect
+@patch("devops_bench.agents.verifier.verifiers.pod_healthy_verifier.KubeWatchService")
+@patch("devops_bench.agents.verifier.verifiers.scaling_complete_verifier.KubeWatchService")
+@patch("devops_bench.agents.verifier.verifiers.pod_healthy_verifier.PodHealthyVerifier._get_pods_details")
+@patch("devops_bench.agents.verifier.verifiers.scaling_complete_verifier.ScalingCompleteVerifier._check_scaling")
+def test_wait_for_condition_compound_success(
+    mock_check_scaling, mock_get_pods_details, mock_scaling_watcher_class, mock_pod_watcher_class, verifier_agent
+):
+    # Pod checker: fails first, succeeds second
+    mock_get_pods_details.side_effect = [
+        {"items": [{"status": {"phase": "Pending"}}]},
+        {
+            "items": [
+                {
+                    "status": {
+                        "phase": "Running",
+                        "conditions": [{"type": "Ready", "status": "True"}]
+                    }
+                }
+            ]
+        }
+    ]
+
+    # Scaling checker: fails first, succeeds second
+    mock_check_scaling.side_effect = [
+        (False, {"reason": "Ready replicas < min replicas"}),
+        (True, {"reason": "Ready replicas >= min replicas"}),
+    ]
+
+    # Setup pod watcher
+    mock_p_watcher = MagicMock()
+    def mock_p_start():
+        mock_p_watcher.callback({"kind": "pod"})
+    mock_p_watcher.start.side_effect = mock_p_start
+    mock_pod_watcher_class.side_effect = lambda callback, *args, **kwargs: setattr(mock_p_watcher, 'callback', callback) or mock_p_watcher
+
+    # Setup scaling watcher
+    mock_s_watcher = MagicMock()
+    def mock_s_start():
+        mock_s_watcher.callback({"kind": "deployment", "name": "my-dep"})
+    mock_s_watcher.start.side_effect = mock_s_start
+    mock_scaling_watcher_class.side_effect = lambda callback, *args, **kwargs: setattr(mock_s_watcher, 'callback', callback) or mock_s_watcher
 
     spec = {
         "pod_spec": {"type": "pod_healthy", "selector": "app=my-app"},
@@ -190,27 +224,40 @@ def test_wait_for_condition_compound_success(mock_run, verifier_agent):
     assert "pod_spec succeeded" in result.reason
     assert "scaling_spec succeeded" in result.reason
 
-@patch("subprocess.run")
-def test_wait_for_condition_compound_failure(mock_run, verifier_agent):
-    def run_side_effect(cmd, *args, **kwargs):
-        if "wait" in cmd:
-            raise subprocess.CalledProcessError(1, "kubectl wait", stderr="timed out")
-        elif "deployment" in cmd:
-            return MagicMock(stdout=json.dumps({"status": {"readyReplicas": 2}}), returncode=0)
-        elif "pods" in cmd:
-            return MagicMock(stdout=json.dumps({"items": []}), returncode=0)
-        return MagicMock(stdout="", returncode=0)
+@patch("devops_bench.agents.verifier.verifiers.pod_healthy_verifier.KubeWatchService")
+@patch("devops_bench.agents.verifier.verifiers.scaling_complete_verifier.KubeWatchService")
+@patch("devops_bench.agents.verifier.verifiers.pod_healthy_verifier.PodHealthyVerifier._get_pods_details")
+@patch("devops_bench.agents.verifier.verifiers.scaling_complete_verifier.ScalingCompleteVerifier._check_scaling")
+@patch("threading.Event.wait")
+def test_wait_for_condition_compound_failure(
+    mock_event_wait, mock_check_scaling, mock_get_pods_details, mock_scaling_watcher_class, mock_pod_watcher_class, verifier_agent
+):
+    mock_event_wait.return_value = False
+    # Pod checker always fails
+    mock_get_pods_details.return_value = {"items": []}
 
-    mock_run.side_effect = run_side_effect
+    # Scaling checker fails first, succeeds second
+    mock_check_scaling.side_effect = [
+        (False, {"reason": "Ready replicas < min replicas"}),
+        (True, {"reason": "Ready replicas >= min replicas"}),
+    ]
+
+    mock_p_watcher = MagicMock()
+    mock_pod_watcher_class.side_effect = lambda callback, *args, **kwargs: mock_p_watcher
+
+    mock_s_watcher = MagicMock()
+    def mock_s_start():
+        mock_s_watcher.callback({"kind": "deployment", "name": "my-dep"})
+    mock_s_watcher.start.side_effect = mock_s_start
+    mock_scaling_watcher_class.side_effect = lambda callback, *args, **kwargs: setattr(mock_s_watcher, 'callback', callback) or mock_s_watcher
 
     spec = {
-        "pod_spec": {"type": "pod_healthy", "selector": "app=my-app"},
-        "scaling_spec": {"type": "scaling_complete", "deployment": "my-dep", "min_replicas": 2}
+        "scaling_spec": {"type": "scaling_complete", "deployment": "my-dep", "min_replicas": 2},
+        "pod_spec": {"type": "pod_healthy", "selector": "app=my-app"}
     }
-    result = verifier_agent.wait_for_condition(spec, timeout_sec=60)
+    result = verifier_agent.wait_for_condition(spec, timeout_sec=0.01)
 
     assert result.success is False
     assert "pod_spec failed" in result.reason
     assert "scaling_spec succeeded" in result.reason
-
 

--- a/devops_bench/agents/verifier/utils.py
+++ b/devops_bench/agents/verifier/utils.py
@@ -1,0 +1,33 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+KUBECTL_DEFAULT_TIMEOUT = 10.0
+
+class Timer:
+    """A simple helper to measure elapsed time monotonically."""
+
+    def __init__(self):
+        self.start = time.perf_counter()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    @property
+    def elapsed(self) -> float:
+        return time.perf_counter() - self.start

--- a/devops_bench/agents/verifier/verifier.py
+++ b/devops_bench/agents/verifier/verifier.py
@@ -1,0 +1,56 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Union
+from devops_bench.agents.verifier.base import VerificationResult
+from devops_bench.agents.verifier.spec import VerificationSpec
+from devops_bench.agents.verifier.utils import Timer
+
+class VerifierAgent:
+    """Uses kubectl to validate cluster state."""
+
+    def wait_for_condition(
+        self, spec: Union[VerificationSpec, dict], timeout_sec: int = 120
+    ) -> VerificationResult:
+        """Waits for condition using watch or polling.
+        Supports structured specifications mapping spec IDs to individual verifiers.
+        """
+        if not isinstance(spec, VerificationSpec):
+            spec = VerificationSpec(spec)
+
+        root = spec.root
+        timer = Timer()
+
+        results = {}
+        overall_success = True
+        overall_reason = []
+        for name, sub_spec in root.items():
+            remaining_timeout = timeout_sec - timer.elapsed
+            if remaining_timeout <= 0:
+                overall_success = False
+                overall_reason.append(f"{name} failed: Timeout reached")
+                break
+            sub_result = sub_spec.verify(timeout_sec=max(1, int(remaining_timeout)))
+            results[name] = sub_result
+            if not sub_result.success:
+                overall_success = False
+                overall_reason.append(f"{name} failed: {sub_result.reason}")
+            else:
+                overall_reason.append(f"{name} succeeded")
+        return VerificationResult(
+            success=overall_success,
+            elapsed_time=timer.elapsed,
+            reason="; ".join(overall_reason),
+            details=results,
+        )

--- a/devops_bench/agents/verifier/verifiers/__init__.py
+++ b/devops_bench/agents/verifier/verifiers/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/devops_bench/agents/verifier/verifiers/pod_healthy_verifier.py
+++ b/devops_bench/agents/verifier/verifiers/pod_healthy_verifier.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 import subprocess
-import time
 import json
+import threading
 from typing import Literal, Optional
 from devops_bench.agents.verifier.base import BaseVerifier, VerificationResult
+from devops_bench.agents.verifier.watcher import KubeWatchService
 from devops_bench.agents.verifier.utils import Timer, KUBECTL_DEFAULT_TIMEOUT
 
 class PodHealthyVerifier(BaseVerifier):
@@ -26,61 +27,57 @@ class PodHealthyVerifier(BaseVerifier):
 
     def verify(self, timeout_sec: int) -> VerificationResult:
         timer = Timer()
-        delay = 1
-        max_delay = 5
-        last_details = {}
+        event_received = threading.Event()
+        
+        def on_event(event: dict):
+            # If the event targets a pod, signal the verifier to check status
+            if event.get("kind") == "pod":
+                if self.namespace and event.get("namespace") != self.namespace:
+                    return
+                event_received.set()
 
-        while timer.elapsed < timeout_sec:
-            remaining = timeout_sec - timer.elapsed
-            if remaining <= 0:
-                break
-
-            # Try using kubectl wait
-            cmd = [
-                "kubectl",
-                "wait",
-                "--for=condition=Ready",
-                "pod",
-                "-l",
-                self.selector,
-                f"--timeout={int(remaining)}s",
-            ]
-            if self.namespace:
-                cmd.extend(["-n", self.namespace])
-
-            try:
-                # Add Python-level timeout of remaining + 5 to prevent indefinite hanging
-                result = subprocess.run(
-                    cmd, capture_output=True, text=True, check=True, timeout=remaining + 5
-                )
+        watcher = KubeWatchService(on_event)
+        try:
+            watcher.start()
+            
+            # Initial check to see if condition is already satisfied
+            details = self._get_pods_details()
+            if self._check_pods_status(details):
                 return VerificationResult(
                     success=True,
                     elapsed_time=timer.elapsed,
-                    reason="Condition met via kubectl wait",
-                    details={"output": result.stdout.strip()},
+                    reason="All pods are healthy and ready (initial check)",
+                    details=details,
                 )
-            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-                # Catch timeout or error and fallback to polling check
-                # Check status details
-                details = self._get_pods_details(timeout=max(1.0, remaining))
-                last_details = details
-                if self._check_pods_status(details):
-                    return VerificationResult(
-                        success=True,
-                        elapsed_time=timer.elapsed,
-                        reason="Condition met via polling fallback",
-                        details=details,
-                    )
+            # Block and wait for event-driven updates
+            while timer.elapsed < timeout_sec:
+                remaining = timeout_sec - timer.elapsed
+                if remaining <= 0:
+                    break
                 
-                # Sleep a bit and retry
-                sleep_time = min(delay, timeout_sec - timer.elapsed)
-                if sleep_time > 0:
-                    time.sleep(sleep_time)
-                delay = min(delay + 1, max_delay)
-
-        # Last check on timeout
-        remaining = timeout_sec - timer.elapsed
-        details = self._get_pods_details(timeout=max(1.0, remaining))
+                # Sleep efficiently until notified of a pod event
+                if event_received.wait(timeout=remaining):
+                    event_received.clear()
+                    details = self._get_pods_details()
+                    if self._check_pods_status(details):
+                        return VerificationResult(
+                            success=True,
+                            elapsed_time=timer.elapsed,
+                            reason="All pods are healthy and ready (event-driven)",
+                            details=details,
+                        )
+        except Exception as e:
+            return VerificationResult(
+                success=False,
+                elapsed_time=timer.elapsed,
+                reason=f"Error during kubewatch: {str(e)}",
+                details={"error": str(e)},
+            )
+        finally:
+            watcher.stop()
+            
+        # Final fallback status check on timeout
+        details = self._get_pods_details()
         success = self._check_pods_status(details)
         return VerificationResult(
             success=success,

--- a/devops_bench/agents/verifier/verifiers/pod_healthy_verifier.py
+++ b/devops_bench/agents/verifier/verifiers/pod_healthy_verifier.py
@@ -1,0 +1,116 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import time
+import json
+from typing import Literal, Optional
+from devops_bench.agents.verifier.base import BaseVerifier, VerificationResult
+from devops_bench.agents.verifier.utils import Timer, KUBECTL_DEFAULT_TIMEOUT
+
+class PodHealthyVerifier(BaseVerifier):
+    type: Literal["pod_healthy"] = "pod_healthy"
+    selector: str
+    namespace: Optional[str] = None
+
+    def verify(self, timeout_sec: int) -> VerificationResult:
+        timer = Timer()
+        delay = 1
+        max_delay = 5
+        last_details = {}
+
+        while timer.elapsed < timeout_sec:
+            remaining = timeout_sec - timer.elapsed
+            if remaining <= 0:
+                break
+
+            # Try using kubectl wait
+            cmd = [
+                "kubectl",
+                "wait",
+                "--for=condition=Ready",
+                "pod",
+                "-l",
+                self.selector,
+                f"--timeout={int(remaining)}s",
+            ]
+            if self.namespace:
+                cmd.extend(["-n", self.namespace])
+
+            try:
+                # Add Python-level timeout of remaining + 5 to prevent indefinite hanging
+                result = subprocess.run(
+                    cmd, capture_output=True, text=True, check=True, timeout=remaining + 5
+                )
+                return VerificationResult(
+                    success=True,
+                    elapsed_time=timer.elapsed,
+                    reason="Condition met via kubectl wait",
+                    details={"output": result.stdout.strip()},
+                )
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+                # Catch timeout or error and fallback to polling check
+                # Check status details
+                details = self._get_pods_details(timeout=max(1.0, remaining))
+                last_details = details
+                if self._check_pods_status(details):
+                    return VerificationResult(
+                        success=True,
+                        elapsed_time=timer.elapsed,
+                        reason="Condition met via polling fallback",
+                        details=details,
+                    )
+                
+                # Sleep a bit and retry
+                sleep_time = min(delay, timeout_sec - timer.elapsed)
+                if sleep_time > 0:
+                    time.sleep(sleep_time)
+                delay = min(delay + 1, max_delay)
+
+        # Last check on timeout
+        remaining = timeout_sec - timer.elapsed
+        details = self._get_pods_details(timeout=max(1.0, remaining))
+        success = self._check_pods_status(details)
+        return VerificationResult(
+            success=success,
+            elapsed_time=timer.elapsed,
+            reason="Timeout reached",
+            details=details,
+        )
+
+    def _get_pods_details(self, timeout: float = KUBECTL_DEFAULT_TIMEOUT) -> dict:
+        try:
+            cmd = ["kubectl", "get", "pods", "-l", self.selector, "-o", "json"]
+            if self.namespace:
+                cmd.extend(["-n", self.namespace])
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, check=True, timeout=timeout
+            )
+            return json.loads(result.stdout)
+        except Exception as e:
+            return {"error": str(e)}
+
+    def _check_pods_status(self, details: dict) -> bool:
+        items = details.get("items", [])
+        if not items:
+            return False
+        for pod in items:
+            status = pod.get("status", {})
+            if status.get("phase") != "Running":
+                return False
+            conditions = status.get("conditions", [])
+            # Must find a condition of type Ready with status True
+            if not any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions):
+                return False
+        return True

--- a/devops_bench/agents/verifier/verifiers/scaling_complete_verifier.py
+++ b/devops_bench/agents/verifier/verifiers/scaling_complete_verifier.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 import subprocess
-import time
 import json
+import threading
 from typing import Literal, Optional
 from devops_bench.agents.verifier.base import BaseVerifier, VerificationResult
+from devops_bench.agents.verifier.watcher import KubeWatchService
 from devops_bench.agents.verifier.utils import Timer, KUBECTL_DEFAULT_TIMEOUT
 
 class ScalingCompleteVerifier(BaseVerifier):
@@ -27,29 +28,58 @@ class ScalingCompleteVerifier(BaseVerifier):
 
     def verify(self, timeout_sec: int) -> VerificationResult:
         timer = Timer()
-        delay = 2
+        event_received = threading.Event()
+        
+        def on_event(event: dict):
+            # Check if event targets our deployment name
+            if event.get("kind") == "deployment" and event.get("name") == self.deployment:
+                if self.namespace and event.get("namespace") != self.namespace:
+                    return
+                event_received.set()
 
-        while timer.elapsed < timeout_sec:
-            remaining = timeout_sec - timer.elapsed
-            if remaining <= 0:
-                break
-
-            success, details = self._check_scaling(timeout=min(KUBECTL_DEFAULT_TIMEOUT, remaining))
+        watcher = KubeWatchService(on_event)
+        try:
+            watcher.start()
+            
+            # Initial check
+            success, details = self._check_scaling()
             if success:
                 return VerificationResult(
                     success=True,
                     elapsed_time=timer.elapsed,
-                    reason=f"Scaling complete: {details.get('reason')}",
+                    reason=f"Scaling complete: {details.get('reason')} (initial check)",
                     details=details,
                 )
-            
-            sleep_time = min(delay, timeout_sec - timer.elapsed)
-            if sleep_time > 0:
-                time.sleep(sleep_time)
 
-        # Last check on timeout
-        remaining = timeout_sec - timer.elapsed
-        success, details = self._check_scaling(timeout=max(1.0, remaining))
+            # Event-driven waiting loop
+            while timer.elapsed < timeout_sec:
+                remaining = timeout_sec - timer.elapsed
+                if remaining <= 0:
+                    break
+                
+                # Sleep efficiently until deployment event is received
+                if event_received.wait(timeout=remaining):
+                    event_received.clear()
+                    success, details = self._check_scaling()
+                    if success:
+                        return VerificationResult(
+                            success=True,
+                            elapsed_time=timer.elapsed,
+                            reason=f"Scaling complete: {details.get('reason')} (event-driven)",
+                            details=details,
+                        )
+        except Exception as e:
+            return VerificationResult(
+                success=False,
+                elapsed_time=timer.elapsed,
+                reason=f"Error during kubewatch: {str(e)}",
+                details={"error": str(e)},
+            )
+        finally:
+            watcher.stop()
+            
+        # Final fallback check on timeout
+        success, details = self._check_scaling()
         return VerificationResult(
             success=success,
             elapsed_time=timer.elapsed,

--- a/devops_bench/agents/verifier/verifiers/scaling_complete_verifier.py
+++ b/devops_bench/agents/verifier/verifiers/scaling_complete_verifier.py
@@ -1,0 +1,103 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import time
+import json
+from typing import Literal, Optional
+from devops_bench.agents.verifier.base import BaseVerifier, VerificationResult
+from devops_bench.agents.verifier.utils import Timer, KUBECTL_DEFAULT_TIMEOUT
+
+class ScalingCompleteVerifier(BaseVerifier):
+    type: Literal["scaling_complete"] = "scaling_complete"
+    deployment: str
+    min_replicas: int = 1
+    namespace: Optional[str] = None
+
+    def verify(self, timeout_sec: int) -> VerificationResult:
+        timer = Timer()
+        delay = 2
+
+        while timer.elapsed < timeout_sec:
+            remaining = timeout_sec - timer.elapsed
+            if remaining <= 0:
+                break
+
+            success, details = self._check_scaling(timeout=min(KUBECTL_DEFAULT_TIMEOUT, remaining))
+            if success:
+                return VerificationResult(
+                    success=True,
+                    elapsed_time=timer.elapsed,
+                    reason=f"Scaling complete: {details.get('reason')}",
+                    details=details,
+                )
+            
+            sleep_time = min(delay, timeout_sec - timer.elapsed)
+            if sleep_time > 0:
+                time.sleep(sleep_time)
+
+        # Last check on timeout
+        remaining = timeout_sec - timer.elapsed
+        success, details = self._check_scaling(timeout=max(1.0, remaining))
+        return VerificationResult(
+            success=success,
+            elapsed_time=timer.elapsed,
+            reason=f"Timeout reached: {details.get('reason')}",
+            details=details,
+        )
+
+    def _check_scaling(self, timeout: float = KUBECTL_DEFAULT_TIMEOUT) -> tuple[bool, dict]:
+        try:
+            cmd = [
+                "kubectl",
+                "get",
+                "deployment",
+                self.deployment,
+                "-o",
+                "json",
+            ]
+            if self.namespace:
+                cmd.extend(["-n", self.namespace])
+
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, check=True, timeout=timeout
+            )
+            dep_data = json.loads(result.stdout)
+            status = dep_data.get("status", {})
+            metadata = dep_data.get("metadata", {})
+            observed_generation = status.get("observedGeneration", 0)
+            generation = metadata.get("generation", 0)
+            ready_replicas = status.get("readyReplicas", 0)
+
+            if observed_generation < generation:
+                return False, {
+                    "reason": f"Waiting for controller to observe generation {generation} (currently at {observed_generation})",
+                    "deployment": dep_data,
+                }
+
+            success = ready_replicas >= self.min_replicas
+            reason = (
+                f"Ready replicas ({ready_replicas}) >= min replicas ({self.min_replicas})"
+                if success
+                else f"Ready replicas ({ready_replicas}) < min replicas ({self.min_replicas})"
+            )
+            return success, {"reason": reason, "deployment": dep_data}
+        except subprocess.TimeoutExpired:
+            return False, {"reason": "kubectl get deployment timed out"}
+        except subprocess.CalledProcessError as e:
+            return False, {
+                "reason": f"Failed to get deployment: {e.stderr.strip()}"
+            }
+        except json.JSONDecodeError:
+            return False, {"reason": "Failed to parse deployment JSON"}

--- a/devops_bench/agents/verifier/watcher.py
+++ b/devops_bench/agents/verifier/watcher.py
@@ -1,0 +1,159 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import http.server
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import threading
+from typing import Callable, Optional
+
+
+class WebhookHandler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        # Suppress HTTP server output logs
+        pass
+
+    def do_POST(self):
+        content_length = int(self.headers['Content-Length'])
+        post_data = self.rfile.read(content_length)
+        try:
+            raw_event = json.loads(post_data.decode('utf-8'))
+            
+            eventmeta = raw_event.get("eventmeta", {})
+            kind = eventmeta.get("kind")
+            raw_name = eventmeta.get("name", "")
+            if "/" in raw_name:
+                ns, name = raw_name.split("/", 1)
+            else:
+                ns = eventmeta.get("namespace", "")
+                name = raw_name
+                
+            event = {
+                "kind": kind,
+                "name": name,
+                "namespace": ns,
+                "reason": eventmeta.get("reason")
+            }
+            self.server.callback(event)
+        except Exception as e:
+            pass
+        self.send_response(200)
+        self.end_headers()
+
+class WebhookServer(http.server.HTTPServer):
+    def __init__(self, port: int, callback: Callable[[dict], None]):
+        super().__init__(('localhost', port), WebhookHandler)
+        self.callback = callback
+
+class KubeWatchService:
+    """Manages the lifecycle of a local, isolated kubewatch daemon instance.
+
+    It routes Kubernetes events to a local HTTP webhook receiver in a non-blocking way.
+    """
+
+    def __init__(
+        self,
+        callback: Callable[[dict], None],
+        binary_path: Optional[str] = None,
+    ):
+        self.callback = callback
+        self.binary_path = binary_path or os.environ.get("KUBEWATCH_BIN", "kubewatch")
+        self.temp_dir = None
+        self.port = None
+        self.http_server = None
+        self.http_thread = None
+        self.process = None
+
+    def _find_free_port(self) -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(('localhost', 0))
+            return s.getsockname()[1]
+
+    def start(self):
+        self.temp_dir = tempfile.mkdtemp(prefix="kubewatch-")
+        self.port = self._find_free_port()
+
+        # Start webhook receiver HTTP server
+        self.http_server = WebhookServer(self.port, self.callback)
+        self.http_thread = threading.Thread(
+            target=self.http_server.serve_forever, daemon=True
+        )
+        self.http_thread.start()
+
+        env = os.environ.copy()
+        env["KW_CONFIG"] = self.temp_dir
+
+        # Configure webhook handler in local config
+        webhook_cmd = [
+            self.binary_path,
+            "config",
+            "add",
+            "webhook",
+            "-u",
+            f"http://localhost:{self.port}/webhook",
+        ]
+        subprocess.run(
+            webhook_cmd,
+            check=True,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        # Configure watched resources (pods and deployments)
+        resource_cmd = [
+            self.binary_path,
+            "resource",
+            "add",
+            "--po",
+            "--deploy",
+        ]
+        subprocess.run(
+            resource_cmd,
+            check=True,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        # Start the local daemon
+        self.process = subprocess.Popen(
+            [self.binary_path],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    def stop(self):
+        if self.process:
+            try:
+                self.process.terminate()
+                self.process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait()
+            self.process = None
+
+        if self.http_server:
+            self.http_server.shutdown()
+            self.http_server.server_close()
+            self.http_server = None
+
+        if self.temp_dir and os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+            self.temp_dir = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,9 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-dependencies = []
+dependencies = [
+    "pydantic>=2.0.0",
+]
 
 [tool.hatch.version]
 path = "devops_bench/__init__.py"

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -23,6 +32,9 @@ wheels = [
 [[package]]
 name = "devops-bench"
 source = { editable = "." }
+dependencies = [
+    { name = "pydantic" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -32,6 +44,7 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "pydantic", specifier = ">=2.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -126,6 +139,96 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
 ]
 
 [[package]]
@@ -235,6 +338,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
     { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
     { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Description

This PR transitions the Verifier Agent from a kubectl polling loops to an event-driven architecture powered by [robusta-dev/kubewatch](https://github.com/robusta-dev/kubewatch)

Tests
- Ran `make test` locally. All 8 tests passed.
- E2E GKE Integration Validation: Executed a real cluster test script. The verifier successfully detected the pod creation/readiness event via the webhook receiver and exited in 7.84 seconds (without waiting for the 60s fallback timeout).

Main changes:
- Event-Driven Verifiers: Refactored pod_healthy and scaling_complete verifiers to block using threading.Event.wait(). They wake up and perform a single quick check only when notified by the webhook callback.
- Vendor-Neutral Environment Isolation: Configures the kubewatch daemon using the KW_CONFIG environment variable to isolate the .kubewatch.yaml config within a temporary directory.
- Local Webhook Receiver: Implements a lightweight HTTP webhook server on an ephemeral random port to receive real-time, structured JSON notifications of resource updates from kubewatch.




