### PR TITLE
feat(core): add the agent model-provider contract

### DIFF
--- a/devops_bench/core/model_providers.py
+++ b/devops_bench/core/model_providers.py
@@ -1,0 +1,186 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The single source of truth for agent model-provider config.
+
+Every harness consumes the same ``AGENT_PROVIDER`` / ``AGENT_MODEL`` /
+``AGENT_API_KEY`` contract through :func:`resolve_provider`, so a config that
+works for one harness behaves identically for the others. A raw provider alias
+resolves to a :class:`ProviderSpec` carrying both axes the harnesses need: the
+adapter family (which models-layer client to build) and the backend / transport
+/ key-routing details (which oc wire-provider, which API-key env var(s), and
+whether the backend authenticates without a key).
+
+Lives in ``core`` (not ``models``/``agents``) so both the models layer and the
+CLI harnesses import it without an import cycle and without pulling any provider
+SDK. Named ``model_providers`` to avoid confusion with
+:mod:`devops_bench.providers` (the cloud/infra OpenTofu providers).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from devops_bench.core.errors import ConfigError
+
+__all__ = ["ProviderSpec", "resolve_provider", "known_providers"]
+
+
+class ProviderSpec(BaseModel):
+    """Resolved config contract for one agent model provider.
+
+    Attributes:
+        canonical: Normalized provider id (the ``_SPECS`` key).
+        adapter_family: Models-layer adapter key for ``get_model`` /
+            ``MODELS.get`` (e.g. ``gemini`` / ``claude`` / ``ollama``).
+        oc_provider: openclaw wire-provider id used in ``provider/model`` and the
+            per-run ``_PROVIDER_TRANSPORT`` lookup.
+        api_key_envs: Env var name(s) a CLI harness sets from ``config.api_key``.
+            Empty for ``anthropic-vertex`` / ``anthropic-bedrock`` / ``ollama``
+            (no key is ever threaded). ``google-vertex`` is keyless-ok but still
+            routes a *provided* key to ``GOOGLE_CLOUD_API_KEY``.
+        keyless_ok: Whether the backend can authenticate without a key (Vertex
+            ADC, Bedrock AWS creds, local ollama).
+        backend: Adapter backend hint (``"vertex"`` / ``"bedrock"``), or ``None``
+            to let the adapter infer the backend from the environment.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    canonical: str
+    adapter_family: str
+    oc_provider: str
+    api_key_envs: tuple[str, ...]
+    keyless_ok: bool
+    backend: str | None = None
+
+
+# Canonical provider id -> spec. Two axes are encoded here: ``adapter_family``
+# (``google`` and ``google-vertex`` both build the ``gemini`` adapter) and the
+# backend/transport/key-routing (which differ between them). Vertex and Bedrock
+# are keyless-ok (ADC / AWS creds) and need no key; ``anthropic-vertex`` /
+# ``anthropic-bedrock`` / ``ollama`` carry empty ``api_key_envs`` so a key is
+# never forced onto them, while ``google-vertex`` still routes a provided key to
+# ``GOOGLE_CLOUD_API_KEY`` (the vertex transport var, not the google-genai one).
+_SPECS: dict[str, ProviderSpec] = {
+    "google": ProviderSpec(
+        canonical="google",
+        adapter_family="gemini",
+        oc_provider="google",
+        api_key_envs=("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+        keyless_ok=False,
+        backend=None,
+    ),
+    "google-vertex": ProviderSpec(
+        canonical="google-vertex",
+        adapter_family="gemini",
+        oc_provider="google-vertex",
+        api_key_envs=("GOOGLE_CLOUD_API_KEY",),
+        keyless_ok=True,
+        backend="vertex",
+    ),
+    "anthropic": ProviderSpec(
+        canonical="anthropic",
+        adapter_family="claude",
+        oc_provider="anthropic",
+        api_key_envs=("ANTHROPIC_API_KEY",),
+        keyless_ok=False,
+        backend=None,  # claude infers api/vertex/bedrock from the environment
+    ),
+    "anthropic-vertex": ProviderSpec(
+        canonical="anthropic-vertex",
+        adapter_family="claude",
+        oc_provider="anthropic-vertex",
+        api_key_envs=(),
+        keyless_ok=True,
+        backend="vertex",
+    ),
+    "anthropic-bedrock": ProviderSpec(
+        canonical="anthropic-bedrock",
+        adapter_family="claude",
+        oc_provider="anthropic-bedrock",
+        api_key_envs=(),
+        keyless_ok=True,
+        backend="bedrock",
+    ),
+    "openai": ProviderSpec(
+        canonical="openai",
+        adapter_family="openai",  # no adapter module today: get_model raises NotRegisteredError
+        oc_provider="openai",
+        api_key_envs=("OPENAI_API_KEY",),
+        keyless_ok=False,
+        backend=None,
+    ),
+    "ollama": ProviderSpec(
+        canonical="ollama",
+        adapter_family="ollama",
+        oc_provider="ollama",
+        api_key_envs=(),  # optional key handled by the adapter via AGENT_API_KEY
+        keyless_ok=True,
+        backend=None,
+    ),
+}
+
+# Raw alias (lowercased) -> canonical id. Company/runtime names and underscore
+# spellings map onto the canonical wire ids above.
+_ALIASES: dict[str, str] = {
+    "gemini": "google",
+    "google": "google",
+    "google-vertex": "google-vertex",
+    "google_vertex": "google-vertex",
+    "claude": "anthropic",
+    "anthropic": "anthropic",
+    "anthropic-vertex": "anthropic-vertex",
+    "anthropic_vertex": "anthropic-vertex",
+    "anthropic-bedrock": "anthropic-bedrock",
+    "anthropic_bedrock": "anthropic-bedrock",
+    "openai": "openai",
+    "ollama": "ollama",
+}
+
+
+def known_providers() -> tuple[str, ...]:
+    """Return the sorted raw provider aliases the contract accepts."""
+    return tuple(sorted(_ALIASES))
+
+
+def resolve_provider(provider: str | None, *, default: str = "google") -> ProviderSpec:
+    """Resolve a raw provider alias to its :class:`ProviderSpec`.
+
+    Matching is case-insensitive; a blank or unset value resolves to ``default``.
+
+    Args:
+        provider: Raw ``AGENT_PROVIDER`` value (or a per-call override). ``None``
+            or blank resolves to ``default``.
+        default: Alias used when ``provider`` is blank/unset.
+
+    Returns:
+        The :class:`ProviderSpec` for the resolved provider.
+
+    Raises:
+        ConfigError: If ``provider`` (or ``default``) is not a known alias.
+
+    Example:
+        >>> resolve_provider("gemini").canonical
+        'google'
+        >>> resolve_provider("google-vertex").backend
+        'vertex'
+    """
+    raw = (provider or "").strip().lower() or default.strip().lower()
+    canonical = _ALIASES.get(raw)
+    if canonical is None:
+        raise ConfigError(
+            f"unknown agent provider {raw!r}; known providers: {', '.join(known_providers())}"
+        )
+    return _SPECS[canonical]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
 ]
 dependencies = [
     "google-genai>=2.8.0",
+    "pydantic>=2.0",
 ]
 
 [tool.hatch.version]

--- a/tests/unit/core/test_model_providers.py
+++ b/tests/unit/core/test_model_providers.py
@@ -1,0 +1,113 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the model-provider contract."""
+
+import pytest
+from pydantic import ValidationError
+
+from devops_bench.core.errors import ConfigError
+from devops_bench.core.model_providers import (
+    known_providers,
+    resolve_provider,
+)
+
+# (raw alias, canonical, adapter_family, oc_provider, api_key_envs, keyless_ok, backend)
+_ROWS = [
+    ("gemini", "google", "gemini", "google", ("GEMINI_API_KEY", "GOOGLE_API_KEY"), False, None),
+    ("google", "google", "gemini", "google", ("GEMINI_API_KEY", "GOOGLE_API_KEY"), False, None),
+    (
+        "google-vertex",
+        "google-vertex",
+        "gemini",
+        "google-vertex",
+        ("GOOGLE_CLOUD_API_KEY",),
+        True,
+        "vertex",
+    ),
+    (
+        "google_vertex",
+        "google-vertex",
+        "gemini",
+        "google-vertex",
+        ("GOOGLE_CLOUD_API_KEY",),
+        True,
+        "vertex",
+    ),
+    ("anthropic", "anthropic", "claude", "anthropic", ("ANTHROPIC_API_KEY",), False, None),
+    ("claude", "anthropic", "claude", "anthropic", ("ANTHROPIC_API_KEY",), False, None),
+    ("anthropic-vertex", "anthropic-vertex", "claude", "anthropic-vertex", (), True, "vertex"),
+    ("anthropic_vertex", "anthropic-vertex", "claude", "anthropic-vertex", (), True, "vertex"),
+    ("anthropic-bedrock", "anthropic-bedrock", "claude", "anthropic-bedrock", (), True, "bedrock"),
+    ("anthropic_bedrock", "anthropic-bedrock", "claude", "anthropic-bedrock", (), True, "bedrock"),
+    ("openai", "openai", "openai", "openai", ("OPENAI_API_KEY",), False, None),
+    ("ollama", "ollama", "ollama", "ollama", (), True, None),
+]
+
+
+@pytest.mark.parametrize("raw,canonical,family,oc_provider,api_key_envs,keyless,backend", _ROWS)
+def test_resolve_provider_table(
+    raw, canonical, family, oc_provider, api_key_envs, keyless, backend
+):
+    spec = resolve_provider(raw)
+    assert spec.canonical == canonical
+    assert spec.adapter_family == family
+    assert spec.oc_provider == oc_provider
+    assert spec.api_key_envs == api_key_envs
+    assert spec.keyless_ok is keyless
+    assert spec.backend == backend
+
+
+def test_resolve_provider_is_case_insensitive():
+    assert resolve_provider("GEMINI").canonical == "google"
+    assert resolve_provider("Google-Vertex").canonical == "google-vertex"
+
+
+@pytest.mark.parametrize("blank", [None, "", "   "])
+def test_blank_resolves_to_default(blank):
+    assert resolve_provider(blank).canonical == "google"
+    assert resolve_provider(blank, default="anthropic").canonical == "anthropic"
+
+
+def test_unknown_provider_raises_with_known_list():
+    with pytest.raises(ConfigError) as exc:
+        resolve_provider("mystery")
+    msg = str(exc.value)
+    assert "mystery" in msg
+    assert "gemini" in msg and "anthropic" in msg
+
+
+def test_only_vertex_bedrock_ollama_are_keyless():
+    keyless = {raw for raw, *_ in _ROWS if resolve_provider(raw).keyless_ok}
+    assert keyless == {
+        "google-vertex",
+        "google_vertex",
+        "anthropic-vertex",
+        "anthropic_vertex",
+        "anthropic-bedrock",
+        "anthropic_bedrock",
+        "ollama",
+    }
+
+
+def test_provider_spec_is_frozen():
+    spec = resolve_provider("google")
+    with pytest.raises(ValidationError):  # frozen pydantic model rejects mutation
+        spec.canonical = "other"
+
+
+def test_known_providers_sorted_and_complete():
+    known = known_providers()
+    assert known == tuple(sorted(known))
+    assert "google-vertex" in known and "ollama" in known

--- a/uv.lock
+++ b/uv.lock
@@ -236,6 +236,7 @@ name = "devops-bench"
 source = { editable = "." }
 dependencies = [
     { name = "google-genai" },
+    { name = "pydantic" },
 ]
 
 [package.dev-dependencies]
@@ -247,7 +248,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "google-genai", specifier = ">=2.8.0" }]
+requires-dist = [
+    { name = "google-genai", specifier = ">=2.8.0" },
+    { name = "pydantic", specifier = ">=2.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## What
Adds `devops_bench/core/model_providers.py` for resolving an agent's model-provider configuration.

`resolve_provider(alias)` maps a raw provider alias (case-insensitive; blank → default) to a frozen `ProviderSpec` carrying the two axes every harness needs:
- `adapter_family`: which client to build (eg: gemini / claude / openai)
- backend / credential routing: the API-key env var(s), whether the backend uses ambient credentials (Vertex ADC, Bedrock AWS creds, local ollama), and an optional backend hint (vertex / bedrock)

It lives in `core/` so `models/` and `agents/` can import it without an import cycle while keeping provider SDKs as optional dependencies.

## Notes
- `ProviderSpec` is a `pydantic` model, so this adds `pydantic` to the project dependencies.
- Includes unit tests (alias resolution, defaults, unknown-provider errors, spec fields).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Standardized model-provider selection using a single resolver with canonical provider IDs and richer alias support.
  * Improved handling of case-insensitive and blank provider inputs (with a configurable default).
  * Added explicit keyless-vs-key-required behavior and optional backend hints (for vertex/bedrock variants).

* **Bug Fixes**
  * Unknown provider names now fail fast with clearer error messaging that includes valid options.

* **Tests**
  * Added comprehensive unit coverage for provider resolution, defaults, error cases, and immutability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->