### PR TITLE
Add the task contract package (schema and loaders)

### DIFF
--- a/devops_bench/tasks/__init__.py
+++ b/devops_bench/tasks/__init__.py
@@ -1,0 +1,26 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Task contracts: the typed schema and loaders for benchmark tasks."""
+
+from devops_bench.tasks.loader import FileSystemTaskLoader, TaskLoader
+from devops_bench.tasks.schema import Constraint, DocumentationEntry, Task
+
+__all__ = [
+    "Task",
+    "Constraint",
+    "DocumentationEntry",
+    "TaskLoader",
+    "FileSystemTaskLoader",
+]

--- a/devops_bench/tasks/loader.py
+++ b/devops_bench/tasks/loader.py
@@ -1,0 +1,214 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Loading task contracts from a tasks directory or a single spec file."""
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+from devops_bench.core import ConfigError, get_logger
+from devops_bench.tasks.schema import Task
+
+__all__ = [
+    "TaskLoader",
+    "FileSystemTaskLoader",
+    "load_from_tasks_dir",
+]
+
+_log = get_logger("tasks.loader")
+
+_TASK_FILE = "task.yaml"
+
+# YAML 1.2 semantics: only ``true``/``false`` are booleans, so ``yes``/``no``/
+# ``on``/``off`` parse as plain strings rather than being coerced to booleans.
+_yaml = YAML(typ="safe")
+
+
+def safe_parse_yaml(content: str) -> Any:
+    """Parse YAML text into a Python value, treating empty documents as ``{}``.
+
+    Args:
+        content: Raw YAML text.
+
+    Returns:
+        The parsed value (typically a mapping, but possibly a list or scalar),
+        or an empty dict for empty/null documents.
+    """
+    return _yaml.load(content) or {}
+
+
+def _sort_key(task: Task) -> tuple[int, int | str]:
+    """Order numeric ids by value and fall back to lexical order otherwise."""
+    text = str(task.id)
+    return (0, int(text)) if text.isdigit() else (1, text)
+
+
+def _load_yaml_task(path: Path, name_default: str, folder: str = "") -> Task | None:
+    """Read one YAML spec file into a Task, or None if it is not a mapping.
+
+    Args:
+        path: Path to the YAML spec file.
+        name_default: Fallback name used when the spec omits one.
+        folder: Directory name recorded on the task's :attr:`~Task.folder`.
+
+    Returns:
+        The parsed task, or ``None`` when the document is not a mapping.
+    """
+    content = safe_parse_yaml(path.read_text(encoding="utf-8"))
+    if not isinstance(content, dict):
+        return None
+    return Task.from_dict(content, name_default=name_default, folder=folder)
+
+
+def load_from_tasks_dir(dir_path: str) -> list[Task]:
+    """Recursively load every ``task.yaml`` under a tasks directory.
+
+    Directories are walked in sorted order for deterministic discovery, and the
+    returned tasks are sorted by id (numeric ids by value). A spec that fails to
+    parse is logged and skipped rather than aborting the load. A duplicate
+    explicit task id is logged as a warning but still loaded, keeping directory
+    loading resilient.
+
+    Args:
+        dir_path: Root directory to scan.
+
+    Returns:
+        The discovered tasks, sorted by id.
+
+    Raises:
+        ConfigError: If ``dir_path`` does not exist.
+    """
+    root_dir = Path(dir_path)
+    if not root_dir.exists():
+        raise ConfigError(f"tasks directory not found at {dir_path}")
+
+    tasks: list[Task] = []
+    seen_ids: set[str] = set()
+    for current, dirs, files in root_dir.walk():
+        # Sort dirs in place to ensure deterministic ordering during walk.
+        dirs.sort()
+        if _TASK_FILE not in files:
+            continue
+
+        yaml_path = current / _TASK_FILE
+        try:
+            task = _load_yaml_task(yaml_path, name_default=current.name, folder=current.name)
+            if task is not None:
+                if task.id and task.id in seen_ids:
+                    _log.warning("duplicate task id %r at %s", task.id, yaml_path)
+                elif task.id:
+                    seen_ids.add(task.id)
+                tasks.append(task)
+        except Exception as exc:
+            _log.warning("Failed to read task spec in %s: %s", yaml_path, exc)
+
+    tasks.sort(key=_sort_key)
+    return tasks
+
+
+def _load_single_file(path: str) -> list[Task]:
+    """Load tasks from a single ``.yaml``/``.yml``/``.json`` spec file.
+
+    YAML files yield a single task; JSON files may hold a single object or a
+    list of objects. A YAML document or JSON payload that is neither a mapping
+    nor (for JSON) a list yields no tasks.
+
+    Args:
+        path: Path to the spec file.
+
+    Returns:
+        The loaded tasks.
+
+    Raises:
+        ConfigError: If the file cannot be parsed or holds a malformed payload.
+            Unlike directory loads (which log and skip), single-file loads
+            always surface a clean ``ConfigError``.
+    """
+    spec = Path(path)
+    # A ``<task-dir>/task.yaml`` stem is just "task", so use the parent dir name
+    # for it (mirroring the directory loader); the parallel matrix loads one
+    # task.yaml per process. Other single specs fall back to the file stem.
+    base = spec.parent.name if spec.name == _TASK_FILE else spec.stem
+    name_default = base
+    folder = base
+
+    try:
+        if spec.suffix in (".yaml", ".yml"):
+            task = _load_yaml_task(spec, name_default=name_default, folder=folder)
+            return [task] if task is not None else []
+
+        raw = json.loads(spec.read_text(encoding="utf-8"))
+
+        if isinstance(raw, dict):
+            return [Task.from_dict(raw, name_default=name_default, folder=folder)]
+        if isinstance(raw, list):
+            tasks: list[Task] = []
+            for idx, item in enumerate(raw):
+                if not isinstance(item, dict):
+                    raise ConfigError(f"task spec {path}: JSON list element {idx} is not an object")
+                tasks.append(Task.from_dict(item, name_default=name_default, folder=folder))
+            return tasks
+        return []
+    except ConfigError:
+        raise
+    except Exception as exc:
+        raise ConfigError(f"failed to load task spec {path}: {exc}") from exc
+
+
+class TaskLoader(ABC):
+    """Loads task contracts from a source such as a directory or file."""
+
+    @abstractmethod
+    def load_tasks(self, source: str) -> list[Task]:
+        """Load and parse tasks from the given source.
+
+        Args:
+            source: Location to load from (e.g. a directory or spec file path).
+
+        Returns:
+            The loaded tasks.
+        """
+
+
+class FileSystemTaskLoader(TaskLoader):
+    """Loads tasks from a directory tree or a single YAML/JSON spec file."""
+
+    def load_tasks(self, source: str) -> list[Task]:
+        """Load tasks from a directory or a single spec file.
+
+        A directory is scanned recursively; a file is parsed as YAML
+        (``.yaml``/``.yml``) or JSON, where JSON may hold a single object or a
+        list of objects.
+
+        Args:
+            source: A tasks directory or a single spec file.
+
+        Returns:
+            The loaded tasks; directory sources are sorted by id.
+
+        Raises:
+            ConfigError: If ``source`` does not exist.
+        """
+        spec = Path(source)
+        if spec.is_dir():
+            return load_from_tasks_dir(source)
+        if not spec.exists():
+            raise ConfigError(f"task spec not found at {source}")
+        return _load_single_file(source)

--- a/devops_bench/tasks/schema.py
+++ b/devops_bench/tasks/schema.py
@@ -1,0 +1,230 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Typed schema for benchmark task contracts."""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+__all__ = ["Task", "DocumentationEntry", "Constraint"]
+
+# Strict validation: reject implicit type coercion (e.g. the string ``"yes"``
+# is not a bool), and ignore unknown keys in source specs.
+_STRICT = ConfigDict(strict=True, extra="ignore")
+
+
+def _text(value: Any) -> Any:
+    """Coalesce an empty (``None``) text value to ``""`` and strip strings.
+
+    A non-string, non-None value is returned unchanged so strict validation can
+    reject it.
+
+    Args:
+        value: The raw text value from a parsed spec.
+
+    Returns:
+        ``""`` for ``None``, the stripped string for a string, else ``value``.
+    """
+    if value is None:
+        return ""
+    return value.strip() if isinstance(value, str) else value
+
+
+def _coalesce_none(data: Any, defaults: dict[str, Any]) -> Any:
+    """Coalesce empty (``None``) mapping keys to field defaults.
+
+    An empty YAML block (``key:`` with no value) parses to ``None``; treat it as
+    the field's empty default rather than rejecting it under strict validation.
+    Only ``None`` values are coalesced, so genuinely wrong types still fail.
+
+    Args:
+        data: The raw value passed to a model validator.
+        defaults: Field-name to empty-default mapping to apply.
+
+    Returns:
+        ``data`` with each listed ``None`` field replaced by its default;
+        returned unchanged when it is not a mapping.
+    """
+    if not isinstance(data, dict):
+        return data
+    coalesced = dict(data)
+    for key, default in defaults.items():
+        if key in coalesced and coalesced[key] is None:
+            coalesced[key] = default
+    return coalesced
+
+
+class Constraint(BaseModel):
+    """A single documented requirement the agent's solution must satisfy.
+
+    Attributes:
+        text: The requirement description.
+        critical: Whether failing this requirement fails the task outright.
+    """
+
+    model_config = _STRICT
+
+    text: str
+    critical: bool = False
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coalesce_empty(cls, data: Any) -> Any:
+        """Coalesce empty (``None``) keys to defaults (e.g. ``critical:`` alone)."""
+        return _coalesce_none(data, {"text": "", "critical": False})
+
+
+class DocumentationEntry(BaseModel):
+    """A reference document and the constraints derived from it.
+
+    Attributes:
+        doc_name: Human-readable document name.
+        url: Source URL for the document.
+        constraints: Requirements drawn from the document.
+    """
+
+    model_config = _STRICT
+
+    doc_name: str = ""
+    url: str = ""
+    constraints: list[Constraint] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coalesce_empty(cls, data: Any) -> Any:
+        """Coalesce empty (``None``) keys to defaults (e.g. ``constraints:`` alone)."""
+        return _coalesce_none(data, {"doc_name": "", "url": "", "constraints": []})
+
+
+class Task(BaseModel):
+    """Standardized representation of an evaluation task.
+
+    Attributes:
+        id: Task identifier.
+        name: Human-readable task name (the ``name:`` field from the spec).
+        folder: Name of the directory the task spec was loaded from; ``""`` when
+            the source is not a directory-backed spec.
+        prompt: Instruction text driving the agent.
+        expected_output: Reference output the result is judged against.
+        retrieval_context: Supporting passages for retrieval-based scoring.
+        chaos_spec: Opaque chaos-injection specification parsed by the chaos
+            subsystem; may be a mapping, list, or raw JSON string.
+        verification_spec: Opaque verification specification parsed by the
+            verification subsystem; may be a mapping, list, or raw JSON string.
+        infrastructure: Deployer and stack settings for the task environment.
+        documentation: Documentation entries, each with per-constraint criticality.
+        validated: Whether the task has been vetted as correct and is eligible to
+            promote to the leaderboard. Defaults to ``False`` so an unvetted task
+            never counts until explicitly marked.
+    """
+
+    model_config = _STRICT
+
+    id: str = ""
+    name: str = ""
+    folder: str = ""
+    prompt: str = ""
+    expected_output: str = ""
+    retrieval_context: list[str] = Field(default_factory=list)
+    chaos_spec: Any = None
+    verification_spec: Any = None
+    infrastructure: dict[str, Any] = Field(default_factory=dict)
+    documentation: list[DocumentationEntry] = Field(default_factory=list)
+    validated: bool = False
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coalesce_empty(cls, data: Any) -> Any:
+        """Coalesce empty (``None``) keys to field defaults.
+
+        Mirrors the defaulting in :meth:`from_dict` so a task built directly via
+        ``model_validate``/``__init__`` handles empty blocks (e.g. ``documentation:``
+        with no value) the same way, covering every scalar and collection field.
+        """
+        return _coalesce_none(
+            data,
+            {
+                "id": "",
+                "name": "",
+                "folder": "",
+                "prompt": "",
+                "expected_output": "",
+                "retrieval_context": [],
+                "infrastructure": {},
+                "documentation": [],
+                "validated": False,
+            },
+        )
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any], *, name_default: str = "", folder: str = "") -> "Task":
+        """Build a task from a parsed spec mapping, validating types strictly.
+
+        Adapts the source naming before validation: ``task_id`` is accepted as an
+        alias for ``id`` (and coerced to a string), and ``goal``/``input`` are
+        accepted as aliases for ``prompt``. Text fields are stripped. Malformed
+        values (e.g. a non-boolean ``critical``) raise ``pydantic.ValidationError``.
+
+        Args:
+            raw: Parsed mapping for a single task.
+            name_default: Name used when the mapping omits ``name``.
+            folder: Directory name the spec was loaded from, recorded on
+                :attr:`folder`.
+
+        Returns:
+            The validated task.
+
+        Raises:
+            ValidationError: If a field has the wrong type.
+        """
+        raw_id = raw.get("id")
+        if raw_id is None:
+            raw_id = raw.get("task_id")
+        name = raw.get("name")
+        prompt = raw.get("prompt")
+        if prompt is None:
+            prompt = raw.get("goal")
+        if prompt is None:
+            prompt = raw.get("input")
+        retrieval = raw.get("retrieval_context", [])
+        infrastructure = raw.get("infrastructure", {})
+        documentation = raw.get("documentation", [])
+        validated = raw.get("validated", False)
+
+        return cls.model_validate(
+            {
+                "id": "" if raw_id is None else _text(str(raw_id)),
+                "name": _text(name_default if name is None else name),
+                "folder": folder,
+                "prompt": _text(prompt),
+                "expected_output": _text(raw.get("expected_output", "")),
+                # An empty YAML block (``key:`` with no value) parses to None;
+                # treat it as the field's empty default rather than rejecting it.
+                "retrieval_context": [] if retrieval is None else retrieval,
+                "chaos_spec": raw.get("chaos_spec"),
+                "verification_spec": raw.get("verification_spec"),
+                "infrastructure": {} if infrastructure is None else infrastructure,
+                "documentation": [] if documentation is None else documentation,
+                "validated": False if validated is None else validated,
+            }
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the task as a plain serializable mapping.
+
+        Returns:
+            A mapping of every field name to its value.
+        """
+        return self.model_dump()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 dependencies = [
     "google-genai>=2.8.0",
     "pydantic>=2.0",
+    "ruamel.yaml>=0.18.0",
 ]
 
 [tool.hatch.version]

--- a/tests/unit/tasks/test_tasks_loader.py
+++ b/tests/unit/tasks/test_tasks_loader.py
@@ -1,0 +1,320 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.tasks.loader using real temp directories."""
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from devops_bench.core.errors import ConfigError
+from devops_bench.tasks.loader import (
+    FileSystemTaskLoader,
+    TaskLoader,
+    load_from_tasks_dir,
+)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def test_load_from_tasks_dir_recursive_and_ordered(tmp_path):
+    # id 2 lives under a directory that sorts before id 1, so a correct
+    # loader must sort by id rather than discovery order.
+    _write(
+        tmp_path / "aaa" / "task-two" / "task.yaml",
+        'task_id: 2\nname: "task-two"\nprompt: "Two"\nexpected_output: "E2"\n',
+    )
+    _write(
+        tmp_path / "zzz" / "task-one" / "task.yaml",
+        'task_id: 1\nname: "task-one"\nprompt: "One"\nexpected_output: "E1"\n',
+    )
+
+    tasks = FileSystemTaskLoader().load_tasks(str(tmp_path))
+    assert len(tasks) == 2
+    assert tasks[0].id == "1"
+    assert tasks[0].name == "task-one"
+    assert tasks[1].id == "2"
+    assert tasks[1].name == "task-two"
+
+
+def test_numeric_ids_sort_by_value_not_lexically(tmp_path):
+    _write(tmp_path / "a" / "task.yaml", 'task_id: 10\nname: "ten"\n')
+    _write(tmp_path / "b" / "task.yaml", 'task_id: 2\nname: "two"\n')
+
+    tasks = load_from_tasks_dir(str(tmp_path))
+    assert [t.name for t in tasks] == ["two", "ten"]
+
+
+def test_load_from_tasks_dir_subdir_scope(tmp_path):
+    _write(
+        tmp_path / "gcp" / "task-gcp" / "task.yaml",
+        'task_id: 1\nname: "task-gcp"\nprompt: "GCP"\nexpected_output: "G"\n',
+    )
+    _write(
+        tmp_path / "generic" / "task-generic" / "task.yaml",
+        'task_id: 2\nname: "task-generic"\nprompt: "Generic"\nexpected_output: "X"\n',
+    )
+
+    scoped = load_from_tasks_dir(str(tmp_path / "generic"))
+    assert len(scoped) == 1
+    assert scoped[0].name == "task-generic"
+
+
+def test_field_defaults_missing_id_and_name(tmp_path):
+    # No task_id and no name -> empty id and the directory basename.
+    _write(
+        tmp_path / "the-dir-name" / "task.yaml",
+        'prompt: "  padded prompt  "\nexpected_output: "  padded  "\n',
+    )
+
+    tasks = load_from_tasks_dir(str(tmp_path))
+    assert len(tasks) == 1
+    assert tasks[0].id == ""
+    assert tasks[0].name == "the-dir-name"
+    # folder is the directory holding task.yaml, independent of the name field.
+    assert tasks[0].folder == "the-dir-name"
+    assert tasks[0].prompt == "padded prompt"
+    assert tasks[0].expected_output == "padded"
+
+
+def test_folder_is_task_directory_not_name(tmp_path):
+    # An explicit name does not change folder; folder tracks the directory.
+    _write(
+        tmp_path / "group" / "task_001" / "task.yaml",
+        'task_id: 7\nname: "Human Readable"\nprompt: "p"\n',
+    )
+    tasks = load_from_tasks_dir(str(tmp_path))
+    assert tasks[0].name == "Human Readable"
+    assert tasks[0].folder == "task_001"
+
+
+def test_goal_alias_in_dir_load(tmp_path):
+    _write(
+        tmp_path / "alias" / "task.yaml",
+        'task_id: 5\ngoal: "  goal driven  "\n',
+    )
+    tasks = load_from_tasks_dir(str(tmp_path))
+    assert tasks[0].prompt == "goal driven"
+
+
+_DOC_YAML = """\
+task_id: 1
+name: "doc-task"
+prompt: "p"
+expected_output: "e"
+documentation:
+  - doc_name: "Guide A"
+    url: "https://example.com/a"
+    constraints:
+      - text: "Must use TLS"
+        critical: true
+      - text: "Prefer caching"
+        critical: false
+  - doc_name: "Guide B"
+    url: "https://example.com/b"
+    constraints:
+      - text: "Optional thing"
+"""
+
+
+def test_documentation_parsed_on_load(tmp_path):
+    _write(tmp_path / "doc" / "task.yaml", _DOC_YAML)
+    docs = load_from_tasks_dir(str(tmp_path))[0].documentation
+    assert len(docs) == 2
+
+    assert docs[0].doc_name == "Guide A"
+    assert docs[0].url == "https://example.com/a"
+    assert [(c.text, c.critical) for c in docs[0].constraints] == [
+        ("Must use TLS", True),
+        ("Prefer caching", False),
+    ]
+
+    assert docs[1].doc_name == "Guide B"
+    assert docs[1].url == "https://example.com/b"
+    # A constraint without an explicit critical flag defaults to False.
+    assert [(c.text, c.critical) for c in docs[1].constraints] == [("Optional thing", False)]
+
+
+def test_invalid_task_is_skipped_with_warning(tmp_path, caplog):
+    # Under YAML 1.2 ``critical: yes`` is the string "yes"; the strict schema
+    # rejects it, so the task is skipped with a warning rather than loaded.
+    yaml_text = (
+        "task_id: 1\n"
+        'name: "n"\n'
+        "documentation:\n"
+        '  - doc_name: "A"\n'
+        "    constraints:\n"
+        '      - text: "x"\n'
+        "        critical: yes\n"
+    )
+    _write(tmp_path / "d" / "task.yaml", yaml_text)
+    with caplog.at_level(logging.WARNING, logger="devops_bench.tasks.loader"):
+        tasks = load_from_tasks_dir(str(tmp_path))
+    assert tasks == []
+    assert any("Failed to read task spec" in rec.message for rec in caplog.records)
+
+
+def test_yaml_1_2_booleans_stay_strings(tmp_path):
+    # ``yes``/``no``/``off`` are plain strings under YAML 1.2; only
+    # ``true``/``false`` are booleans.
+    _write(
+        tmp_path / "t" / "task.yaml",
+        'task_id: 1\ninfrastructure:\n  a: yes\n  b: "no"\n  c: true\n',
+    )
+    infra = load_from_tasks_dir(str(tmp_path))[0].infrastructure
+    assert infra["a"] == "yes"
+    assert infra["b"] == "no"
+    assert infra["c"] is True
+
+
+def test_load_single_yaml_file(tmp_path):
+    path = tmp_path / "case.yaml"
+    _write(path, 'task_id: 11\nname: "single"\nprompt: "  hi  "\nexpected_output: "out"\n')
+    tasks = FileSystemTaskLoader().load_tasks(str(path))
+    assert len(tasks) == 1
+    assert tasks[0].id == "11"
+    assert tasks[0].name == "single"
+    # A single spec file has no task directory; folder falls back to the stem.
+    assert tasks[0].folder == "case"
+    assert tasks[0].prompt == "hi"
+
+
+def test_single_task_yaml_file_folder_is_parent_dir(tmp_path):
+    # Loading a single ``<task-dir>/task.yaml`` (how the parallel matrix runs one
+    # task per process) must report the parent directory as the folder, not the
+    # literal ``"task"`` stem — mirroring the directory loader.
+    path = tmp_path / "secret-rotation" / "task.yaml"
+    _write(path, 'task_id: 7\nprompt: "p"\n')
+    tasks = FileSystemTaskLoader().load_tasks(str(path))
+    assert len(tasks) == 1
+    assert tasks[0].folder == "secret-rotation"
+    # name also falls back to the parent dir (not "task") when the spec omits one.
+    assert tasks[0].name == "secret-rotation"
+
+
+def test_load_single_json_file_object_with_goal_alias(tmp_path):
+    path = tmp_path / "case.json"
+    _write(
+        path,
+        json.dumps({"task_id": 4, "name": "json-case", "goal": "json goal"}),
+    )
+    tasks = FileSystemTaskLoader().load_tasks(str(path))
+    assert len(tasks) == 1
+    assert tasks[0].id == "4"
+    assert tasks[0].name == "json-case"
+    assert tasks[0].prompt == "json goal"
+
+
+def test_load_single_json_file_list(tmp_path):
+    path = tmp_path / "cases.json"
+    _write(
+        path,
+        json.dumps(
+            [
+                {"task_id": 1, "name": "a", "input": "ia"},
+                {"task_id": 2, "name": "b", "goal": "gb"},
+            ]
+        ),
+    )
+    tasks = FileSystemTaskLoader().load_tasks(str(path))
+    assert [t.name for t in tasks] == ["a", "b"]
+    assert tasks[0].prompt == "ia"
+    assert tasks[1].prompt == "gb"
+
+
+def test_single_file_malformed_yaml_raises_config_error(tmp_path):
+    # A single malformed YAML spec surfaces a clean ConfigError rather than
+    # leaking the underlying parser error.
+    path = tmp_path / "broken.yaml"
+    _write(path, "[unterminated")
+    with pytest.raises(ConfigError):
+        FileSystemTaskLoader().load_tasks(str(path))
+
+
+def test_single_file_json_list_non_dict_element_raises_config_error(tmp_path):
+    # A JSON list whose elements are not all objects is rejected with a clean
+    # ConfigError instead of crashing inside Task.from_dict.
+    path = tmp_path / "cases.json"
+    _write(path, json.dumps([{"task_id": 1}, 5]))
+    with pytest.raises(ConfigError):
+        FileSystemTaskLoader().load_tasks(str(path))
+
+
+def test_missing_directory_raises_config_error(tmp_path):
+    missing = tmp_path / "definitely-does-not-exist-xyz-123"
+    with pytest.raises(ConfigError):
+        load_from_tasks_dir(str(missing))
+
+
+def test_missing_directory_via_loader_raises_config_error(tmp_path):
+    missing = tmp_path / "definitely-does-not-exist-xyz-456"
+    with pytest.raises(ConfigError):
+        FileSystemTaskLoader().load_tasks(str(missing))
+
+
+def test_parse_error_is_logged_and_skipped(tmp_path, caplog):
+    # A valid task plus one with malformed YAML; the bad one is skipped.
+    _write(
+        tmp_path / "good" / "task.yaml",
+        'task_id: 1\nname: "good"\nprompt: "p"\nexpected_output: "e"\n',
+    )
+    _write(
+        tmp_path / "bad" / "task.yaml",
+        "task_id: 2\nname: [unterminated\n",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="devops_bench.tasks.loader"):
+        tasks = load_from_tasks_dir(str(tmp_path))
+
+    assert [t.name for t in tasks] == ["good"]
+    assert any("Failed to read task spec" in rec.message for rec in caplog.records)
+
+
+def test_duplicate_task_id_logs_warning(tmp_path, caplog):
+    # Two task.yaml with the same explicit task_id: the duplicate is logged as
+    # a warning but both are still loaded (directory loading stays resilient).
+    _write(
+        tmp_path / "first" / "task.yaml",
+        'task_id: 7\nname: "first"\nprompt: "p"\n',
+    )
+    _write(
+        tmp_path / "second" / "task.yaml",
+        'task_id: 7\nname: "second"\nprompt: "q"\n',
+    )
+
+    with caplog.at_level(logging.WARNING, logger="devops_bench.tasks.loader"):
+        tasks = load_from_tasks_dir(str(tmp_path))
+
+    assert len(tasks) == 2
+    assert any("duplicate task id" in rec.message for rec in caplog.records)
+
+
+def test_filesystem_task_loader_is_a_task_loader():
+    assert isinstance(FileSystemTaskLoader(), TaskLoader)
+
+
+def test_task_loader_cannot_be_instantiated():
+    with pytest.raises(TypeError):
+        TaskLoader()
+
+
+def test_filesystem_task_loader_loads_directory(tmp_path):
+    _write(tmp_path / "t" / "task.yaml", 'task_id: 1\nname: "t"\nprompt: "p"\n')
+    tasks = FileSystemTaskLoader().load_tasks(str(tmp_path))
+    assert [t.name for t in tasks] == ["t"]

--- a/tests/unit/tasks/test_tasks_schema.py
+++ b/tests/unit/tasks/test_tasks_schema.py
@@ -1,0 +1,234 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.tasks.schema."""
+
+import pytest
+from pydantic import ValidationError
+
+from devops_bench.tasks.schema import Task
+
+
+def test_from_dict_full():
+    raw = {
+        "task_id": 7,
+        "name": "explicit-name",
+        "prompt": "  do the thing  ",
+        "expected_output": "  done  ",
+        "retrieval_context": ["ctx"],
+        "chaos_spec": {"kind": "kill"},
+        "verification_spec": {"check": "ok"},
+        "infrastructure": {"deployer": "tofu"},
+    }
+    task = Task.from_dict(raw, name_default="dir-name")
+
+    assert task.id == "7"
+    assert task.name == "explicit-name"
+    assert task.prompt == "do the thing"
+    assert task.expected_output == "done"
+    assert task.retrieval_context == ["ctx"]
+    assert task.chaos_spec == {"kind": "kill"}
+    assert task.verification_spec == {"check": "ok"}
+    assert task.infrastructure == {"deployer": "tofu"}
+
+
+def test_id_coerced_to_string():
+    assert Task.from_dict({"task_id": 7}, name_default="d").id == "7"
+    assert Task.from_dict({"id": "abc"}, name_default="d").id == "abc"
+
+
+def test_id_zero_is_preserved():
+    assert Task.from_dict({"id": 0}, name_default="d").id == "0"
+
+
+def test_null_id_falls_back_to_task_id():
+    assert Task.from_dict({"id": None, "task_id": 5}, name_default="d").id == "5"
+
+
+def test_missing_id_defaults_to_empty():
+    task = Task.from_dict({"prompt": "x"}, name_default="d")
+    assert task.id == ""
+
+
+def test_explicit_null_id_defaults_to_empty():
+    task = Task.from_dict({"task_id": None, "prompt": "x"}, name_default="d")
+    assert task.id == ""
+
+
+def test_missing_name_uses_default():
+    task = Task.from_dict({"prompt": "x"}, name_default="from-dir")
+    assert task.name == "from-dir"
+
+
+def test_prompt_is_stripped():
+    task = Task.from_dict({"prompt": "  hello  "}, name_default="d")
+    assert task.prompt == "hello"
+
+
+def test_goal_alias_maps_to_prompt():
+    task = Task.from_dict({"goal": "  goal text  "}, name_default="d")
+    assert task.prompt == "goal text"
+
+
+def test_prompt_takes_precedence_over_goal():
+    task = Task.from_dict({"prompt": "p", "goal": "g"}, name_default="d")
+    assert task.prompt == "p"
+
+
+def test_defaults_for_empty_mapping():
+    task = Task.from_dict({}, name_default="d")
+    assert task.id == ""
+    assert task.name == "d"
+    assert task.prompt == ""
+    assert task.expected_output == ""
+    assert task.retrieval_context == []
+    assert task.chaos_spec is None
+    assert task.verification_spec is None
+    assert task.infrastructure == {}
+    assert task.documentation == []
+
+
+def test_non_string_prompt_raises():
+    with pytest.raises(ValidationError):
+        Task.from_dict({"prompt": 123}, name_default="d")
+
+
+def test_non_list_retrieval_context_raises():
+    with pytest.raises(ValidationError):
+        Task.from_dict({"retrieval_context": "nope"}, name_default="d")
+
+
+def test_documentation_defaults_url_and_critical():
+    raw = {
+        "documentation": [
+            {
+                "doc_name": "A",
+                "constraints": [
+                    {"text": "needs url default"},
+                    {"text": "explicit critical", "critical": True},
+                ],
+            }
+        ]
+    }
+    doc = Task.from_dict(raw, name_default="d").documentation[0]
+    assert doc.url == ""
+    assert [(c.text, c.critical) for c in doc.constraints] == [
+        ("needs url default", False),
+        ("explicit critical", True),
+    ]
+
+
+def test_documentation_non_bool_critical_raises():
+    # Strict validation: ``critical: "yes"`` (the string a YAML 1.2 parser
+    # yields) is not a boolean and must raise rather than be coerced.
+    raw = {"documentation": [{"doc_name": "A", "constraints": [{"text": "x", "critical": "yes"}]}]}
+    with pytest.raises(ValidationError):
+        Task.from_dict(raw, name_default="d")
+
+
+def test_documentation_missing_constraint_text_raises():
+    raw = {"documentation": [{"doc_name": "A", "constraints": [{"critical": True}]}]}
+    with pytest.raises(ValidationError):
+        Task.from_dict(raw, name_default="d")
+
+
+def test_non_list_documentation_raises():
+    with pytest.raises(ValidationError):
+        Task.from_dict({"documentation": "nope"}, name_default="d")
+
+
+def test_empty_yaml_blocks_become_defaults():
+    # An empty block (``key:`` with no value) parses to None and must fall back
+    # to the field default rather than failing strict validation.
+    raw = {
+        "infrastructure": None,
+        "retrieval_context": None,
+        "documentation": None,
+        "prompt": None,
+        "expected_output": None,
+    }
+    task = Task.from_dict(raw, name_default="d")
+    assert task.infrastructure == {}
+    assert task.retrieval_context == []
+    assert task.documentation == []
+    assert task.prompt == ""
+    assert task.expected_output == ""
+
+
+def test_documentation_entry_empty_nested_keys_coalesce():
+    # Empty nested YAML keys parse to None; the strict schema must coalesce them
+    # to defaults rather than rejecting them.
+    raw = {"documentation": [{"doc_name": None, "url": None, "constraints": None}]}
+    doc = Task.from_dict(raw, name_default="d").documentation[0]
+    assert doc.doc_name == ""
+    assert doc.url == ""
+    assert doc.constraints == []
+
+
+def test_constraint_empty_text_coalesces():
+    raw = {"documentation": [{"doc_name": "A", "constraints": [{"text": None}]}]}
+    constraint = Task.from_dict(raw, name_default="d").documentation[0].constraints[0]
+    assert constraint.text == ""
+    assert constraint.critical is False
+
+
+def test_chaos_and_verification_specs_are_opaque():
+    # These specs are parsed downstream, so the schema accepts any shape
+    # (e.g. a raw JSON string from a YAML literal block, a list, or a mapping).
+    raw = {"chaos_spec": '[{"name": "spike"}]', "verification_spec": [{"name": "v"}]}
+    task = Task.from_dict(raw, name_default="d")
+    assert task.chaos_spec == '[{"name": "spike"}]'
+    assert task.verification_spec == [{"name": "v"}]
+
+
+def test_to_dict_roundtrip_fields():
+    task = Task.from_dict(
+        {"task_id": 3, "name": "n", "prompt": "p", "expected_output": "e"},
+        name_default="d",
+    )
+    d = task.to_dict()
+    assert d["id"] == "3"
+    assert d["name"] == "n"
+    assert d["prompt"] == "p"
+    assert d["expected_output"] == "e"
+    assert set(d) == {
+        "id",
+        "name",
+        "folder",
+        "prompt",
+        "expected_output",
+        "retrieval_context",
+        "chaos_spec",
+        "verification_spec",
+        "infrastructure",
+        "documentation",
+        "validated",
+    }
+
+
+def test_validated_defaults_false():
+    assert Task.from_dict({"name": "n"}, name_default="d").validated is False
+
+
+def test_validated_parsed_from_spec():
+    assert Task.from_dict({"name": "n", "validated": True}).validated is True
+
+
+def test_validated_empty_block_coalesces_false():
+    # An empty YAML block (``validated:`` with no value) parses to None.
+    assert Task.from_dict({"name": "n", "validated": None}).validated is False
+
+
+def test_validated_roundtrips_in_to_dict():
+    assert Task.from_dict({"name": "n", "validated": True}).to_dict()["validated"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -237,6 +237,7 @@ source = { editable = "." }
 dependencies = [
     { name = "google-genai" },
     { name = "pydantic" },
+    { name = "ruamel-yaml" },
 ]
 
 [package.dev-dependencies]
@@ -251,6 +252,7 @@ dev = [
 requires-dist = [
     { name = "google-genai", specifier = ">=2.8.0" },
     { name = "pydantic", specifier = ">=2.0" },
+    { name = "ruamel-yaml", specifier = ">=0.18.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -672,6 +674,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this adds

`devops_bench/tasks` — the typed contract layer that defines what a benchmark
task is and how tasks are loaded:

- **`schema.py`** — the `Task` model with its `Constraint` and
  `DocumentationEntry` components and cross-field validation.
- **`loader.py`** — the `TaskLoader` abstract base and a `FileSystemTaskLoader`
  that reads task definitions from YAML/JSON on disk.
- **`__init__.py`** — re-exports the public contract (`Task`, `Constraint`,
  `DocumentationEntry`, `TaskLoader`, `FileSystemTaskLoader`).

## Dependencies

Declares `pydantic` (schema) and `ruamel.yaml` (loader) as project dependencies
and refreshes `uv.lock`.

## Testing

Unit tests under `tests/unit/tasks/` cover schema validation and the filesystem
loader (48 tests). Verified locally: `uv sync --frozen`, `ruff check`, and
`pytest tests/unit/tasks` all pass.

/kind feature

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic benchmark task loading from a directory of `task.yaml` files (recursive) or from a single YAML/JSON spec.
  * Introduced strict, typed task contract schemas with consistent defaults, aliases, and serialization.
  * Exposed a public task API for loaders and schema types.
* **Bug Fixes**
  * Improved resilience to incomplete/empty task documents and duplicate task IDs, with clearer warning/skip behavior.
* **Tests**
  * Added unit tests for loader discovery/ordering and schema parsing/validation plus round-tripping.
* **Chores**
  * Added `ruamel.yaml` for safe YAML parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->