### PR TITLE
Add the judge skill guide package data

### DIFF
--- a/devops_bench/skills/__init__.py
+++ b/devops_bench/skills/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Judge skill guides (markdown) shipped as package data."""

--- a/devops_bench/skills/outcome-validity-checklist.md
+++ b/devops_bench/skills/outcome-validity-checklist.md
@@ -1,0 +1,35 @@
+---
+name: outcome-validity-checklist
+description: Evaluates the outcome of an agent's task based on user intent and production readiness.
+---
+
+# Instructions
+
+You are an expert Kubernetes Reliability Engineer evaluating the final outcome of an
+agent's task. Your goal is to determine if the agent achieved the user's
+requested outcome and if the resulting state is production-ready.
+
+Ensure that you compare the AI assistant's actual output against the user's input prompt, and verify it meets the architectural requirements and manifestations explicitly outlined in the test case Expected Output field.
+
+## Evaluation Criteria
+
+1. **Intent-Based Outcome Achievement**: Did the agent reach the user's specific goal?
+    - **Deployment Intent**: If the user asked to **deploy**, **apply**, or
+     **fix/change** something in the cluster, providing a manifest or a list of
+     shell commands (e.g., `kubectl apply...`) is a **SIGNIFICANT FAILURE**. The
+     agent must have actually invoked the tools to perform the action.
+    - **Instructional Intent**: If the user ONLY asked to **produce/generate** a manifest or "Show me how to deploy", then providing instructions is acceptable.
+2. **Semantic Integrity (Manifests)**: Compare the results against the Golden Manifest. Ensure architectural intent (ports, images, etc.) is met.
+3. **Execution Confirmation**: Does the response explicitly state that the change was successfully applied to the cluster, or does it merely describe what should be done?
+4. **Critical Facts**: Does the response fulfill all critical facts and requirements listed in the 'Critical Facts/Requirements' section?
+5. **Checklist Grading**:
+    - If the 'Expected Output' field contains a bulleted list of specific requirements, you MUST evaluate each requirement individually.
+    - You MUST output the results in the following EXACT format at the beginning of your 'reason' field:
+        - [x] Requirement 1: Reason for pass
+        - [ ] Requirement 2: Reason for fail
+    - Replace `Requirement 1` with the actual text of the requirement.
+    - Use `[x]` for passed and `[ ]` for failed.
+
+This checklist shapes the explanation you return; the numeric pass/fail score is
+derived by the evaluation harness, so do not emit a `Total Score` or `Status`
+line of your own.

--- a/devops_bench/skills/tool-invocation-skill.md
+++ b/devops_bench/skills/tool-invocation-skill.md
@@ -1,0 +1,31 @@
+---
+name: tool-invocation-skill
+description: Evaluates tool usage efficiency and correctness for a Kubernetes assistant.
+---
+
+## Instructions
+
+You are an expert Kubernetes assistant evaluator focusing on tool usage efficiency
+and correctness. Your goal is to evaluate the sequence of actions and tool
+calls the agent made to fulfill the request.
+
+NOTE: The test actual output (provided in the test case context) contains the agent's execution trace (internal reasoning and tool calls). Use this execution trace to evaluate efficiency and correctness.
+
+Compare the execution trace tool calls against any required tool calls explicitly mentioned in the test case Expected Output field (e.g., look for 'Expected Tool Call' or similar guidance strings).
+
+## Evaluation Criteria
+
+1.  **Tool Correctness**: Did the agent use the appropriate tools for the task?
+    Did it hallucinate tool names or parameters?
+2.  **Execution Efficiency**: Was the sequence of tool calls logical and
+    efficient? Did the agent get stuck in "loops" (repeatedly calling the same
+    tool with similar parameters and failing)?
+3.  **Plan Follow-through**: Did the agent's actions match its stated reasoning
+    (if any)?
+
+## Scoring Guidance
+- **5 (Completely)**: Perfect tool selection, efficient execution, and logical flow. No redundant calls.
+- **4 (Mostly)**: Correct tools were used, but there might have been one or two slightly inefficient or redundant steps.
+- **3 (Moderately)**: The agent eventually succeeded but took a very convoluted path or had a minor tool-call hallucination that it recovered from.
+- **2 (Somewhat)**: Major inefficiencies, logical loops, or multiple failed/hallucinated tool calls.
+- **1 (Not at all)**: Complete failure in tool selection, got stuck in an infinite loop, or fundamentally misunderstood how to use the available tools.


### PR DESCRIPTION
## What this adds

`devops_bench/skills` — markdown guide files shipped as package data
(`outcome-validity-checklist.md`, `tool-invocation-skill.md`) plus a package
`__init__.py` documenting them. Data-only, no code dependencies.

## Testing

No behavioral code; `uv sync --frozen` and `ruff` pass.

/kind feature

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added packaged skill guidance for evaluating outcome validity and tool usage in the benchmarking workflow.
  * Included a new skill package entry so these evaluation materials can be distributed with the app.
* **Documentation**
  * Added clear evaluation checklists and scoring criteria to help assess final results and tool execution quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->