### PR TITLE
feat(agents): add the agent harness base package

### DIFF
--- a/devops_bench/agents/__init__.py
+++ b/devops_bench/agents/__init__.py
@@ -12,4 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Package for agents.
+"""Agents under evaluation and the agent-selection registry.
+
+``import devops_bench.agents`` is intentionally light: it pulls only the
+template-method :class:`AgentHarness`, the typed :class:`AgentConfig` /
+:class:`AgentResult` / :class:`ToolCall`, and the :data:`AGENTS` registry.
+
+Each concrete harness lives in a sibling subpackage (``cli.gemini_cli`` /
+``cli.openclaw``) and self-registers under its canonical key via
+``@AGENTS.register``. Those subpackages pull in heavy optional dependencies
+(``deepeval``, provider SDKs); they are imported only when the agent is
+selected, never on package import. The harness consumer imports the builtin
+subpackages at call time before resolving via :data:`AGENTS`.
+"""
+
+from __future__ import annotations
+
+from devops_bench.agents.base import AGENTS, AgentHarness
+from devops_bench.agents.config import AgentConfig
+from devops_bench.agents.result import AgentResult, ToolCall
+
+__all__ = [
+    "AGENTS",
+    "AgentConfig",
+    "AgentHarness",
+    "AgentResult",
+    "ToolCall",
+]

--- a/devops_bench/agents/base.py
+++ b/devops_bench/agents/base.py
@@ -1,0 +1,135 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agent-under-test interface and the agent-selection registry.
+
+This module defines the template-method :class:`AgentHarness` consumed by every
+concrete agent. The base owns latency bookkeeping and a broad safety net so a
+single agent crash never aborts the benchmark. Subclasses implement
+:meth:`AgentHarness._execute` to do the provider-specific work and return an
+:class:`AgentResult`.
+
+Each concrete harness lives in a sibling subpackage (``cli.gemini_cli`` /
+``cli.openclaw``) and self-registers under its canonical key via
+``@AGENTS.register``. Heavy imports (``deepeval``, provider SDKs) stay
+function-local — ``import devops_bench.agents`` pulls only this module.
+"""
+
+from __future__ import annotations
+
+import time
+from abc import ABC, abstractmethod
+
+from devops_bench.agents.config import AgentConfig
+from devops_bench.agents.result import AgentResult
+from devops_bench.core import Registry, get_logger
+
+__all__ = ["AgentHarness", "AGENTS"]
+
+AGENTS: Registry[type[AgentHarness]] = Registry("agents")
+
+_log = get_logger("agents.base")
+
+
+class AgentHarness(ABC):
+    """Template-method base class for an agent driven during a benchmark run.
+
+    The base owns three concerns common to every agent:
+
+    1. **Latency bookkeeping** — :meth:`run` measures wall-clock seconds and
+       stamps ``AgentResult.latency`` so subclasses never re-implement it.
+    2. **Broad safety net** — any unexpected exception from :meth:`_execute`
+       (including subclass bugs and provider SDK crashes) is caught and
+       converted to ``AgentResult.errored(...)``; one agent fault never aborts
+       the benchmark.
+    3. **Optional tracing** — when ``deepeval`` is installed, the run is wrapped
+       in an ``@observe`` span. The import stays function-local so the agents
+       package can be imported on a host without ``deepeval``.
+
+    Concrete subclasses live in sibling modules and self-register a canonical
+    key via ``@AGENTS.register(...)``. They override :meth:`_execute` to build
+    argv / drive the loop, run, parse, and return an :class:`AgentResult`. They
+    handle their own *known* errors (subprocess failures, parse misses) by
+    populating ``AgentResult.errors`` — the safety net is only for unexpected
+    exceptions.
+
+    Args:
+        config: Typed configuration. ``None`` substitutes a default
+            ``AgentConfig()`` (use the agent's built-in defaults).
+    """
+
+    def __init__(self, config: AgentConfig | None = None) -> None:
+        self.config = config or AgentConfig()
+
+    def run(self, prompt: str) -> AgentResult:
+        """Execute the agent against ``prompt`` and return a typed result.
+
+        Template method: wraps :meth:`_execute` in the latency stamp and the
+        safety net. ``agent.run(prompt) -> AgentResult`` is the only entry point
+        the harness calls.
+
+        Args:
+            prompt: Task prompt handed to the agent.
+
+        Returns:
+            An :class:`AgentResult` with ``latency`` always populated. A
+            subclass crash produces ``AgentResult.errored(msg)``.
+        """
+        traced = _maybe_observe(self._execute)
+        start = time.monotonic()
+        try:
+            result = traced(prompt)
+        except Exception as exc:  # noqa: BLE001 - safety net for the whole benchmark
+            elapsed = time.monotonic() - start
+            _log.exception("agent _execute raised; converting to errored result")
+            return AgentResult.errored(f"{type(exc).__name__}: {exc}", latency=elapsed)
+
+        elapsed = time.monotonic() - start
+        # Trust _execute when it already stamped latency (e.g. it has finer
+        # timing for a sub-step it wants surfaced); only fill in when zero.
+        if not result.latency:
+            result.latency = elapsed
+        return result
+
+    @abstractmethod
+    def _execute(self, prompt: str) -> AgentResult:
+        """Run the agent and return its typed result.
+
+        Subclass extension point. Implementations build the provider-specific
+        invocation, parse the output into the canonical trajectory, and return
+        an :class:`AgentResult`. Subclasses handle their own *known* errors by
+        populating ``AgentResult.errors``; the base's safety net catches only
+        unexpected exceptions.
+
+        Args:
+            prompt: Task prompt handed to the agent.
+
+        Returns:
+            An :class:`AgentResult` (``latency`` may be left zero — the base
+            fills it in).
+        """
+
+
+def _maybe_observe(func):
+    """Return ``func`` wrapped in ``deepeval.tracing.observe`` when available.
+
+    The wrap is performed once per ``run()`` call rather than at import time so
+    the agents package can be imported on hosts without ``deepeval``. Import
+    failures degrade gracefully — the run proceeds untraced.
+    """
+    try:
+        from deepeval.tracing import observe
+    except ImportError:
+        return func
+    return observe()(func)

--- a/devops_bench/agents/base.py
+++ b/devops_bench/agents/base.py
@@ -90,17 +90,16 @@ class AgentHarness(ABC):
         start = time.monotonic()
         try:
             result = traced(prompt)
+            elapsed = time.monotonic() - start
+            # Trust _execute when it already stamped latency (e.g. it has finer
+            # timing for a sub-step it wants surfaced); only fill in when zero.
+            if not result.latency:
+                result.latency = elapsed
+            return result
         except Exception as exc:  # noqa: BLE001 - safety net for the whole benchmark
             elapsed = time.monotonic() - start
             _log.exception("agent _execute raised; converting to errored result")
             return AgentResult.errored(f"{type(exc).__name__}: {exc}", latency=elapsed)
-
-        elapsed = time.monotonic() - start
-        # Trust _execute when it already stamped latency (e.g. it has finer
-        # timing for a sub-step it wants surfaced); only fill in when zero.
-        if not result.latency:
-            result.latency = elapsed
-        return result
 
     @abstractmethod
     def _execute(self, prompt: str) -> AgentResult:

--- a/devops_bench/agents/base.py
+++ b/devops_bench/agents/base.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import time
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 
 from devops_bench.agents.config import AgentConfig
 from devops_bench.agents.result import AgentResult
@@ -86,9 +87,9 @@ class AgentHarness(ABC):
             An :class:`AgentResult` with ``latency`` always populated. A
             subclass crash produces ``AgentResult.errored(msg)``.
         """
-        traced = _maybe_observe(self._execute)
         start = time.monotonic()
         try:
+            traced = _maybe_observe(self._execute)
             result = traced(prompt)
             elapsed = time.monotonic() - start
             # Trust _execute when it already stamped latency (e.g. it has finer
@@ -120,7 +121,7 @@ class AgentHarness(ABC):
         """
 
 
-def _maybe_observe(func):
+def _maybe_observe(func: Callable[[str], AgentResult]) -> Callable[[str], AgentResult]:
     """Return ``func`` wrapped in ``deepeval.tracing.observe`` when available.
 
     The wrap is performed once per ``run()`` call rather than at import time so

--- a/devops_bench/agents/capabilities/__init__.py
+++ b/devops_bench/agents/capabilities/__init__.py
@@ -1,0 +1,35 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agent capabilities: binding data + structural Protocols for MCP, skills, and rules."""
+
+from __future__ import annotations
+
+from devops_bench.agents.capabilities.aggregate import AllCapabilities
+from devops_bench.agents.capabilities.mcp import McpBinding, SupportsMcp
+from devops_bench.agents.capabilities.rules import AgentRules, SupportsRules
+from devops_bench.agents.capabilities.skills import (
+    SkillBinding,
+    SupportsSkills,
+)
+
+__all__ = [
+    "AgentRules",
+    "AllCapabilities",
+    "McpBinding",
+    "SkillBinding",
+    "SupportsMcp",
+    "SupportsRules",
+    "SupportsSkills",
+]

--- a/devops_bench/agents/capabilities/aggregate.py
+++ b/devops_bench/agents/capabilities/aggregate.py
@@ -1,0 +1,69 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Aggregate of the three capability bindings carried by :class:`AgentConfig`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from devops_bench.agents.capabilities.mcp import McpBinding
+from devops_bench.agents.capabilities.rules import AgentRules
+from devops_bench.agents.capabilities.skills import SkillBinding
+
+__all__ = ["AllCapabilities"]
+
+
+@dataclass(frozen=True)
+class AllCapabilities:
+    """Bundle of the three capability bindings granted to an agent for a run.
+
+    Attributes:
+        mcp_servers: MCP server bindings the agent may drive. Empty tuple
+            disables MCP entirely.
+        skills: Skill binding the agent may load. Default empty binding
+            disables skills.
+        rules: Operator-brief text. Default empty :class:`AgentRules` means
+            "no preamble".
+    """
+
+    mcp_servers: tuple[McpBinding, ...] = ()
+    skills: SkillBinding = field(default_factory=SkillBinding)
+    rules: AgentRules = field(default_factory=AgentRules)
+
+    @property
+    def mcp(self) -> McpBinding | None:
+        """Return the first MCP binding, or ``None`` when MCP is disabled.
+
+        Gotcha:
+            Only the first binding is honored; servers 2..N are dropped —
+            iterate ``mcp_servers`` for all.
+        """
+        return self.mcp_servers[0] if self.mcp_servers else None
+
+    @property
+    def allowed_tools(self) -> tuple[str, ...]:
+        """Aggregate of every MCP binding's ``tools`` in declared order.
+
+        Returns:
+            A flat tuple of tool names — what the Gemini CLI passes as
+            ``--allowed-tools <name>`` arguments. Empty when no MCP server is
+            bound.
+        """
+        return tuple(tool for server in self.mcp_servers for tool in server.tools)
+
+    @property
+    def tools_enabled(self) -> bool:
+        """Convenience boolean: any MCP binding present (regardless of tools)."""
+        return bool(self.mcp_servers)

--- a/devops_bench/agents/capabilities/mcp.py
+++ b/devops_bench/agents/capabilities/mcp.py
@@ -1,0 +1,62 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MCP capability: binding data + agent-side Protocol."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+__all__ = ["McpBinding", "SupportsMcp"]
+
+
+@dataclass(frozen=True)
+class McpBinding:
+    """One MCP server an agent may drive during a run.
+
+    A binding with an empty ``command`` is valid for CLI agents whose binary
+    launches its own MCP infrastructure (e.g. Gemini's built-in MCP host); the
+    binding still carries the ``tools`` list so the agent knows what to
+    advertise / pre-approve.
+
+    Attributes:
+        name: Human-readable label for the server. Metadata only — never
+            inspected to gate behavior.
+        command: argv-style command launching the MCP server, or ``()`` when
+            the agent runs MCP in-process. The API agent feeds this to
+            :class:`~devops_bench.agents.api.mcp.MCPClient`.
+        tools: Tool names this server exposes to the agent. The Gemini CLI
+            passes these via ``--allowed-tools``; the API agent advertises
+            whatever the live MCP server lists (this field acts as
+            documentation / pre-approval there).
+    """
+
+    name: str = ""
+    command: tuple[str, ...] = ()
+    tools: tuple[str, ...] = ()
+
+
+@runtime_checkable
+class SupportsMcp(Protocol):
+    """Structural marker for an agent that can drive MCP servers.
+
+    The orchestrator runs ``isinstance(agent, SupportsMcp)`` before granting
+    an MCP binding so a task requiring MCP never silently runs against an
+    agent that ignores it. Membership is structural: any class with a
+    ``mcp_servers`` attribute typed as ``tuple[McpBinding, ...]`` satisfies it
+    (concrete agents assign ``self.mcp_servers`` in ``__init__``).
+    """
+
+    mcp_servers: tuple[McpBinding, ...]

--- a/devops_bench/agents/capabilities/rules.py
+++ b/devops_bench/agents/capabilities/rules.py
@@ -1,0 +1,41 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rules capability: binding data + agent-side Protocol."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+__all__ = ["AgentRules", "SupportsRules"]
+
+
+@dataclass(frozen=True)
+class AgentRules:
+    """The operator brief delivered to an agent at run start.
+
+    Attributes:
+        text: Free-form rules / system-prompt text. An empty string means "no
+            preamble" (the agent runs with only the task prompt).
+    """
+
+    text: str = ""
+
+
+@runtime_checkable
+class SupportsRules(Protocol):
+    """Structural marker for an agent that can carry an :class:`AgentRules` text."""
+
+    rules: AgentRules

--- a/devops_bench/agents/capabilities/skills.py
+++ b/devops_bench/agents/capabilities/skills.py
@@ -1,0 +1,48 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skills capability: binding data + agent-side Protocol."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+__all__ = ["SkillBinding", "SupportsSkills"]
+
+
+@dataclass(frozen=True)
+class SkillBinding:
+    """Local skill directories an agent may load.
+
+    Attributes:
+        paths: Filesystem locations to walk for ``SKILL.md`` files. The agent
+            walks each path recursively at run time; missing paths are warned
+            and skipped. An empty tuple disables skills entirely —
+            independently of MCP.
+    """
+
+    paths: tuple[str, ...] = ()
+
+
+@runtime_checkable
+class SupportsSkills(Protocol):
+    """Structural marker for an agent that can load local skill files.
+
+    The orchestrator runs ``isinstance(agent, SupportsSkills)`` before
+    granting a :class:`SkillBinding` so a task requiring skills never silently
+    runs against an agent that ignores them.
+    """
+
+    skills: SkillBinding

--- a/devops_bench/agents/config.py
+++ b/devops_bench/agents/config.py
@@ -92,7 +92,10 @@ class AgentConfig:
             this — its MCP server command rides on ``capabilities.mcp.command``.
         timeout_sec: Wall-clock seconds before an external call is aborted; the
             base harness threads this into every subprocess invocation. ``None``
-            disables the timeout (use only for tests / local debug).
+            disables the timeout, reachable only via direct construction (use
+            only for tests / local debug) — :meth:`from_env` always falls back
+            to the 600s default since ``AGENT_TIMEOUT_SEC`` has no sentinel for
+            "disabled".
         max_turns: Safety cap on the API agent's tool-use loop turns; flows from
             ``AGENT_MAX_TURNS``. ``None`` uses the agent's built-in default.
         capabilities: Aggregate of the MCP / skills / rules bindings granted

--- a/devops_bench/agents/config.py
+++ b/devops_bench/agents/config.py
@@ -1,0 +1,142 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Typed configuration for the agent harness."""
+
+from __future__ import annotations
+
+import shlex
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from devops_bench.agents.capabilities import (
+    AgentRules,
+    AllCapabilities,
+    McpBinding,
+    SkillBinding,
+)
+from devops_bench.core import get_env, get_int
+
+__all__ = ["AgentConfig"]
+
+
+def _parse_csv(raw: str | None) -> tuple[str, ...]:
+    """Split a comma-separated env value into a tuple, skipping blanks."""
+    if not raw:
+        return ()
+    return tuple(item.strip() for item in raw.split(",") if item.strip())
+
+
+def _build_capabilities_from_env(env: Mapping[str, str] | None) -> AllCapabilities:
+    """Build an :class:`AllCapabilities` aggregate from ``AGENT_*`` env vars.
+
+    Reads ``AGENT_MCP_SERVER`` (shell-quoted argv) and ``AGENT_ALLOWED_TOOLS``
+    (CSV) into a single :class:`McpBinding` when either is set;
+    ``AGENT_SKILLS_PATHS`` (CSV) into a :class:`SkillBinding`; and
+    ``AGENT_RULES_TEXT`` into :class:`AgentRules`. A missing variable yields
+    the default (empty) shape, so the function never raises on unset values
+    and a fully unset env produces a default :class:`AllCapabilities`.
+
+    Args:
+        env: Optional mapping read from (defaults to ``os.environ``).
+
+    Returns:
+        A populated :class:`AllCapabilities`.
+    """
+    mcp_command_raw = get_env("AGENT_MCP_SERVER", env=env) or ""
+    mcp_command = tuple(shlex.split(mcp_command_raw)) if mcp_command_raw else ()
+    allowed_tools = _parse_csv(get_env("AGENT_ALLOWED_TOOLS", env=env))
+
+    mcp_servers: tuple[McpBinding, ...] = ()
+    if mcp_command or allowed_tools:
+        # ``name="default"`` is generic: env-driven from_env has no catalog to
+        # pull a real name from, and the agent never inspects it.
+        mcp_servers = (McpBinding(name="default", command=mcp_command, tools=allowed_tools),)
+
+    skills_paths = _parse_csv(get_env("AGENT_SKILLS_PATHS", env=env))
+    skills = SkillBinding(paths=skills_paths)
+
+    rules_text = get_env("AGENT_RULES_TEXT", env=env) or ""
+    rules = AgentRules(text=rules_text)
+
+    return AllCapabilities(mcp_servers=mcp_servers, skills=skills, rules=rules)
+
+
+@dataclass
+class AgentConfig:
+    """Typed configuration for an agent run.
+
+    All optional fields default to ``None`` / empty so a bare ``AgentConfig()``
+    represents "use the agent's built-in defaults". :meth:`from_env` is the only
+    reader of ``AGENT_*`` environment variables.
+
+    Attributes:
+        model: Optional model id; flows from ``AGENT_MODEL``.
+        provider: Optional provider key (``gemini``/``anthropic``/``ollama``/...);
+            flows from ``AGENT_PROVIDER``.
+        api_key: Optional API key delivered to provider-specific env vars by the
+            concrete agent; flows from ``AGENT_API_KEY``.
+        target: Optional CLI binary path for CLI agents (``gemini`` / ``oc``);
+            flows from ``AGENT_TARGET``. The API agent does **not** consume
+            this — its MCP server command rides on ``capabilities.mcp.command``.
+        timeout_sec: Wall-clock seconds before an external call is aborted; the
+            base harness threads this into every subprocess invocation. ``None``
+            disables the timeout (use only for tests / local debug).
+        max_turns: Safety cap on the API agent's tool-use loop turns; flows from
+            ``AGENT_MAX_TURNS``. ``None`` uses the agent's built-in default.
+        capabilities: Aggregate of the MCP / skills / rules bindings granted
+            for the run. Constructed by the orchestrator from a benchmark
+            catalog (no GKE-specific strings live in agent code).
+        extra_env: Provider-agnostic env overlay forwarded to subprocess calls.
+            Concrete agents may add their own provider-specific keys on top.
+    """
+
+    model: str | None = None
+    provider: str | None = None
+    api_key: str | None = None
+    target: str | None = None
+    timeout_sec: float | None = 600.0
+    max_turns: int | None = None
+    capabilities: AllCapabilities = field(default_factory=AllCapabilities)
+    extra_env: Mapping[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> AgentConfig:
+        """Build a config from the ``AGENT_*`` environment variables.
+
+        Reads ``AGENT_MODEL`` / ``AGENT_PROVIDER`` / ``AGENT_API_KEY`` /
+        ``AGENT_TARGET`` / ``AGENT_TIMEOUT_SEC`` / ``AGENT_MAX_TURNS`` and
+        delegates capability construction (``AGENT_MCP_SERVER`` /
+        ``AGENT_ALLOWED_TOOLS`` / ``AGENT_SKILLS_PATHS`` / ``AGENT_RULES_TEXT``)
+        to :func:`_build_capabilities_from_env`. A missing variable yields the
+        dataclass default — this method never raises on unset variables.
+
+        Args:
+            env: Optional mapping to read from (defaults to ``os.environ``).
+                Tests inject a dict here to avoid mutating the process env.
+
+        Returns:
+            A populated :class:`AgentConfig`.
+        """
+        timeout = get_int("AGENT_TIMEOUT_SEC", env=env)
+        max_turns = get_int("AGENT_MAX_TURNS", env=env)
+        return cls(
+            model=get_env("AGENT_MODEL", env=env),
+            provider=get_env("AGENT_PROVIDER", env=env),
+            api_key=get_env("AGENT_API_KEY", env=env),
+            target=get_env("AGENT_TARGET", env=env),
+            timeout_sec=float(timeout) if timeout is not None else 600.0,
+            max_turns=max_turns,
+            capabilities=_build_capabilities_from_env(env),
+        )

--- a/devops_bench/agents/result.py
+++ b/devops_bench/agents/result.py
@@ -1,0 +1,120 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Typed agent results and the canonical trajectory entry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+__all__ = ["ToolCall", "AgentResult"]
+
+
+@dataclass
+class ToolCall:
+    """Canonical trajectory entry emitted by every agent.
+
+    Attributes:
+        name: Tool name as advertised by the agent (e.g. an MCP tool name).
+        args: Tool arguments as a JSON-serializable mapping.
+        result: Tool output text once the tool returns; ``None`` until then.
+        status: Lifecycle marker — ``"called"`` when first emitted,
+            ``"completed"`` once the result is folded in, ``"error"`` when the
+            tool failed.
+    """
+
+    name: str
+    args: dict
+    result: str | None = None
+    status: str = "called"
+
+    def to_dict(self) -> dict:
+        """Return the JSON-serializable mapping the harness writes to disk."""
+        return {
+            "name": self.name,
+            "args": self.args,
+            "result": self.result,
+            "status": self.status,
+        }
+
+
+@dataclass
+class AgentResult:
+    """Outcome of a single agent invocation.
+
+    Attributes:
+        output: Final assistant text the judge grades.
+        trajectory: Ordered list of ``ToolCall.to_dict()`` entries (optionally
+            interleaved with text turns by API agents). Every agent emits the
+            same canonical entry shape so metrics consume one schema.
+        tokens: Provider-reported token usage (shape is provider-defined; pass
+            through verbatim).
+        latency: Total wall-clock seconds spent inside the agent run, stamped
+            by :meth:`AgentHarness.run`.
+        errors: Human-readable error or extraction-failure messages. **Empty**
+            on a clean run; populated when a known-error path (subprocess
+            failure, parse miss, timeout) is reached — never silently dropped.
+        metadata: Agent-specific extras (e.g. raw provider stats, session ids)
+            that do not fit the typed fields above.
+    """
+
+    output: str
+    trajectory: list[dict]
+    tokens: dict = field(default_factory=dict)
+    latency: float = 0.0
+    errors: list[str] = field(default_factory=list)
+    metadata: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        """Return the JSON-serializable mapping consumed by the harness.
+
+        Container fields are shallow copies: mutating the returned dict's lists
+        does not leak back into this :class:`AgentResult`.
+
+        >>> r = AgentResult(output="ok", trajectory=[{"name": "ls"}])
+        >>> snapshot = r.to_dict()
+        >>> snapshot["trajectory"].append({"name": "rm"})
+        >>> r.trajectory
+        [{'name': 'ls'}]
+        """
+        return {
+            "output": self.output,
+            "trajectory": list(self.trajectory),
+            "tokens": dict(self.tokens),
+            "latency": self.latency,
+            "errors": list(self.errors),
+            "metadata": dict(self.metadata),
+        }
+
+    def has_errors(self) -> bool:
+        """Return ``True`` when at least one error was recorded.
+
+        The metrics layer uses this to distinguish a real model run that
+        finished with empty output from one that aborted mid-flight.
+        """
+        return bool(self.errors)
+
+    @classmethod
+    def errored(cls, msg: str, *, latency: float = 0.0) -> AgentResult:
+        """Build a result representing a failed run.
+
+        Args:
+            msg: Error message to surface on :attr:`errors` and ``output``.
+            latency: Elapsed seconds before the failure, when available.
+
+        Returns:
+            An :class:`AgentResult` with empty trajectory and the message in
+            both ``output`` and ``errors``.
+        """
+        return cls(output=f"Error: {msg}", trajectory=[], latency=latency, errors=[msg])

--- a/devops_bench/agents/result.py
+++ b/devops_bench/agents/result.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 __all__ = ["ToolCall", "AgentResult"]
 
@@ -35,11 +36,11 @@ class ToolCall:
     """
 
     name: str
-    args: dict
+    args: dict[str, Any]
     result: str | None = None
     status: str = "called"
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Return the JSON-serializable mapping the harness writes to disk."""
         return {
             "name": self.name,
@@ -70,13 +71,13 @@ class AgentResult:
     """
 
     output: str
-    trajectory: list[dict]
-    tokens: dict = field(default_factory=dict)
+    trajectory: list[dict[str, Any]]
+    tokens: dict[str, Any] = field(default_factory=dict)
     latency: float = 0.0
     errors: list[str] = field(default_factory=list)
-    metadata: dict = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Return the JSON-serializable mapping consumed by the harness.
 
         Container fields are shallow copies: mutating the returned dict's lists

--- a/tests/unit/agents/__init__.py
+++ b/tests/unit/agents/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/tests/unit/agents/test_agents_base.py
+++ b/tests/unit/agents/test_agents_base.py
@@ -1,0 +1,103 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.agents.base."""
+
+import pytest
+
+from devops_bench.agents import AGENTS, AgentConfig, AgentHarness, AgentResult
+from devops_bench.core import Registry
+from devops_bench.core.errors import AlreadyRegisteredError, NotRegisteredError
+
+
+def test_agents_registry_is_a_core_registry():
+    assert isinstance(AGENTS, Registry)
+    assert AGENTS.name == "agents"
+
+
+def test_abstract_base_cannot_be_instantiated():
+    with pytest.raises(TypeError):
+        AgentHarness()  # type: ignore[abstract]
+
+
+def test_subclass_run_returns_typed_result_with_latency():
+    class _Stub(AgentHarness):
+        def _execute(self, prompt: str) -> AgentResult:
+            return AgentResult(output=f"echo:{prompt}", trajectory=[])
+
+    result = _Stub().run("hi")
+    assert isinstance(result, AgentResult)
+    assert result.output == "echo:hi"
+    assert result.latency > 0.0
+
+
+def test_subclass_can_self_stamp_latency():
+    class _Stub(AgentHarness):
+        def _execute(self, prompt: str) -> AgentResult:
+            # Subclasses with finer-grained timing may pre-fill latency; the
+            # base must leave that value untouched.
+            return AgentResult(output="x", trajectory=[], latency=99.0)
+
+    assert _Stub().run("hi").latency == 99.0
+
+
+def test_safety_net_converts_unexpected_exception_to_errored_result():
+    class _Boom(AgentHarness):
+        def _execute(self, prompt: str) -> AgentResult:
+            raise RuntimeError("kaboom")
+
+    result = _Boom().run("hi")
+    assert isinstance(result, AgentResult)
+    assert result.has_errors()
+    assert "RuntimeError" in result.errors[0]
+    assert "kaboom" in result.errors[0]
+    assert result.output.startswith("Error:")
+    assert result.latency >= 0.0
+
+
+def test_config_default_is_a_fresh_agent_config():
+    class _Stub(AgentHarness):
+        def _execute(self, prompt: str) -> AgentResult:
+            return AgentResult(output="", trajectory=[])
+
+    a = _Stub()
+    b = _Stub()
+    assert isinstance(a.config, AgentConfig)
+    assert a.config is not b.config
+
+
+def test_third_party_can_register_with_no_central_edit():
+    """A dummy agent registers via @AGENTS.register and resolves via .get."""
+
+    class _Dummy(AgentHarness):
+        def _execute(self, prompt: str) -> AgentResult:
+            return AgentResult(output="", trajectory=[])
+
+    AGENTS.register("dummy-extension")(_Dummy)
+    try:
+        assert AGENTS.get("dummy-extension") is _Dummy
+        assert "dummy-extension" in AGENTS
+        # Re-registering the same key is rejected so the registry can never
+        # silently shadow a builtin agent.
+        with pytest.raises(AlreadyRegisteredError):
+            AGENTS.register("dummy-extension")(_Dummy)
+    finally:
+        # The registry has no public unregister; touch the private dict to
+        # leave the global clean for other tests.
+        AGENTS._items.pop("dummy-extension", None)
+
+
+def test_registry_miss_raises_not_registered():
+    with pytest.raises(NotRegisteredError):
+        AGENTS.get("definitely-not-registered")

--- a/tests/unit/agents/test_agents_base.py
+++ b/tests/unit/agents/test_agents_base.py
@@ -21,17 +21,17 @@ from devops_bench.core import Registry
 from devops_bench.core.errors import AlreadyRegisteredError, NotRegisteredError
 
 
-def test_agents_registry_is_a_core_registry():
+def test_agents_registry_is_a_core_registry() -> None:
     assert isinstance(AGENTS, Registry)
     assert AGENTS.name == "agents"
 
 
-def test_abstract_base_cannot_be_instantiated():
+def test_abstract_base_cannot_be_instantiated() -> None:
     with pytest.raises(TypeError):
         AgentHarness()  # type: ignore[abstract]
 
 
-def test_subclass_run_returns_typed_result_with_latency():
+def test_subclass_run_returns_typed_result_with_latency() -> None:
     class _Stub(AgentHarness):
         def _execute(self, prompt: str) -> AgentResult:
             return AgentResult(output=f"echo:{prompt}", trajectory=[])
@@ -42,7 +42,7 @@ def test_subclass_run_returns_typed_result_with_latency():
     assert result.latency > 0.0
 
 
-def test_subclass_can_self_stamp_latency():
+def test_subclass_can_self_stamp_latency() -> None:
     class _Stub(AgentHarness):
         def _execute(self, prompt: str) -> AgentResult:
             # Subclasses with finer-grained timing may pre-fill latency; the
@@ -52,7 +52,7 @@ def test_subclass_can_self_stamp_latency():
     assert _Stub().run("hi").latency == 99.0
 
 
-def test_safety_net_converts_unexpected_exception_to_errored_result():
+def test_safety_net_converts_unexpected_exception_to_errored_result() -> None:
     class _Boom(AgentHarness):
         def _execute(self, prompt: str) -> AgentResult:
             raise RuntimeError("kaboom")
@@ -66,7 +66,7 @@ def test_safety_net_converts_unexpected_exception_to_errored_result():
     assert result.latency >= 0.0
 
 
-def test_safety_net_covers_a_none_result_from_execute():
+def test_safety_net_covers_a_none_result_from_execute() -> None:
     class _Forgetful(AgentHarness):
         def _execute(self, prompt: str) -> AgentResult:
             return None  # type: ignore[return-value]  # subclass bug: forgot to return
@@ -77,7 +77,7 @@ def test_safety_net_covers_a_none_result_from_execute():
     assert "AttributeError" in result.errors[0]
 
 
-def test_config_default_is_a_fresh_agent_config():
+def test_config_default_is_a_fresh_agent_config() -> None:
     class _Stub(AgentHarness):
         def _execute(self, prompt: str) -> AgentResult:
             return AgentResult(output="", trajectory=[])
@@ -88,7 +88,7 @@ def test_config_default_is_a_fresh_agent_config():
     assert a.config is not b.config
 
 
-def test_third_party_can_register_with_no_central_edit():
+def test_third_party_can_register_with_no_central_edit() -> None:
     """A dummy agent registers via @AGENTS.register and resolves via .get."""
 
     class _Dummy(AgentHarness):
@@ -109,6 +109,6 @@ def test_third_party_can_register_with_no_central_edit():
         AGENTS._items.pop("dummy-extension", None)
 
 
-def test_registry_miss_raises_not_registered():
+def test_registry_miss_raises_not_registered() -> None:
     with pytest.raises(NotRegisteredError):
         AGENTS.get("definitely-not-registered")

--- a/tests/unit/agents/test_agents_base.py
+++ b/tests/unit/agents/test_agents_base.py
@@ -66,6 +66,17 @@ def test_safety_net_converts_unexpected_exception_to_errored_result():
     assert result.latency >= 0.0
 
 
+def test_safety_net_covers_a_none_result_from_execute():
+    class _Forgetful(AgentHarness):
+        def _execute(self, prompt: str) -> AgentResult:
+            return None  # type: ignore[return-value]  # subclass bug: forgot to return
+
+    result = _Forgetful().run("hi")
+    assert isinstance(result, AgentResult)
+    assert result.has_errors()
+    assert "AttributeError" in result.errors[0]
+
+
 def test_config_default_is_a_fresh_agent_config():
     class _Stub(AgentHarness):
         def _execute(self, prompt: str) -> AgentResult:

--- a/tests/unit/agents/test_agents_capabilities.py
+++ b/tests/unit/agents/test_agents_capabilities.py
@@ -1,0 +1,162 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for :mod:`devops_bench.agents.capabilities`."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from devops_bench.agents.capabilities import (
+    AgentRules,
+    AllCapabilities,
+    McpBinding,
+    SkillBinding,
+    SupportsMcp,
+    SupportsRules,
+    SupportsSkills,
+)
+
+# ---------------------------------------------------------------------------
+# Binding construction
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_binding_defaults_to_empty_command_and_tools():
+    binding = McpBinding()
+    assert binding.name == ""
+    assert binding.command == ()
+    assert binding.tools == ()
+
+
+def test_mcp_binding_is_frozen():
+    """Frozen so a binding can be shared safely across agents in a run."""
+    binding = McpBinding(name="gke", command=("/bin/mcp",), tools=("list",))
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        binding.name = "other"  # type: ignore[misc]
+
+
+def test_skill_binding_defaults_to_empty_paths_and_is_frozen():
+    binding = SkillBinding()
+    assert binding.paths == ()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        binding.paths = ("/x",)  # type: ignore[misc]
+
+
+def test_agent_rules_defaults_to_empty_text_and_is_frozen():
+    rules = AgentRules()
+    assert rules.text == ""
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        rules.text = "x"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# AllCapabilities aggregate
+# ---------------------------------------------------------------------------
+
+
+def test_agent_capabilities_defaults_are_empty_bindings():
+    caps = AllCapabilities()
+    assert caps.mcp_servers == ()
+    assert caps.skills == SkillBinding()
+    assert caps.rules == AgentRules()
+    assert caps.allowed_tools == ()
+    assert caps.tools_enabled is False
+    assert caps.mcp is None
+
+
+def test_agent_capabilities_aggregates_allowed_tools_across_servers():
+    caps = AllCapabilities(
+        mcp_servers=(
+            McpBinding(name="a", tools=("t1", "t2")),
+            McpBinding(name="b", tools=("t3",)),
+        ),
+    )
+    assert caps.allowed_tools == ("t1", "t2", "t3")
+    assert caps.tools_enabled is True
+    # ``.mcp`` returns the first binding for the common single-server case.
+    assert caps.mcp is not None and caps.mcp.name == "a"
+
+
+def test_agent_capabilities_tools_enabled_reflects_any_mcp_binding():
+    """A binding with no tools still counts — the agent has *some* MCP."""
+    caps = AllCapabilities(mcp_servers=(McpBinding(name="x"),))
+    assert caps.tools_enabled is True
+    assert caps.allowed_tools == ()
+
+
+def test_agent_capabilities_is_frozen():
+    caps = AllCapabilities()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        caps.mcp_servers = (McpBinding(),)  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Protocol membership (runtime_checkable Protocols — structural, no mixins)
+# ---------------------------------------------------------------------------
+
+
+class _OnlyMcp:
+    """A bare type exposing ``mcp_servers`` to gain SupportsMcp."""
+
+    mcp_servers: tuple[McpBinding, ...] = ()
+
+
+class _OnlySkills:
+    skills = SkillBinding()
+
+
+class _OnlyRules:
+    rules = AgentRules()
+
+
+def test_mcp_attribute_grants_supports_mcp():
+    assert isinstance(_OnlyMcp(), SupportsMcp)
+    assert not isinstance(_OnlyMcp(), SupportsSkills)
+    assert not isinstance(_OnlyMcp(), SupportsRules)
+
+
+def test_skills_attribute_grants_supports_skills():
+    assert isinstance(_OnlySkills(), SupportsSkills)
+    assert not isinstance(_OnlySkills(), SupportsMcp)
+
+
+def test_rules_attribute_grants_supports_rules():
+    assert isinstance(_OnlyRules(), SupportsRules)
+    assert not isinstance(_OnlyRules(), SupportsMcp)
+
+
+def test_protocols_accept_duck_typed_classes():
+    """Structural typing — any class exposing the attribute satisfies the
+    Protocol, no inheritance required."""
+
+    class Duck:
+        mcp_servers: tuple = ()
+        skills = SkillBinding()
+        rules = AgentRules()
+
+    duck = Duck()
+    assert isinstance(duck, SupportsMcp)
+    assert isinstance(duck, SupportsSkills)
+    assert isinstance(duck, SupportsRules)
+
+
+def test_defaults_keep_a_fresh_agent_disabled():
+    """A class exposing the attribute without bindings reports the defaults
+    (empty tuple) — the harness's structural check still passes but the agent
+    runs with no capability granted."""
+    instance = _OnlyMcp()
+    assert instance.mcp_servers == ()

--- a/tests/unit/agents/test_agents_capabilities.py
+++ b/tests/unit/agents/test_agents_capabilities.py
@@ -35,28 +35,28 @@ from devops_bench.agents.capabilities import (
 # ---------------------------------------------------------------------------
 
 
-def test_mcp_binding_defaults_to_empty_command_and_tools():
+def test_mcp_binding_defaults_to_empty_command_and_tools() -> None:
     binding = McpBinding()
     assert binding.name == ""
     assert binding.command == ()
     assert binding.tools == ()
 
 
-def test_mcp_binding_is_frozen():
+def test_mcp_binding_is_frozen() -> None:
     """Frozen so a binding can be shared safely across agents in a run."""
     binding = McpBinding(name="gke", command=("/bin/mcp",), tools=("list",))
     with pytest.raises(dataclasses.FrozenInstanceError):
         binding.name = "other"  # type: ignore[misc]
 
 
-def test_skill_binding_defaults_to_empty_paths_and_is_frozen():
+def test_skill_binding_defaults_to_empty_paths_and_is_frozen() -> None:
     binding = SkillBinding()
     assert binding.paths == ()
     with pytest.raises(dataclasses.FrozenInstanceError):
         binding.paths = ("/x",)  # type: ignore[misc]
 
 
-def test_agent_rules_defaults_to_empty_text_and_is_frozen():
+def test_agent_rules_defaults_to_empty_text_and_is_frozen() -> None:
     rules = AgentRules()
     assert rules.text == ""
     with pytest.raises(dataclasses.FrozenInstanceError):
@@ -68,7 +68,7 @@ def test_agent_rules_defaults_to_empty_text_and_is_frozen():
 # ---------------------------------------------------------------------------
 
 
-def test_agent_capabilities_defaults_are_empty_bindings():
+def test_agent_capabilities_defaults_are_empty_bindings() -> None:
     caps = AllCapabilities()
     assert caps.mcp_servers == ()
     assert caps.skills == SkillBinding()
@@ -78,7 +78,7 @@ def test_agent_capabilities_defaults_are_empty_bindings():
     assert caps.mcp is None
 
 
-def test_agent_capabilities_aggregates_allowed_tools_across_servers():
+def test_agent_capabilities_aggregates_allowed_tools_across_servers() -> None:
     caps = AllCapabilities(
         mcp_servers=(
             McpBinding(name="a", tools=("t1", "t2")),
@@ -91,14 +91,14 @@ def test_agent_capabilities_aggregates_allowed_tools_across_servers():
     assert caps.mcp is not None and caps.mcp.name == "a"
 
 
-def test_agent_capabilities_tools_enabled_reflects_any_mcp_binding():
+def test_agent_capabilities_tools_enabled_reflects_any_mcp_binding() -> None:
     """A binding with no tools still counts — the agent has *some* MCP."""
     caps = AllCapabilities(mcp_servers=(McpBinding(name="x"),))
     assert caps.tools_enabled is True
     assert caps.allowed_tools == ()
 
 
-def test_agent_capabilities_is_frozen():
+def test_agent_capabilities_is_frozen() -> None:
     caps = AllCapabilities()
     with pytest.raises(dataclasses.FrozenInstanceError):
         caps.mcp_servers = (McpBinding(),)  # type: ignore[misc]
@@ -123,23 +123,23 @@ class _OnlyRules:
     rules = AgentRules()
 
 
-def test_mcp_attribute_grants_supports_mcp():
+def test_mcp_attribute_grants_supports_mcp() -> None:
     assert isinstance(_OnlyMcp(), SupportsMcp)
     assert not isinstance(_OnlyMcp(), SupportsSkills)
     assert not isinstance(_OnlyMcp(), SupportsRules)
 
 
-def test_skills_attribute_grants_supports_skills():
+def test_skills_attribute_grants_supports_skills() -> None:
     assert isinstance(_OnlySkills(), SupportsSkills)
     assert not isinstance(_OnlySkills(), SupportsMcp)
 
 
-def test_rules_attribute_grants_supports_rules():
+def test_rules_attribute_grants_supports_rules() -> None:
     assert isinstance(_OnlyRules(), SupportsRules)
     assert not isinstance(_OnlyRules(), SupportsMcp)
 
 
-def test_protocols_accept_duck_typed_classes():
+def test_protocols_accept_duck_typed_classes() -> None:
     """Structural typing — any class exposing the attribute satisfies the
     Protocol, no inheritance required."""
 
@@ -154,7 +154,7 @@ def test_protocols_accept_duck_typed_classes():
     assert isinstance(duck, SupportsRules)
 
 
-def test_defaults_keep_a_fresh_agent_disabled():
+def test_defaults_keep_a_fresh_agent_disabled() -> None:
     """A class exposing the attribute without bindings reports the defaults
     (empty tuple) — the harness's structural check still passes but the agent
     runs with no capability granted."""

--- a/tests/unit/agents/test_agents_capabilities_import_hygiene.py
+++ b/tests/unit/agents/test_agents_capabilities_import_hygiene.py
@@ -1,0 +1,43 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``import devops_bench.agents.capabilities`` must stay light (CONVENTIONS §8)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_capabilities_import_pulls_no_sdk_or_mcp():
+    """Spawn a fresh interpreter so prior tests' imports do not contaminate."""
+    script = textwrap.dedent(
+        """
+        import sys
+        import devops_bench.agents.capabilities  # noqa: F401
+        loaded = sorted(sys.modules)
+        heavy = ['mcp', 'deepeval', 'anthropic', 'google.genai', 'openai']
+        hits = [m for m in loaded if any(m == h or m.startswith(h + '.') for h in heavy)]
+        if hits:
+            print('LEAKED:', ','.join(hits))
+            sys.exit(1)
+        print('OK')
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK" in result.stdout

--- a/tests/unit/agents/test_agents_capabilities_import_hygiene.py
+++ b/tests/unit/agents/test_agents_capabilities_import_hygiene.py
@@ -21,7 +21,7 @@ import sys
 import textwrap
 
 
-def test_capabilities_import_pulls_no_sdk_or_mcp():
+def test_capabilities_import_pulls_no_sdk_or_mcp() -> None:
     """Spawn a fresh interpreter so prior tests' imports do not contaminate."""
     script = textwrap.dedent(
         """

--- a/tests/unit/agents/test_agents_config.py
+++ b/tests/unit/agents/test_agents_config.py
@@ -1,0 +1,140 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.agents.config."""
+
+from devops_bench.agents.capabilities import (
+    AgentRules,
+    AllCapabilities,
+    McpBinding,
+    SkillBinding,
+)
+from devops_bench.agents.config import AgentConfig
+
+
+def test_default_construction_uses_safe_defaults():
+    cfg = AgentConfig()
+    assert cfg.model is None
+    assert cfg.provider is None
+    assert cfg.api_key is None
+    assert cfg.target is None
+    assert cfg.timeout_sec == 600.0
+    assert cfg.max_turns is None
+    # Capability bindings default to "no capabilities granted" — a fresh
+    # ``AgentConfig`` looks indistinguishable from "use built-in defaults".
+    assert cfg.capabilities == AllCapabilities()
+    assert cfg.capabilities.mcp_servers == ()
+    assert cfg.capabilities.skills == SkillBinding()
+    assert cfg.capabilities.rules == AgentRules()
+    assert cfg.capabilities.allowed_tools == ()
+    assert cfg.capabilities.tools_enabled is False
+    assert cfg.capabilities.mcp is None
+    assert dict(cfg.extra_env) == {}
+
+
+def test_from_env_maps_each_field():
+    env = {
+        "AGENT_MODEL": "gemini-2.5-pro",
+        "AGENT_PROVIDER": "gemini",
+        "AGENT_API_KEY": "secret",
+        "AGENT_TARGET": "/usr/local/bin/gemini",
+        "AGENT_TIMEOUT_SEC": "42",
+        "AGENT_MCP_SERVER": "uv run mcp-server",
+        "AGENT_ALLOWED_TOOLS": "tool_a, tool_b ,tool_c",
+        "AGENT_SKILLS_PATHS": "/a/skills, /b/skills",
+        "AGENT_RULES_TEXT": "be careful",
+        "AGENT_MAX_TURNS": "25",
+    }
+    cfg = AgentConfig.from_env(env)
+    assert cfg.model == "gemini-2.5-pro"
+    assert cfg.provider == "gemini"
+    assert cfg.api_key == "secret"
+    assert cfg.target == "/usr/local/bin/gemini"
+    assert cfg.timeout_sec == 42.0
+    assert cfg.max_turns == 25
+    # MCP binding aggregates both the server command and the tool allow-list.
+    assert cfg.capabilities.mcp_servers == (
+        McpBinding(
+            name="default",
+            command=("uv", "run", "mcp-server"),
+            tools=("tool_a", "tool_b", "tool_c"),
+        ),
+    )
+    assert cfg.capabilities.allowed_tools == ("tool_a", "tool_b", "tool_c")
+    assert cfg.capabilities.skills == SkillBinding(paths=("/a/skills", "/b/skills"))
+    assert cfg.capabilities.rules == AgentRules(text="be careful")
+
+
+def test_from_env_treats_unset_as_defaults():
+    cfg = AgentConfig.from_env({})
+    assert cfg.model is None
+    assert cfg.provider is None
+    assert cfg.timeout_sec == 600.0
+    assert cfg.max_turns is None
+    assert cfg.capabilities == AllCapabilities()
+
+
+def test_from_env_blank_allowed_tools_yields_empty_tuple():
+    cfg = AgentConfig.from_env({"AGENT_ALLOWED_TOOLS": ""})
+    assert cfg.capabilities.mcp_servers == ()  # blank → no binding at all
+    cfg = AgentConfig.from_env({"AGENT_ALLOWED_TOOLS": " , , "})
+    assert cfg.capabilities.mcp_servers == ()
+
+
+def test_from_env_allowed_tools_only_builds_mcp_binding_with_empty_command():
+    """A CLI agent (Gemini) gets an MCP binding with no launch command — the
+    binary launches MCP in-process — but still carries the tools allow-list."""
+    cfg = AgentConfig.from_env({"AGENT_ALLOWED_TOOLS": "alpha,beta"})
+    assert cfg.capabilities.mcp_servers == (
+        McpBinding(name="default", command=(), tools=("alpha", "beta")),
+    )
+    assert cfg.capabilities.allowed_tools == ("alpha", "beta")
+    assert cfg.capabilities.tools_enabled is True
+
+
+def test_from_env_mcp_server_only_builds_binding_with_no_tools():
+    """The API agent path: a server command but no pre-approved tool list."""
+    cfg = AgentConfig.from_env({"AGENT_MCP_SERVER": "/usr/local/bin/mcp-gke"})
+    assert cfg.capabilities.mcp_servers == (
+        McpBinding(name="default", command=("/usr/local/bin/mcp-gke",), tools=()),
+    )
+    assert cfg.capabilities.allowed_tools == ()
+
+
+def test_from_env_skips_mcp_binding_when_neither_command_nor_tools_set():
+    """No MCP env at all → ``mcp_servers`` stays empty (default capabilities)."""
+    cfg = AgentConfig.from_env({"AGENT_MODEL": "x"})
+    assert cfg.capabilities.mcp_servers == ()
+
+
+def test_from_env_blank_rules_text_yields_default_rules():
+    cfg = AgentConfig.from_env({"AGENT_RULES_TEXT": ""})
+    assert cfg.capabilities.rules == AgentRules()
+
+
+def test_capabilities_constructor_is_harness_friendly():
+    """The harness builds ``AllCapabilities`` directly with named bindings —
+    not via env reads — and passes it to ``AgentConfig(capabilities=...)``."""
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="gke", command=("/bin/mcp",), tools=("list",)),),
+        skills=SkillBinding(paths=("/opt/skills",)),
+        rules=AgentRules(text="you are a sre"),
+    )
+    cfg = AgentConfig(model="m", provider="p", capabilities=caps)
+    assert cfg.capabilities is caps
+    assert cfg.capabilities.mcp.name == "gke"
+    assert cfg.capabilities.mcp.command == ("/bin/mcp",)
+    assert cfg.capabilities.allowed_tools == ("list",)
+    assert cfg.capabilities.skills.paths == ("/opt/skills",)
+    assert cfg.capabilities.rules.text == "you are a sre"

--- a/tests/unit/agents/test_agents_config.py
+++ b/tests/unit/agents/test_agents_config.py
@@ -105,9 +105,9 @@ def test_from_env_allowed_tools_only_builds_mcp_binding_with_empty_command() -> 
 
 def test_from_env_mcp_server_only_builds_binding_with_no_tools() -> None:
     """The API agent path: a server command but no pre-approved tool list."""
-    cfg = AgentConfig.from_env({"AGENT_MCP_SERVER": "/usr/local/bin/mcp-gke"})
+    cfg = AgentConfig.from_env({"AGENT_MCP_SERVER": "/usr/local/bin/mcp-server"})
     assert cfg.capabilities.mcp_servers == (
-        McpBinding(name="default", command=("/usr/local/bin/mcp-gke",), tools=()),
+        McpBinding(name="default", command=("/usr/local/bin/mcp-server",), tools=()),
     )
     assert cfg.capabilities.allowed_tools == ()
 
@@ -127,13 +127,13 @@ def test_capabilities_constructor_is_harness_friendly() -> None:
     """The harness builds ``AllCapabilities`` directly with named bindings —
     not via env reads — and passes it to ``AgentConfig(capabilities=...)``."""
     caps = AllCapabilities(
-        mcp_servers=(McpBinding(name="gke", command=("/bin/mcp",), tools=("list",)),),
+        mcp_servers=(McpBinding(name="k8s", command=("/bin/mcp",), tools=("list",)),),
         skills=SkillBinding(paths=("/opt/skills",)),
         rules=AgentRules(text="you are a sre"),
     )
     cfg = AgentConfig(model="m", provider="p", capabilities=caps)
     assert cfg.capabilities is caps
-    assert cfg.capabilities.mcp.name == "gke"
+    assert cfg.capabilities.mcp.name == "k8s"
     assert cfg.capabilities.mcp.command == ("/bin/mcp",)
     assert cfg.capabilities.allowed_tools == ("list",)
     assert cfg.capabilities.skills.paths == ("/opt/skills",)

--- a/tests/unit/agents/test_agents_config.py
+++ b/tests/unit/agents/test_agents_config.py
@@ -23,7 +23,7 @@ from devops_bench.agents.capabilities import (
 from devops_bench.agents.config import AgentConfig
 
 
-def test_default_construction_uses_safe_defaults():
+def test_default_construction_uses_safe_defaults() -> None:
     cfg = AgentConfig()
     assert cfg.model is None
     assert cfg.provider is None
@@ -43,7 +43,7 @@ def test_default_construction_uses_safe_defaults():
     assert dict(cfg.extra_env) == {}
 
 
-def test_from_env_maps_each_field():
+def test_from_env_maps_each_field() -> None:
     env = {
         "AGENT_MODEL": "gemini-2.5-pro",
         "AGENT_PROVIDER": "gemini",
@@ -76,7 +76,7 @@ def test_from_env_maps_each_field():
     assert cfg.capabilities.rules == AgentRules(text="be careful")
 
 
-def test_from_env_treats_unset_as_defaults():
+def test_from_env_treats_unset_as_defaults() -> None:
     cfg = AgentConfig.from_env({})
     assert cfg.model is None
     assert cfg.provider is None
@@ -85,14 +85,14 @@ def test_from_env_treats_unset_as_defaults():
     assert cfg.capabilities == AllCapabilities()
 
 
-def test_from_env_blank_allowed_tools_yields_empty_tuple():
+def test_from_env_blank_allowed_tools_yields_empty_tuple() -> None:
     cfg = AgentConfig.from_env({"AGENT_ALLOWED_TOOLS": ""})
     assert cfg.capabilities.mcp_servers == ()  # blank → no binding at all
     cfg = AgentConfig.from_env({"AGENT_ALLOWED_TOOLS": " , , "})
     assert cfg.capabilities.mcp_servers == ()
 
 
-def test_from_env_allowed_tools_only_builds_mcp_binding_with_empty_command():
+def test_from_env_allowed_tools_only_builds_mcp_binding_with_empty_command() -> None:
     """A CLI agent (Gemini) gets an MCP binding with no launch command — the
     binary launches MCP in-process — but still carries the tools allow-list."""
     cfg = AgentConfig.from_env({"AGENT_ALLOWED_TOOLS": "alpha,beta"})
@@ -103,7 +103,7 @@ def test_from_env_allowed_tools_only_builds_mcp_binding_with_empty_command():
     assert cfg.capabilities.tools_enabled is True
 
 
-def test_from_env_mcp_server_only_builds_binding_with_no_tools():
+def test_from_env_mcp_server_only_builds_binding_with_no_tools() -> None:
     """The API agent path: a server command but no pre-approved tool list."""
     cfg = AgentConfig.from_env({"AGENT_MCP_SERVER": "/usr/local/bin/mcp-gke"})
     assert cfg.capabilities.mcp_servers == (
@@ -112,18 +112,18 @@ def test_from_env_mcp_server_only_builds_binding_with_no_tools():
     assert cfg.capabilities.allowed_tools == ()
 
 
-def test_from_env_skips_mcp_binding_when_neither_command_nor_tools_set():
+def test_from_env_skips_mcp_binding_when_neither_command_nor_tools_set() -> None:
     """No MCP env at all → ``mcp_servers`` stays empty (default capabilities)."""
     cfg = AgentConfig.from_env({"AGENT_MODEL": "x"})
     assert cfg.capabilities.mcp_servers == ()
 
 
-def test_from_env_blank_rules_text_yields_default_rules():
+def test_from_env_blank_rules_text_yields_default_rules() -> None:
     cfg = AgentConfig.from_env({"AGENT_RULES_TEXT": ""})
     assert cfg.capabilities.rules == AgentRules()
 
 
-def test_capabilities_constructor_is_harness_friendly():
+def test_capabilities_constructor_is_harness_friendly() -> None:
     """The harness builds ``AllCapabilities`` directly with named bindings —
     not via env reads — and passes it to ``AgentConfig(capabilities=...)``."""
     caps = AllCapabilities(

--- a/tests/unit/agents/test_agents_import_hygiene.py
+++ b/tests/unit/agents/test_agents_import_hygiene.py
@@ -1,0 +1,43 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``import devops_bench.agents`` must stay light per CONVENTIONS §8."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_agents_import_pulls_no_sdk_or_mcp():
+    """Spawn a fresh interpreter so prior tests' imports do not contaminate."""
+    script = textwrap.dedent(
+        """
+        import sys
+        import devops_bench.agents  # noqa: F401
+        loaded = sorted(sys.modules)
+        heavy = ['mcp', 'deepeval', 'anthropic', 'google.genai', 'openai']
+        hits = [m for m in loaded if any(m == h or m.startswith(h + '.') for h in heavy)]
+        if hits:
+            print('LEAKED:', ','.join(hits))
+            sys.exit(1)
+        print('OK')
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK" in result.stdout

--- a/tests/unit/agents/test_agents_import_hygiene.py
+++ b/tests/unit/agents/test_agents_import_hygiene.py
@@ -21,7 +21,7 @@ import sys
 import textwrap
 
 
-def test_agents_import_pulls_no_sdk_or_mcp():
+def test_agents_import_pulls_no_sdk_or_mcp() -> None:
     """Spawn a fresh interpreter so prior tests' imports do not contaminate."""
     script = textwrap.dedent(
         """

--- a/tests/unit/agents/test_agents_no_gke_strings.py
+++ b/tests/unit/agents/test_agents_no_gke_strings.py
@@ -1,0 +1,96 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Acceptance: ``devops_bench/agents/`` runs no GKE-specific behavior.
+
+Capabilities are generic by design (handoff §5 / PR3 acceptance): the GKE MCP
+server name, the GKE tool names, and the GKE skill paths all arrive as values
+on :class:`~devops_bench.agents.capabilities.AllCapabilities`, never as
+literals inside agent code. The orchestrator's catalog is the *one* place that
+knows the word "GKE".
+
+This is a regression bar — it walks the agents/ source AST and fails fast if
+any *runtime* code (string literal, identifier, attribute) references GKE.
+Comments and docstrings are intentionally allowed: the new capability classes
+document why GKE *no longer* appears in their bodies, which is the right place
+to teach the reader.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import devops_bench.agents as _agents_pkg
+
+# Tokens that must not appear in *runtime* values inside agents/. Matched
+# case-insensitively against AST identifiers and string-literal values.
+_FORBIDDEN_TOKENS = ("gke",)
+
+
+def _docstring_node_ids(tree: ast.AST) -> set[int]:
+    """Return ``id(node)`` of every docstring constant in ``tree``.
+
+    A docstring is the first statement of a Module / FunctionDef /
+    AsyncFunctionDef / ClassDef when that statement is an ``Expr`` wrapping a
+    string ``Constant``. The walker skips those identifiers when checking
+    runtime literals.
+    """
+    docstring_ids: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Module | ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            body = getattr(node, "body", None)
+            if not body:
+                continue
+            first = body[0]
+            if (
+                isinstance(first, ast.Expr)
+                and isinstance(first.value, ast.Constant)
+                and isinstance(first.value.value, str)
+            ):
+                docstring_ids.add(id(first.value))
+    return docstring_ids
+
+
+def test_agents_package_has_no_gke_specific_runtime_strings():
+    root = pathlib.Path(_agents_pkg.__file__).parent
+    hits: list[tuple[pathlib.Path, int, str]] = []
+    for src in root.rglob("*.py"):
+        text = src.read_text(encoding="utf-8")
+        tree = ast.parse(text, filename=str(src))
+        docstring_ids = _docstring_node_ids(tree)
+
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Constant)
+                and isinstance(node.value, str)
+                and id(node) not in docstring_ids
+            ):
+                lowered = node.value.lower()
+                if any(tok in lowered for tok in _FORBIDDEN_TOKENS):
+                    hits.append((src.relative_to(root.parent), node.lineno, node.value))
+            elif isinstance(node, ast.Name):
+                lowered = node.id.lower()
+                if any(tok in lowered for tok in _FORBIDDEN_TOKENS):
+                    hits.append((src.relative_to(root.parent), node.lineno, node.id))
+            elif isinstance(node, ast.Attribute):
+                lowered = node.attr.lower()
+                if any(tok in lowered for tok in _FORBIDDEN_TOKENS):
+                    hits.append((src.relative_to(root.parent), node.lineno, node.attr))
+
+    assert not hits, (
+        "agents/ must carry no GKE-specific runtime literals (catalog lives "
+        "in the harness, per PR3 §5). Offenders:\n"
+        + "\n".join(f"  {p}:{ln}: {snippet}" for p, ln, snippet in hits)
+    )

--- a/tests/unit/agents/test_agents_no_gke_strings.py
+++ b/tests/unit/agents/test_agents_no_gke_strings.py
@@ -63,7 +63,14 @@ def _docstring_node_ids(tree: ast.AST) -> set[int]:
     return docstring_ids
 
 
-def test_agents_package_has_no_gke_specific_runtime_strings():
+def test_agents_package_has_no_gke_specific_runtime_strings() -> None:
+    """Assert no runtime code in agents/ references forbidden GKE tokens.
+
+    Walks every ``.py`` file under ``devops_bench/agents/``, parses its AST,
+    and fails if any string literal, identifier, attribute, function/class
+    name, parameter, import alias, keyword argument, or global/nonlocal
+    declaration contains a forbidden token.
+    """
     root = pathlib.Path(_agents_pkg.__file__).parent
     hits: list[tuple[pathlib.Path, int, str]] = []
     for src in root.rglob("*.py"):
@@ -88,6 +95,25 @@ def test_agents_package_has_no_gke_specific_runtime_strings():
                 lowered = node.attr.lower()
                 if any(tok in lowered for tok in _FORBIDDEN_TOKENS):
                     hits.append((src.relative_to(root.parent), node.lineno, node.attr))
+            elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+                lowered = node.name.lower()
+                if any(tok in lowered for tok in _FORBIDDEN_TOKENS):
+                    hits.append((src.relative_to(root.parent), node.lineno, node.name))
+            elif isinstance(node, ast.arg):
+                lowered = node.arg.lower()
+                if any(tok in lowered for tok in _FORBIDDEN_TOKENS):
+                    hits.append((src.relative_to(root.parent), node.lineno, node.arg))
+            elif isinstance(node, ast.alias):
+                for value in (node.name, node.asname):
+                    if value and any(tok in value.lower() for tok in _FORBIDDEN_TOKENS):
+                        hits.append((src.relative_to(root.parent), node.lineno, value))
+            elif isinstance(node, ast.keyword):
+                if node.arg and any(tok in node.arg.lower() for tok in _FORBIDDEN_TOKENS):
+                    hits.append((src.relative_to(root.parent), node.lineno, node.arg))
+            elif isinstance(node, ast.Global | ast.Nonlocal):
+                for name in node.names:
+                    if any(tok in name.lower() for tok in _FORBIDDEN_TOKENS):
+                        hits.append((src.relative_to(root.parent), node.lineno, name))
 
     assert not hits, (
         "agents/ must carry no GKE-specific runtime literals (catalog lives "

--- a/tests/unit/agents/test_agents_result.py
+++ b/tests/unit/agents/test_agents_result.py
@@ -1,0 +1,89 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.agents.result."""
+
+from devops_bench.agents.result import AgentResult, ToolCall
+
+
+def test_tool_call_to_dict_round_trip():
+    call = ToolCall(name="k", args={"a": 1}, result="ok", status="completed")
+    assert call.to_dict() == {
+        "name": "k",
+        "args": {"a": 1},
+        "result": "ok",
+        "status": "completed",
+    }
+
+
+def test_tool_call_defaults():
+    call = ToolCall(name="x", args={})
+    assert call.result is None
+    assert call.status == "called"
+
+
+def test_agent_result_defaults_to_empty_collections():
+    result = AgentResult(output="hi", trajectory=[])
+    assert result.tokens == {}
+    assert result.errors == []
+    assert result.metadata == {}
+    assert result.latency == 0.0
+    assert not result.has_errors()
+
+
+def test_agent_result_to_dict_is_serializable_copies():
+    trajectory = [ToolCall(name="t", args={}).to_dict()]
+    result = AgentResult(
+        output="done",
+        trajectory=trajectory,
+        tokens={"prompt": 1},
+        latency=2.5,
+        errors=["x"],
+        metadata={"k": 1},
+    )
+    out = result.to_dict()
+    assert out == {
+        "output": "done",
+        "trajectory": trajectory,
+        "tokens": {"prompt": 1},
+        "latency": 2.5,
+        "errors": ["x"],
+        "metadata": {"k": 1},
+    }
+    # to_dict must hand the harness fresh containers so mutating the snapshot
+    # never bleeds back into the result it came from.
+    out["trajectory"].append({"name": "extra", "args": {}, "result": None, "status": "called"})
+    out["tokens"]["mutated"] = True
+    out["errors"].append("mutated")
+    out["metadata"]["mutated"] = True
+    assert result.trajectory == trajectory
+    assert result.tokens == {"prompt": 1}
+    assert result.errors == ["x"]
+    assert result.metadata == {"k": 1}
+
+
+def test_agent_result_errored_classmethod_populates_errors():
+    result = AgentResult.errored("boom", latency=1.25)
+    assert result.output == "Error: boom"
+    assert result.trajectory == []
+    assert result.errors == ["boom"]
+    assert result.latency == 1.25
+    assert result.has_errors()
+
+
+def test_agent_result_has_errors_is_false_on_clean_run():
+    result = AgentResult(output="ok", trajectory=[])
+    assert result.has_errors() is False
+    result.errors.append("late")
+    assert result.has_errors() is True

--- a/tests/unit/agents/test_agents_result.py
+++ b/tests/unit/agents/test_agents_result.py
@@ -17,7 +17,7 @@
 from devops_bench.agents.result import AgentResult, ToolCall
 
 
-def test_tool_call_to_dict_round_trip():
+def test_tool_call_to_dict_round_trip() -> None:
     call = ToolCall(name="k", args={"a": 1}, result="ok", status="completed")
     assert call.to_dict() == {
         "name": "k",
@@ -27,13 +27,13 @@ def test_tool_call_to_dict_round_trip():
     }
 
 
-def test_tool_call_defaults():
+def test_tool_call_defaults() -> None:
     call = ToolCall(name="x", args={})
     assert call.result is None
     assert call.status == "called"
 
 
-def test_agent_result_defaults_to_empty_collections():
+def test_agent_result_defaults_to_empty_collections() -> None:
     result = AgentResult(output="hi", trajectory=[])
     assert result.tokens == {}
     assert result.errors == []
@@ -42,7 +42,7 @@ def test_agent_result_defaults_to_empty_collections():
     assert not result.has_errors()
 
 
-def test_agent_result_to_dict_is_serializable_copies():
+def test_agent_result_to_dict_is_serializable_copies() -> None:
     trajectory = [ToolCall(name="t", args={}).to_dict()]
     result = AgentResult(
         output="done",
@@ -73,7 +73,7 @@ def test_agent_result_to_dict_is_serializable_copies():
     assert result.metadata == {"k": 1}
 
 
-def test_agent_result_errored_classmethod_populates_errors():
+def test_agent_result_errored_classmethod_populates_errors() -> None:
     result = AgentResult.errored("boom", latency=1.25)
     assert result.output == "Error: boom"
     assert result.trajectory == []
@@ -82,7 +82,7 @@ def test_agent_result_errored_classmethod_populates_errors():
     assert result.has_errors()
 
 
-def test_agent_result_has_errors_is_false_on_clean_run():
+def test_agent_result_has_errors_is_false_on_clean_run() -> None:
     result = AgentResult(output="ok", trajectory=[])
     assert result.has_errors() is False
     result.errors.append("late")


### PR DESCRIPTION
Adds the template-method AgentHarness base class, typed AgentConfig and AgentResult data models, and the capability protocols (MCP bindings, skill bindings, rule bindings) that concrete agent harnesses implement and compose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standardized agent harness with consistent run handling, wall-clock latency tracking, and conversion of unexpected failures into errored agent results.
  * Introduced environment-driven agent configuration, including timeout/max-turns and capability selection.
  * Added capability definitions for skills, rules, and MCP tool bindings, including aggregated “allowed tools” behavior.
  * Introduced structured `AgentResult` and `ToolCall` outputs for serialization and inspection.
* **Tests**
  * Expanded unit coverage for harness behavior, configuration parsing, capabilities, and result serialization.
  * Added import-hygiene checks and a regression test preventing forbidden runtime strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->