### PR TITLE
feat(core): k8s wrapper classes for kubectl and conditions

### DIFF
--- a/devops_bench/k8s/__init__.py
+++ b/devops_bench/k8s/__init__.py
@@ -1,0 +1,33 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reusable Kubernetes primitives: kubectl wrappers and wait/poll conditions."""
+
+from devops_bench.k8s.conditions import poll_until
+from devops_bench.k8s.kubectl import (
+    apply,
+    get_resource,
+    port_forward,
+    rollout_status,
+    wait,
+)
+
+__all__ = [
+    "apply",
+    "get_resource",
+    "poll_until",
+    "port_forward",
+    "rollout_status",
+    "wait",
+]

--- a/devops_bench/k8s/conditions.py
+++ b/devops_bench/k8s/conditions.py
@@ -1,0 +1,63 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generic wait/poll engine for Kubernetes resources."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+__all__ = [
+    "poll_until",
+]
+
+
+def poll_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout_sec: float,
+    initial_delay: float = 1.0,
+    max_delay: float = 10.0,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> bool:
+    """Poll a predicate with exponential backoff until it holds or time runs out.
+
+    The predicate is checked once per iteration; on failure the loop sleeps for a
+    delay that doubles each round (capped at ``max_delay``) before rechecking. The
+    final sleep is clamped to the time left, so the call never blocks past
+    ``timeout_sec``.
+
+    Args:
+        predicate: Zero-argument callable returning True when the wait is done.
+        timeout_sec: Maximum wall-clock seconds to keep polling.
+        initial_delay: Seconds to sleep after the first failed check.
+        max_delay: Upper bound on the backoff delay.
+        sleep: Sleep function; injectable so tests can avoid real waiting.
+        monotonic: Elapsed-time source; injectable for testing.
+
+    Returns:
+        True if the predicate held within the timeout, otherwise False.
+    """
+    start = monotonic()
+    delay = initial_delay
+    while True:
+        if predicate():
+            return True
+        elapsed = monotonic() - start
+        if elapsed >= timeout_sec:
+            return False
+        sleep(min(delay, timeout_sec - elapsed))
+        delay = min(delay * 2, max_delay)

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -1,0 +1,298 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Thin, shell-free wrappers around the ``kubectl`` command line."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import subprocess
+import time
+from collections.abc import Iterator
+from typing import Any, Protocol
+
+from devops_bench.core import get_logger
+from devops_bench.core.subprocess import CompletedProcess, run
+
+__all__ = [
+    "apply",
+    "get_resource",
+    "port_forward",
+    "rollout_status",
+    "wait",
+]
+
+_log = get_logger("k8s.kubectl")
+
+# Seconds to let ``kubectl port-forward`` establish the tunnel before yielding.
+_PORT_FORWARD_SETTLE_SEC = 3
+
+
+class KubeconfigProvider(Protocol):
+    """Structural type for objects that expose a kubeconfig path."""
+
+    kubeconfig_path: str | None
+
+
+# Accepts a raw kubeconfig path or any object exposing ``kubeconfig_path``.
+type KubeconfigSource = str | KubeconfigProvider | None
+
+
+def _resolve_kubeconfig(kubeconfig: KubeconfigSource) -> str | None:
+    """Return a kubeconfig path from a string or a provider object.
+
+    Args:
+        kubeconfig: Explicit path, a ``KubeconfigProvider``, or None.
+
+    Returns:
+        The kubeconfig path, or None when none is available.
+    """
+    if kubeconfig is None or isinstance(kubeconfig, str):
+        return kubeconfig
+    return kubeconfig.kubeconfig_path
+
+
+def _namespace_args(namespace: str | None) -> list[str]:
+    return ["-n", namespace] if namespace else []
+
+
+def _selector_args(selector: str | None) -> list[str]:
+    return ["-l", selector] if selector else []
+
+
+def _run_kubectl(argv: list[str], kubeconfig: KubeconfigSource, **kwargs: Any) -> CompletedProcess:
+    """Run ``kubectl`` with the resolved kubeconfig overlaid on the environment.
+
+    Args:
+        argv: Full kubectl command and arguments, never a shell string.
+        kubeconfig: Explicit path, a ``KubeconfigProvider``, or None.
+        **kwargs: Extra keyword arguments forwarded to ``core.subprocess.run``
+            (e.g. ``timeout``).
+
+    Returns:
+        The completed process.
+
+    Raises:
+        SubprocessError: If kubectl exits non-zero or times out.
+    """
+    path = _resolve_kubeconfig(kubeconfig)
+    extra_env = {"KUBECONFIG": path} if path else None
+    return run(argv, extra_env=extra_env, **kwargs)
+
+
+def wait(
+    resource_type: str,
+    *,
+    selector: str | None = None,
+    for_condition: str = "condition=Ready",
+    timeout_sec: float,
+    namespace: str | None = None,
+    kubeconfig: KubeconfigSource = None,
+) -> CompletedProcess:
+    """Block until a resource satisfies a condition via ``kubectl wait``.
+
+    Args:
+        resource_type: Resource kind to wait on, e.g. ``"pod"``.
+        selector: Optional label selector (``-l``).
+        for_condition: Condition expression for ``--for``.
+        timeout_sec: Maximum seconds to wait (``--timeout=<n>s``).
+        namespace: Optional namespace (``-n``).
+        kubeconfig: Kubeconfig path or context-like object.
+
+    Returns:
+        The completed process.
+
+    Raises:
+        SubprocessError: If the condition is not met before the timeout.
+    """
+    argv = [
+        "kubectl",
+        "wait",
+        f"--for={for_condition}",
+        resource_type,
+        *_selector_args(selector),
+        f"--timeout={timeout_sec}s",
+        *_namespace_args(namespace),
+    ]
+    return _run_kubectl(argv, kubeconfig)
+
+
+def get_resource(
+    resource_type: str,
+    name: str | None = None,
+    *,
+    selector: str | None = None,
+    namespace: str | None = None,
+    kubeconfig: KubeconfigSource = None,
+) -> dict[str, Any]:
+    """Fetch a resource (or list) as parsed JSON via ``kubectl get -o json``.
+
+    Args:
+        resource_type: Resource kind to fetch, e.g. ``"pods"``.
+        name: Optional specific resource name.
+        selector: Optional label selector (``-l``).
+        namespace: Optional namespace (``-n``).
+        kubeconfig: Kubeconfig path or context-like object.
+
+    Returns:
+        The parsed JSON document.
+
+    Raises:
+        SubprocessError: If kubectl exits non-zero or times out.
+        json.JSONDecodeError: If the output is not valid JSON.
+    """
+    argv = [
+        "kubectl",
+        "get",
+        resource_type,
+        *([name] if name else []),
+        *_selector_args(selector),
+        "-o",
+        "json",
+        *_namespace_args(namespace),
+    ]
+    completed = _run_kubectl(argv, kubeconfig)
+    return json.loads(completed.stdout)
+
+
+def apply(
+    path: str,
+    *,
+    namespace: str | None = None,
+    kubeconfig: KubeconfigSource = None,
+) -> CompletedProcess:
+    """Apply a manifest file or directory via ``kubectl apply -f``.
+
+    Args:
+        path: Manifest file, directory, or URL passed to ``-f``.
+        namespace: Optional namespace (``-n``).
+        kubeconfig: Kubeconfig path or context-like object.
+
+    Returns:
+        The completed process.
+
+    Raises:
+        SubprocessError: If kubectl exits non-zero or times out.
+    """
+    argv = ["kubectl", "apply", "-f", path, *_namespace_args(namespace)]
+    return _run_kubectl(argv, kubeconfig)
+
+
+def rollout_status(
+    resource: str,
+    *,
+    timeout_sec: float | None = None,
+    namespace: str | None = None,
+    kubeconfig: KubeconfigSource = None,
+) -> CompletedProcess:
+    """Wait for a rollout to finish via ``kubectl rollout status``.
+
+    Args:
+        resource: Resource reference, e.g. ``"deployment/web"``.
+        timeout_sec: Optional maximum seconds to wait (``--timeout=<n>s``).
+        namespace: Optional namespace (``-n``).
+        kubeconfig: Kubeconfig path or context-like object.
+
+    Returns:
+        The completed process.
+
+    Raises:
+        SubprocessError: If the rollout does not complete before the timeout.
+    """
+    argv = [
+        "kubectl",
+        "rollout",
+        "status",
+        resource,
+        *([f"--timeout={timeout_sec}s"] if timeout_sec is not None else []),
+        *_namespace_args(namespace),
+    ]
+    return _run_kubectl(argv, kubeconfig)
+
+
+@contextlib.contextmanager
+def port_forward(
+    target: str,
+    local_port: int,
+    remote_port: int | None = None,
+    *,
+    namespace: str | None = None,
+    settle_sec: float = _PORT_FORWARD_SETTLE_SEC,
+    kubeconfig: KubeconfigSource = None,
+) -> Iterator[None]:
+    """Hold a ``kubectl port-forward`` open for the duration of the ``with`` body.
+
+    Unlike the one-shot wrappers, this drives :func:`subprocess.Popen` directly
+    so the tunnel can stay open while the body runs. ``stdout`` / ``stderr`` go
+    to ``DEVNULL`` because nothing reads the pipes — ``PIPE`` would let
+    ``kubectl`` block once its output buffer fills under sustained traffic. The
+    tunnel is always terminated on exit, whether the body completes or raises,
+    so it never outlives the ``with`` block.
+
+    Args:
+        target: Resource to forward, e.g. ``"deployment/web-app"`` or
+            ``"svc/web"``.
+        local_port: Local port to bind.
+        remote_port: Port on the target; defaults to ``local_port``.
+        namespace: Optional namespace (``-n``).
+        settle_sec: Seconds to wait for the tunnel to establish before yielding.
+        kubeconfig: Kubeconfig path or context-like object.
+
+    Yields:
+        ``None`` once the tunnel has had time to settle.
+
+    Raises:
+        RuntimeError: If ``kubectl port-forward`` exits before the settle window
+            elapses (e.g. the target does not exist).
+    """
+    remote = remote_port if remote_port is not None else local_port
+    argv = [
+        "kubectl",
+        "port-forward",
+        target,
+        f"{local_port}:{remote}",
+        *_namespace_args(namespace),
+    ]
+    path = _resolve_kubeconfig(kubeconfig)
+    env = {**os.environ, "KUBECONFIG": path} if path else None
+
+    _log.info("establishing port-forward to %s on port %d...", target, local_port)
+    process = subprocess.Popen(
+        argv,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
+
+    time.sleep(settle_sec)
+    if process.poll() is not None:
+        # Reap the already-exited child before raising so it does not linger as
+        # a zombie waiting for ``wait()``. ``terminate`` is a no-op on a
+        # process that already exited; ``wait`` collects the exit status.
+        returncode = process.returncode
+        try:
+            process.wait(timeout=settle_sec)
+        except Exception as exc:  # noqa: BLE001 - never mask the raise reason
+            _log.warning("error reaping early-exited port-forward: %s", exc)
+        raise RuntimeError(f"kubectl port-forward exited early (code {returncode}) for {target}")
+
+    try:
+        yield
+    finally:
+        _log.info("terminating port-forward to %s...", target)
+        process.terminate()
+        process.wait()
+        _log.info("port-forward to %s terminated.", target)

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -18,14 +18,13 @@ from __future__ import annotations
 
 import contextlib
 import json
-import os
 import subprocess
 import time
 from collections.abc import Iterator
 from typing import Any, Protocol
 
 from devops_bench.core import get_logger
-from devops_bench.core.subprocess import CompletedProcess, run
+from devops_bench.core.subprocess import CompletedProcess, _build_env, run
 
 __all__ = [
     "apply",
@@ -39,6 +38,9 @@ _log = get_logger("k8s.kubectl")
 
 # Seconds to let ``kubectl port-forward`` establish the tunnel before yielding.
 _PORT_FORWARD_SETTLE_SEC = 3
+
+# Grace period after SIGTERM before escalating to SIGKILL on teardown.
+_PORT_FORWARD_TERM_GRACE_SEC = 5
 
 
 class KubeconfigProvider(Protocol):
@@ -267,7 +269,11 @@ def port_forward(
         *_namespace_args(namespace),
     ]
     path = _resolve_kubeconfig(kubeconfig)
-    env = {**os.environ, "KUBECONFIG": path} if path else None
+    # Reuse core.subprocess env semantics so this Popen path never drifts from
+    # the shared ``run`` helper. ``_build_env`` overlays KUBECONFIG on a full
+    # copy of the parent environment (what Popen needs), and returns None when
+    # no path is supplied so the child inherits the parent environment.
+    env = _build_env(None, {"KUBECONFIG": path} if path else None)
 
     _log.info("establishing port-forward to %s on port %d...", target, local_port)
     process = subprocess.Popen(
@@ -294,5 +300,15 @@ def port_forward(
     finally:
         _log.info("terminating port-forward to %s...", target)
         process.terminate()
-        process.wait()
+        try:
+            process.wait(timeout=_PORT_FORWARD_TERM_GRACE_SEC)
+        except subprocess.TimeoutExpired:
+            _log.warning("port-forward ignored SIGTERM, escalating to SIGKILL")
+            process.kill()
+            try:
+                process.wait(timeout=_PORT_FORWARD_TERM_GRACE_SEC)
+            except subprocess.TimeoutExpired:
+                # A process wedged in uninterruptible sleep can outlast even
+                # SIGKILL; abandon it rather than block the ``with`` exit forever.
+                _log.error("port-forward (pid %s) survived SIGKILL; abandoning it", process.pid)
         _log.info("port-forward to %s terminated.", target)

--- a/hack/boilerplate.py
+++ b/hack/boilerplate.py
@@ -64,6 +64,7 @@ DEFAULT_EXCLUDES = [
     "__pycache__/**",
     "node_modules/**",
     "vendor/**",
+    "third_party/**",
     ".venv/**",
     "**/*.yaml",
     "**/*.yml",

--- a/tests/unit/k8s/test_k8s_conditions.py
+++ b/tests/unit/k8s/test_k8s_conditions.py
@@ -36,7 +36,7 @@ class FakeClock:
         self.now += seconds
 
 
-def test_poll_until_returns_true_immediately_without_sleeping():
+def test_poll_until_returns_true_immediately_without_sleeping() -> None:
     clock = FakeClock()
 
     result = conditions.poll_until(
@@ -50,7 +50,7 @@ def test_poll_until_returns_true_immediately_without_sleeping():
     assert clock.sleeps == []
 
 
-def test_poll_until_succeeds_after_a_few_attempts():
+def test_poll_until_succeeds_after_a_few_attempts() -> None:
     clock = FakeClock()
     calls = {"n": 0}
 
@@ -70,7 +70,7 @@ def test_poll_until_succeeds_after_a_few_attempts():
     assert clock.sleeps == [1.0, 2.0]
 
 
-def test_poll_until_backoff_sequence_is_capped():
+def test_poll_until_backoff_sequence_is_capped() -> None:
     clock = FakeClock()
 
     # Always false; deadline large enough to exercise the cap, but the fake
@@ -89,7 +89,7 @@ def test_poll_until_backoff_sequence_is_capped():
     assert clock.sleeps == [1.0, 2.0, 4.0, 8.0, 10.0, 10.0, 5.0]
 
 
-def test_poll_until_respects_custom_delays():
+def test_poll_until_respects_custom_delays() -> None:
     clock = FakeClock()
 
     result = conditions.poll_until(
@@ -107,7 +107,7 @@ def test_poll_until_respects_custom_delays():
     assert clock.sleeps == [2.0, 4.0, 5.0, 5.0, 4.0]
 
 
-def test_poll_until_timeout_returns_false():
+def test_poll_until_timeout_returns_false() -> None:
     clock = FakeClock()
 
     result = conditions.poll_until(
@@ -122,7 +122,7 @@ def test_poll_until_timeout_returns_false():
     assert clock.sleeps == []
 
 
-def test_poll_until_catches_success_on_next_check_after_sleep():
+def test_poll_until_catches_success_on_next_check_after_sleep() -> None:
     clock = FakeClock()
     calls = {"n": 0}
 

--- a/tests/unit/k8s/test_k8s_conditions.py
+++ b/tests/unit/k8s/test_k8s_conditions.py
@@ -1,0 +1,141 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.k8s.conditions.
+
+A fake clock and fake sleep drive ``poll_until`` so the backoff schedule is
+verified without any real waiting.
+"""
+
+from devops_bench.k8s import conditions
+
+
+class FakeClock:
+    """Monotonic clock stub whose ``sleep`` advances the recorded time."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+def test_poll_until_returns_true_immediately_without_sleeping():
+    clock = FakeClock()
+
+    result = conditions.poll_until(
+        lambda: True,
+        timeout_sec=100,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    assert result is True
+    assert clock.sleeps == []
+
+
+def test_poll_until_succeeds_after_a_few_attempts():
+    clock = FakeClock()
+    calls = {"n": 0}
+
+    def predicate() -> bool:
+        calls["n"] += 1
+        return calls["n"] == 3
+
+    result = conditions.poll_until(
+        predicate,
+        timeout_sec=100,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    assert result is True
+    # Two failures before success -> two backoff sleeps.
+    assert clock.sleeps == [1.0, 2.0]
+
+
+def test_poll_until_backoff_sequence_is_capped():
+    clock = FakeClock()
+
+    # Always false; deadline large enough to exercise the cap, but the fake
+    # clock advances via sleep so the loop terminates deterministically.
+    result = conditions.poll_until(
+        lambda: False,
+        timeout_sec=40,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    assert result is False
+    # Doubling is capped at max_delay (10), and the final sleep is clamped to the
+    # remaining time so the loop lands exactly on the 40s deadline rather than
+    # overshooting it (0,1,3,7,15,25,35,40).
+    assert clock.sleeps == [1.0, 2.0, 4.0, 8.0, 10.0, 10.0, 5.0]
+
+
+def test_poll_until_respects_custom_delays():
+    clock = FakeClock()
+
+    result = conditions.poll_until(
+        lambda: False,
+        timeout_sec=20,
+        initial_delay=2.0,
+        max_delay=5.0,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    assert result is False
+    # 0 -> 2 -> 6 -> 11 -> 16 -> 20: the final sleep is clamped from 5 to the
+    # remaining 4 seconds so the loop lands exactly on the deadline.
+    assert clock.sleeps == [2.0, 4.0, 5.0, 5.0, 4.0]
+
+
+def test_poll_until_timeout_returns_false():
+    clock = FakeClock()
+
+    result = conditions.poll_until(
+        lambda: False,
+        timeout_sec=0,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    # Deadline already passed: one predicate check, no sleep.
+    assert result is False
+    assert clock.sleeps == []
+
+
+def test_poll_until_catches_success_on_next_check_after_sleep():
+    clock = FakeClock()
+    calls = {"n": 0}
+
+    def predicate() -> bool:
+        calls["n"] += 1
+        # False on the first check, True on the recheck after the backoff sleep.
+        return calls["n"] == 2
+
+    result = conditions.poll_until(
+        predicate,
+        timeout_sec=1,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    assert result is True

--- a/tests/unit/k8s/test_k8s_kubectl.py
+++ b/tests/unit/k8s/test_k8s_kubectl.py
@@ -1,0 +1,199 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.k8s.kubectl.
+
+These patch the module-local ``run`` so no real ``kubectl`` is invoked, and
+assert the exact argv lists and KUBECONFIG threading.
+"""
+
+import json
+import subprocess
+
+import pytest
+
+from devops_bench.core.context import ClusterInfo, RunContext
+from devops_bench.core.errors import SubprocessError
+from devops_bench.k8s import kubectl
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
+    """Build a real CompletedProcess for the patched ``run``."""
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout)
+
+
+def test_wait_builds_argv_and_threads_kubeconfig(mocker):
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+
+    kubectl.wait(
+        "pod",
+        selector="app=my-app",
+        timeout_sec=60,
+        namespace="prod",
+        kubeconfig="/tmp/kc",
+    )
+
+    argv = mock_run.call_args.args[0]
+    assert argv == [
+        "kubectl",
+        "wait",
+        "--for=condition=Ready",
+        "pod",
+        "-l",
+        "app=my-app",
+        "--timeout=60s",
+        "-n",
+        "prod",
+    ]
+    assert mock_run.call_args.kwargs["extra_env"] == {"KUBECONFIG": "/tmp/kc"}
+
+
+def test_wait_custom_condition_without_optionals(mocker):
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+
+    kubectl.wait("deployment", for_condition="condition=Available", timeout_sec=30)
+
+    argv = mock_run.call_args.args[0]
+    assert argv == [
+        "kubectl",
+        "wait",
+        "--for=condition=Available",
+        "deployment",
+        "--timeout=30s",
+    ]
+    # No kubeconfig supplied -> run is called without overlaying KUBECONFIG.
+    assert mock_run.call_args.kwargs["extra_env"] is None
+
+
+def test_get_resource_parses_output_and_builds_argv(mocker):
+    payload = {"items": [{"status": {"phase": "Running"}}]}
+    mock_run = mocker.patch(
+        "devops_bench.k8s.kubectl.run",
+        return_value=_completed(stdout=json.dumps(payload)),
+    )
+
+    result = kubectl.get_resource("pods", selector="app=web", namespace="default")
+
+    assert result == payload
+    argv = mock_run.call_args.args[0]
+    assert argv == [
+        "kubectl",
+        "get",
+        "pods",
+        "-l",
+        "app=web",
+        "-o",
+        "json",
+        "-n",
+        "default",
+    ]
+
+
+def test_get_resource_with_name(mocker):
+    payload = {"status": {"readyReplicas": 3}}
+    mock_run = mocker.patch(
+        "devops_bench.k8s.kubectl.run",
+        return_value=_completed(stdout=json.dumps(payload)),
+    )
+
+    result = kubectl.get_resource("deployment", "my-dep")
+
+    assert result == payload
+    argv = mock_run.call_args.args[0]
+    assert argv == ["kubectl", "get", "deployment", "my-dep", "-o", "json"]
+
+
+def test_apply_builds_argv(mocker):
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+
+    kubectl.apply("/manifests/app.yaml", namespace="staging")
+
+    argv = mock_run.call_args.args[0]
+    assert argv == ["kubectl", "apply", "-f", "/manifests/app.yaml", "-n", "staging"]
+
+
+def test_rollout_status_with_timeout(mocker):
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+
+    kubectl.rollout_status("deployment/web", timeout_sec=120, namespace="prod")
+
+    argv = mock_run.call_args.args[0]
+    assert argv == [
+        "kubectl",
+        "rollout",
+        "status",
+        "deployment/web",
+        "--timeout=120s",
+        "-n",
+        "prod",
+    ]
+
+
+def test_rollout_status_without_timeout(mocker):
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+
+    kubectl.rollout_status("deployment/web")
+
+    argv = mock_run.call_args.args[0]
+    assert argv == ["kubectl", "rollout", "status", "deployment/web"]
+
+
+def test_kubeconfig_from_run_context(mocker):
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+    ctx = RunContext(
+        task_id="t1",
+        cluster=ClusterInfo(name="c1", kubeconfig_path="/ctx/kc"),
+    )
+
+    kubectl.wait("pod", timeout_sec=10, kubeconfig=ctx)
+
+    assert mock_run.call_args.kwargs["extra_env"] == {"KUBECONFIG": "/ctx/kc"}
+
+
+def test_kubeconfig_from_cluster_info(mocker):
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+    cluster = ClusterInfo(name="c1", kubeconfig_path="/cluster/kc")
+
+    kubectl.wait("pod", timeout_sec=10, kubeconfig=cluster)
+
+    assert mock_run.call_args.kwargs["extra_env"] == {"KUBECONFIG": "/cluster/kc"}
+
+
+def test_run_context_without_cluster_omits_kubeconfig(mocker):
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+    ctx = RunContext(task_id="t1")
+
+    kubectl.wait("pod", timeout_sec=10, kubeconfig=ctx)
+
+    assert mock_run.call_args.kwargs["extra_env"] is None
+
+
+def test_get_resource_propagates_invalid_json(mocker):
+    mocker.patch(
+        "devops_bench.k8s.kubectl.run",
+        return_value=_completed(stdout="not json"),
+    )
+
+    with pytest.raises(json.JSONDecodeError):
+        kubectl.get_resource("pods")
+
+
+def test_wait_propagates_subprocess_error(mocker):
+    mocker.patch(
+        "devops_bench.k8s.kubectl.run",
+        side_effect=SubprocessError(["kubectl", "wait"], returncode=1),
+    )
+
+    with pytest.raises(SubprocessError):
+        kubectl.wait("pod", timeout_sec=10)

--- a/tests/unit/k8s/test_k8s_kubectl.py
+++ b/tests/unit/k8s/test_k8s_kubectl.py
@@ -22,6 +22,7 @@ import json
 import subprocess
 
 import pytest
+from pytest_mock import MockerFixture
 
 from devops_bench.core.context import ClusterInfo, RunContext
 from devops_bench.core.errors import SubprocessError
@@ -33,7 +34,7 @@ def _completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedPro
     return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout)
 
 
-def test_wait_builds_argv_and_threads_kubeconfig(mocker):
+def test_wait_builds_argv_and_threads_kubeconfig(mocker: MockerFixture) -> None:
     mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
 
     kubectl.wait(
@@ -59,7 +60,7 @@ def test_wait_builds_argv_and_threads_kubeconfig(mocker):
     assert mock_run.call_args.kwargs["extra_env"] == {"KUBECONFIG": "/tmp/kc"}
 
 
-def test_wait_custom_condition_without_optionals(mocker):
+def test_wait_custom_condition_without_optionals(mocker: MockerFixture) -> None:
     mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
 
     kubectl.wait("deployment", for_condition="condition=Available", timeout_sec=30)
@@ -76,7 +77,7 @@ def test_wait_custom_condition_without_optionals(mocker):
     assert mock_run.call_args.kwargs["extra_env"] is None
 
 
-def test_get_resource_parses_output_and_builds_argv(mocker):
+def test_get_resource_parses_output_and_builds_argv(mocker: MockerFixture) -> None:
     payload = {"items": [{"status": {"phase": "Running"}}]}
     mock_run = mocker.patch(
         "devops_bench.k8s.kubectl.run",
@@ -100,7 +101,7 @@ def test_get_resource_parses_output_and_builds_argv(mocker):
     ]
 
 
-def test_get_resource_with_name(mocker):
+def test_get_resource_with_name(mocker: MockerFixture) -> None:
     payload = {"status": {"readyReplicas": 3}}
     mock_run = mocker.patch(
         "devops_bench.k8s.kubectl.run",
@@ -114,7 +115,7 @@ def test_get_resource_with_name(mocker):
     assert argv == ["kubectl", "get", "deployment", "my-dep", "-o", "json"]
 
 
-def test_apply_builds_argv(mocker):
+def test_apply_builds_argv(mocker: MockerFixture) -> None:
     mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
 
     kubectl.apply("/manifests/app.yaml", namespace="staging")
@@ -123,7 +124,7 @@ def test_apply_builds_argv(mocker):
     assert argv == ["kubectl", "apply", "-f", "/manifests/app.yaml", "-n", "staging"]
 
 
-def test_rollout_status_with_timeout(mocker):
+def test_rollout_status_with_timeout(mocker: MockerFixture) -> None:
     mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
 
     kubectl.rollout_status("deployment/web", timeout_sec=120, namespace="prod")
@@ -140,7 +141,7 @@ def test_rollout_status_with_timeout(mocker):
     ]
 
 
-def test_rollout_status_without_timeout(mocker):
+def test_rollout_status_without_timeout(mocker: MockerFixture) -> None:
     mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
 
     kubectl.rollout_status("deployment/web")
@@ -149,7 +150,7 @@ def test_rollout_status_without_timeout(mocker):
     assert argv == ["kubectl", "rollout", "status", "deployment/web"]
 
 
-def test_kubeconfig_from_run_context(mocker):
+def test_kubeconfig_from_run_context(mocker: MockerFixture) -> None:
     mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
     ctx = RunContext(
         task_id="t1",
@@ -161,7 +162,7 @@ def test_kubeconfig_from_run_context(mocker):
     assert mock_run.call_args.kwargs["extra_env"] == {"KUBECONFIG": "/ctx/kc"}
 
 
-def test_kubeconfig_from_cluster_info(mocker):
+def test_kubeconfig_from_cluster_info(mocker: MockerFixture) -> None:
     mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
     cluster = ClusterInfo(name="c1", kubeconfig_path="/cluster/kc")
 
@@ -170,7 +171,7 @@ def test_kubeconfig_from_cluster_info(mocker):
     assert mock_run.call_args.kwargs["extra_env"] == {"KUBECONFIG": "/cluster/kc"}
 
 
-def test_run_context_without_cluster_omits_kubeconfig(mocker):
+def test_run_context_without_cluster_omits_kubeconfig(mocker: MockerFixture) -> None:
     mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
     ctx = RunContext(task_id="t1")
 
@@ -179,7 +180,7 @@ def test_run_context_without_cluster_omits_kubeconfig(mocker):
     assert mock_run.call_args.kwargs["extra_env"] is None
 
 
-def test_get_resource_propagates_invalid_json(mocker):
+def test_get_resource_propagates_invalid_json(mocker: MockerFixture) -> None:
     mocker.patch(
         "devops_bench.k8s.kubectl.run",
         return_value=_completed(stdout="not json"),
@@ -189,7 +190,7 @@ def test_get_resource_propagates_invalid_json(mocker):
         kubectl.get_resource("pods")
 
 
-def test_wait_propagates_subprocess_error(mocker):
+def test_wait_propagates_subprocess_error(mocker: MockerFixture) -> None:
     mocker.patch(
         "devops_bench.k8s.kubectl.run",
         side_effect=SubprocessError(["kubectl", "wait"], returncode=1),
@@ -197,3 +198,104 @@ def test_wait_propagates_subprocess_error(mocker):
 
     with pytest.raises(SubprocessError):
         kubectl.wait("pod", timeout_sec=10)
+
+
+def test_port_forward_builds_argv_and_terminates_on_exit(mocker: MockerFixture) -> None:
+    mock_popen = mocker.patch("devops_bench.k8s.kubectl.subprocess.Popen")
+    proc = mock_popen.return_value
+    proc.poll.return_value = None  # tunnel still alive after the settle window
+    mock_sleep = mocker.patch("devops_bench.k8s.kubectl.time.sleep")
+
+    with kubectl.port_forward("svc/web", 8080, namespace="prod"):
+        # Tunnel is live inside the body; teardown has not run yet.
+        proc.terminate.assert_not_called()
+
+    argv = mock_popen.call_args.args[0]
+    assert argv == [
+        "kubectl",
+        "port-forward",
+        "svc/web",
+        "8080:8080",
+        "-n",
+        "prod",
+    ]
+    # No kubeconfig -> child inherits the parent environment (env=None).
+    assert mock_popen.call_args.kwargs["env"] is None
+    # Settled before yielding, then terminated with a bounded grace period.
+    mock_sleep.assert_called_once_with(kubectl._PORT_FORWARD_SETTLE_SEC)
+    proc.terminate.assert_called_once()
+    proc.wait.assert_called_once_with(timeout=kubectl._PORT_FORWARD_TERM_GRACE_SEC)
+    proc.kill.assert_not_called()
+
+
+def test_port_forward_defaults_remote_port_to_local(mocker: MockerFixture) -> None:
+    mock_popen = mocker.patch("devops_bench.k8s.kubectl.subprocess.Popen")
+    mock_popen.return_value.poll.return_value = None
+    mocker.patch("devops_bench.k8s.kubectl.time.sleep")
+
+    with kubectl.port_forward("svc/web", 8080, remote_port=9090):
+        pass
+
+    assert mock_popen.call_args.args[0][3] == "8080:9090"
+
+
+def test_port_forward_threads_kubeconfig_into_env(mocker: MockerFixture) -> None:
+    mock_popen = mocker.patch("devops_bench.k8s.kubectl.subprocess.Popen")
+    mock_popen.return_value.poll.return_value = None
+    mocker.patch("devops_bench.k8s.kubectl.time.sleep")
+
+    with kubectl.port_forward("svc/web", 8080, kubeconfig="/tmp/kc"):
+        pass
+
+    assert mock_popen.call_args.kwargs["env"]["KUBECONFIG"] == "/tmp/kc"
+
+
+def test_port_forward_raises_when_process_exits_early(mocker: MockerFixture) -> None:
+    proc = mocker.patch("devops_bench.k8s.kubectl.subprocess.Popen").return_value
+    proc.poll.return_value = 1  # already exited by the time we check
+    proc.returncode = 1
+    mocker.patch("devops_bench.k8s.kubectl.time.sleep")
+
+    with (
+        pytest.raises(RuntimeError, match="exited early"),
+        kubectl.port_forward("svc/web", 8080),
+    ):
+        pass
+
+    # Early-exited child is reaped, not terminated.
+    proc.wait.assert_called_once_with(timeout=kubectl._PORT_FORWARD_SETTLE_SEC)
+    proc.terminate.assert_not_called()
+
+
+def test_port_forward_escalates_to_kill_when_terminate_times_out(mocker: MockerFixture) -> None:
+    proc = mocker.patch("devops_bench.k8s.kubectl.subprocess.Popen").return_value
+    proc.poll.return_value = None
+    # First wait (SIGTERM grace) times out; second wait (after SIGKILL) returns.
+    proc.wait.side_effect = [
+        subprocess.TimeoutExpired(cmd="kubectl", timeout=5),
+        0,
+    ]
+    mocker.patch("devops_bench.k8s.kubectl.time.sleep")
+
+    with kubectl.port_forward("svc/web", 8080):
+        pass
+
+    proc.terminate.assert_called_once()
+    proc.kill.assert_called_once()
+    assert proc.wait.call_count == 2
+
+
+def test_port_forward_abandons_process_that_survives_sigkill(mocker: MockerFixture) -> None:
+    proc = mocker.patch("devops_bench.k8s.kubectl.subprocess.Popen").return_value
+    proc.poll.return_value = None
+    # Both the SIGTERM grace wait and the post-SIGKILL wait time out.
+    proc.wait.side_effect = subprocess.TimeoutExpired(cmd="kubectl", timeout=5)
+    mocker.patch("devops_bench.k8s.kubectl.time.sleep")
+
+    # Teardown must neither raise nor hang even when the process never dies.
+    with kubectl.port_forward("svc/web", 8080):
+        pass
+
+    proc.terminate.assert_called_once()
+    proc.kill.assert_called_once()
+    assert proc.wait.call_count == 2

--- a/tests/unit/k8s/test_k8s_kubectl.py
+++ b/tests/unit/k8s/test_k8s_kubectl.py
@@ -228,7 +228,7 @@ def test_port_forward_builds_argv_and_terminates_on_exit(mocker: MockerFixture) 
     proc.kill.assert_not_called()
 
 
-def test_port_forward_defaults_remote_port_to_local(mocker: MockerFixture) -> None:
+def test_port_forward_uses_explicit_remote_port(mocker: MockerFixture) -> None:
     mock_popen = mocker.patch("devops_bench.k8s.kubectl.subprocess.Popen")
     mock_popen.return_value.poll.return_value = None
     mocker.patch("devops_bench.k8s.kubectl.time.sleep")


### PR DESCRIPTION
 This PR introduces thin, shell-free wrappers around the `kubectl` command line and a
  generic wait/poll engine for Kubernetes resources.
It includes:
    - `devops_bench/k8s/kubectl.py`: Wrappers for standard `kubectl` operations (`apply`,
  `get`, `wait`, `rollout status`, and `port-forward`).
    - `devops_bench/k8s/conditions.py`: A generic `poll_until` engine with exponential backoff
  for checking conditions.
    - Co-located unit tests under `tests/unit/k8s/`.
    - A minor fix to `hack/boilerplate.py` to exclude `third_party/` directories from the
  license header check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified Kubernetes helper interface for applying manifests, fetching resources, waiting on readiness/conditions, checking rollout status, and running port-forward.
  * Introduced a polling utility with configurable timeouts and exponential backoff to reliably wait for Kubernetes state changes.
* **Tests**
  * Expanded unit test coverage for command/argument construction, JSON parsing, timeout/backoff behavior, and port-forward lifecycle (including termination/escalation handling).
* **Chores**
  * Updated generated header exclusions to ignore `third_party/**` content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->