### PR TITLE
feat(results): add the result row model with normalize and aggregate helpers

### DIFF
--- a/devops_bench/results/__init__.py
+++ b/devops_bench/results/__init__.py
@@ -1,0 +1,49 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ingest-ready result rows bridging the harness output and the dashboard."""
+
+from devops_bench.results.aggregate import (
+    aggregate,
+    build_manifests,
+    dedupe_latest,
+    discover_row_files,
+    rebatch_rows,
+)
+from devops_bench.results.normalize import (
+    build_rows,
+    derive_augmentation,
+    extract_score,
+    normalize_tokens,
+    setup_id,
+    slugify,
+)
+from devops_bench.results.row import SCHEMA_VERSION, Manifest, ResultRow
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "Manifest",
+    "ResultRow",
+    "aggregate",
+    "build_manifests",
+    "build_rows",
+    "dedupe_latest",
+    "derive_augmentation",
+    "discover_row_files",
+    "extract_score",
+    "normalize_tokens",
+    "rebatch_rows",
+    "setup_id",
+    "slugify",
+]

--- a/devops_bench/results/aggregate.py
+++ b/devops_bench/results/aggregate.py
@@ -1,0 +1,274 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Combine per-task parallel runs into one batch run for dashboard ingest.
+
+The matrix runs one task per process, emitting a ``rows.json`` per task with its
+own ``runId``/``t``; the dashboard models a run as a batch of tasks sharing one
+``runId``/``t`` (tasks kept distinct by ``taskFolder``). This rewrites the
+per-task rows onto a single batch ``run_id`` + ``t`` and writes a combined
+``rows.json`` + per-setup ``manifests.json``. The batch ``run_id`` carries a
+unique suffix so repeated/concurrent runs never collide on the
+``setupId__runId__taskFolder__iteration`` doc id.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+from collections.abc import Iterable
+from pathlib import Path
+
+from devops_bench.results.row import SCHEMA_VERSION, Manifest, ResultRow
+
+__all__ = [
+    "aggregate",
+    "build_manifests",
+    "dedupe_latest",
+    "discover_row_files",
+    "rebatch_rows",
+]
+
+# ``manifests.json`` is plural: the combined file may span several setups.
+_ROWS_FILENAME = "rows.json"
+_OUT_ROWS_FILENAME = "rows.json"
+_OUT_MANIFESTS_FILENAME = "manifests.json"
+
+
+def discover_row_files(root: str | os.PathLike[str], *, exclude: Iterable[Path] = ()) -> list[Path]:
+    """Recursively collect per-task ``rows.json`` files under ``root``.
+
+    Walks ``root`` in sorted order for deterministic aggregation and skips any
+    path in ``exclude`` (e.g. a previously written combined output living under
+    the same tree).
+
+    Args:
+        root: Directory to scan (e.g. the matrix results root).
+        exclude: Absolute paths to skip.
+
+    Returns:
+        The discovered ``rows.json`` paths, path-sorted.
+    """
+    root_path = Path(root)
+    skip = {Path(p).resolve() for p in exclude}
+    out = [p for p in sorted(root_path.rglob(_ROWS_FILENAME)) if p.resolve() not in skip]
+    return out
+
+
+def _load_rows(files: Iterable[Path]) -> list[dict]:
+    """Read and concatenate the ``ResultRow[]`` arrays from ``files``.
+
+    Args:
+        files: ``rows.json`` paths, each holding a JSON list of row dicts.
+
+    Returns:
+        The flattened row dicts, in file order.
+
+    Raises:
+        ValueError: If any file's top-level JSON is not a list.
+    """
+    rows: list[dict] = []
+    for file in files:
+        parsed = json.loads(Path(file).read_text(encoding="utf-8"))
+        if not isinstance(parsed, list):
+            raise ValueError(f"{file}: top level must be a ResultRow[] array")
+        rows.extend(parsed)
+    return rows
+
+
+def dedupe_latest(rows: Iterable[dict]) -> list[dict]:
+    """Drop duplicate ``(setupId, taskFolder, iteration)`` rows, keeping the latest.
+
+    A retried task can appear more than once across per-task run dirs; since those
+    three fields plus ``runId`` form the Firestore document id, two rows that
+    collide after re-batching would overwrite each other. Resolve it here by
+    keeping the row with the greatest original ``t`` (ISO timestamps sort
+    lexicographically), so a retry's newer result wins deterministically.
+
+    Args:
+        rows: Per-task row dicts (still carrying their original ``t``).
+
+    Returns:
+        The de-duplicated rows, in first-seen key order.
+    """
+    chosen: dict[tuple[str, str, int], dict] = {}
+    order: list[tuple[str, str, int]] = []
+    for row in rows:
+        key = (row.get("setupId", ""), row.get("taskFolder", ""), int(row.get("iteration", 0)))
+        prev = chosen.get(key)
+        if prev is None:
+            order.append(key)
+            chosen[key] = row
+        elif str(row.get("t", "")) >= str(prev.get("t", "")):
+            chosen[key] = row
+    return [chosen[key] for key in order]
+
+
+def rebatch_rows(rows: Iterable[dict], *, run_id: str, t: str) -> list[ResultRow]:
+    """Stamp every row with one shared batch ``run_id`` and ``t``.
+
+    Each input dict is validated against :class:`ResultRow` (camelCase aliases),
+    so a malformed row fails loudly here rather than silently corrupting the
+    leaderboard. The run-level identity is the only thing rewritten.
+
+    Args:
+        rows: Per-task row dicts (camelCase keys, as written by the reporter).
+        run_id: Batch run id to apply to every row.
+        t: Batch UTC ISO-8601 timestamp to apply to every row.
+
+    Returns:
+        Re-batched :class:`ResultRow` instances, input order preserved.
+
+    Raises:
+        pydantic.ValidationError: If any row does not match the schema.
+    """
+    return [
+        ResultRow.model_validate(row).model_copy(update={"run_id": run_id, "t": t}) for row in rows
+    ]
+
+
+def build_manifests(rows: Iterable[ResultRow], *, run_id: str, t: str) -> list[Manifest]:
+    """Build one :class:`Manifest` per distinct setup in ``rows``.
+
+    Setups appear in first-seen order; each manifest takes the arm identity
+    (model / harness / augmentation) from that setup's first row and shares the
+    batch ``run_id`` / ``t``.
+
+    Args:
+        rows: Re-batched rows (all already carrying the batch ``run_id`` / ``t``).
+        run_id: Batch run id, mirrored onto every manifest.
+        t: Batch timestamp, mirrored onto every manifest.
+
+    Returns:
+        One manifest per setup, in first-seen order.
+    """
+    manifests: dict[str, Manifest] = {}
+    for row in rows:
+        if row.setup_id in manifests:
+            continue
+        manifests[row.setup_id] = Manifest(
+            schema_version=SCHEMA_VERSION,
+            run_id=run_id,
+            t=t,
+            setup_id=row.setup_id,
+            model=row.model,
+            harness=row.harness,
+            augmentation=list(row.augmentation),
+        )
+    return list(manifests.values())
+
+
+def aggregate(files: Iterable[Path], *, run_id: str, t: str) -> tuple[list[dict], list[dict]]:
+    """Aggregate per-task ``rows.json`` files into one batch run.
+
+    De-duplicates retried tasks (latest wins), re-batches the rows onto a single
+    ``run_id`` / ``t``, and derives the per-setup manifests.
+
+    Args:
+        files: Per-task ``rows.json`` paths.
+        run_id: Batch run id to stamp on every row/manifest.
+        t: Batch UTC ISO-8601 timestamp to stamp on every row/manifest.
+
+    Returns:
+        A ``(rows, manifests)`` pair of JSON-serializable dict lists, ready to
+        write as ``rows.json`` / ``manifests.json``.
+    """
+    deduped = dedupe_latest(_load_rows(files))
+    rows = rebatch_rows(deduped, run_id=run_id, t=t)
+    manifests = build_manifests(rows, run_id=run_id, t=t)
+    return [row.to_dict() for row in rows], [m.to_dict() for m in manifests]
+
+
+def _default_run_id() -> str:
+    """Generate a batch run id ``run_YYYYMMDD_HHMMSS_<pid>``.
+
+    The ``run_<ts>`` prefix keeps it human-sortable and PROTOCOL-shaped; the pid
+    suffix makes it unique across concurrent matrix aggregations in the same
+    second. Pass ``--run-id`` to use the matrix's own id instead.
+    """
+    now = datetime.datetime.now(datetime.UTC)
+    return f"run_{now.strftime('%Y%m%d_%H%M%S')}_{os.getpid()}"
+
+
+def _now_iso() -> str:
+    """Return the current time as a UTC ISO-8601 ``...Z`` string."""
+    return datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: aggregate a matrix results tree into one combined run.
+
+    Args:
+        argv: Argument vector (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        Process exit code (0 on success).
+    """
+    parser = argparse.ArgumentParser(
+        prog="python -m devops_bench.results.aggregate",
+        description="Combine per-task parallel run rows.json files into one batch "
+        "run (shared runId/t) for dashboard ingest.",
+    )
+    parser.add_argument("root", help="Results root scanned recursively for per-task rows.json.")
+    parser.add_argument(
+        "-o",
+        "--out-dir",
+        default=None,
+        help="Output directory for the combined rows.json/manifests.json (default: ROOT).",
+    )
+    parser.add_argument(
+        "--run-id",
+        default=None,
+        help="Batch run id to stamp on every row (default: run_<ts>_<pid>).",
+    )
+    parser.add_argument(
+        "--t",
+        default=None,
+        help="Batch UTC ISO-8601 timestamp to stamp on every row (default: now).",
+    )
+    args = parser.parse_args(argv)
+
+    out_dir = Path(args.out_dir) if args.out_dir else Path(args.root)
+    out_rows = (out_dir / _OUT_ROWS_FILENAME).resolve()
+    out_manifests = (out_dir / _OUT_MANIFESTS_FILENAME).resolve()
+
+    run_id = args.run_id or _default_run_id()
+    t = args.t or _now_iso()
+
+    # Exclude the outputs so re-running over the same tree is idempotent.
+    files = discover_row_files(args.root, exclude=(out_rows, out_manifests))
+    if not files:
+        parser.error(f"no {_ROWS_FILENAME} files found under {args.root}")
+
+    rows, manifests = aggregate(files, run_id=run_id, t=t)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_rows.write_text(json.dumps(rows, indent=2) + "\n", encoding="utf-8")
+    out_manifests.write_text(json.dumps(manifests, indent=2) + "\n", encoding="utf-8")
+
+    print(
+        f"aggregated {len(files)} file(s) -> {len(rows)} rows across "
+        f"{len(manifests)} setup(s) | run_id={run_id} t={t}"
+    )
+    print(f"  {out_rows}")
+    print(f"  {out_manifests}")
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/devops_bench/results/normalize.py
+++ b/devops_bench/results/normalize.py
@@ -1,0 +1,232 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Flatten nested harness records into :class:`ResultRow` rows.
+
+Pure functions only: this module reads no environment and performs no scoring.
+It maps the harness's metric-keyed records and a run-level :class:`Manifest`
+onto the flat dashboard contract, normalizing the per-provider token shapes and
+the per-metric score shapes along the way.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from devops_bench.results.row import Manifest, ResultRow
+
+__all__ = [
+    "OUTCOME_SCORE_KEY",
+    "TOOL_SCORE_KEY",
+    "build_rows",
+    "derive_augmentation",
+    "extract_score",
+    "normalize_tokens",
+    "setup_id",
+    "slugify",
+]
+
+#: ``res["scores"]`` keys the flat ``outcomeScore`` / ``toolScore`` are read
+#: from. These match the ``MetricScore.name`` of the builtin outcome and tool
+#: metrics.
+OUTCOME_SCORE_KEY = "OutcomeValidity"
+TOOL_SCORE_KEY = "ToolInvocation"
+
+# Token usage aliases per provider, in lookup priority. Kept in sync with
+# ``devops_bench.agents.api.agent.extract_tokens`` (API providers) and the CLI
+# parsers, which emit ``input`` / ``output``.
+_INPUT_TOKEN_KEYS = ("prompt_tokens", "prompt_token_count", "input_tokens", "input")
+_OUTPUT_TOKEN_KEYS = (
+    "candidates_tokens",
+    "candidates_token_count",
+    "completion_tokens",
+    "output_tokens",
+    "output",
+)
+
+# Runs of characters outside ``[a-z0-9]`` collapse to a single ``-``. Mirrors the
+# dashboard's ``catalog.mjs`` / seeder ``slugify`` so the model component of a
+# setup id matches the model catalog doc key (``gemini-3.1-pro`` ->
+# ``gemini-3-1-pro``, not ``gemini-31-pro``).
+_DISALLOWED_ID_CHARS = re.compile(r"[^a-z0-9]+")
+
+
+def slugify(text: str) -> str:
+    """Reduce ``text`` to a document-key-safe slug.
+
+    Lower-cases ``text``, collapses each run of characters outside ``[a-z0-9]``
+    to a single ``-``, and strips leading/trailing dashes. This is byte-for-byte
+    the dashboard's ``catalog.mjs`` / seeder ``slugify`` algorithm, so the same
+    arm yields the same id across the producer, the seeder, and the catalog join
+    (e.g. ``gemini-3.1-pro`` -> ``gemini-3-1-pro``).
+
+    Args:
+        text: Arbitrary identifier text.
+
+    Returns:
+        The sanitized slug (possibly empty).
+    """
+    return _DISALLOWED_ID_CHARS.sub("-", text.lower()).strip("-")
+
+
+def setup_id(model: str, harness: str, augmentation: Iterable[str]) -> str:
+    """Build the deterministic setup id for a ``(model, harness, augmentation)`` arm.
+
+    The augmentation tokens are sorted so the id is independent of token order;
+    the baseline arm (no tokens) yields ``"<model>-<harness>"`` with no trailing
+    dash.
+
+    Args:
+        model: Model identifier.
+        harness: Canonical harness key.
+        augmentation: Capability tokens for the arm.
+
+    Returns:
+        The sanitized setup id.
+    """
+    parts = [model, harness]
+    tokens = sorted(augmentation)
+    if tokens:
+        parts.append("-".join(tokens))
+    return slugify("-".join(parts))
+
+
+def derive_augmentation(capabilities_granted: Mapping[str, Any] | None) -> list[str]:
+    """Map a record's ``capabilities_granted`` to sorted augmentation tokens.
+
+    ``use_mcp`` contributes ``"mcp"``; a non-empty ``skills`` list contributes
+    ``"skills"``. An arm with neither yields ``[]`` (baseline).
+
+    Args:
+        capabilities_granted: The record's ``capabilities_granted`` mapping
+            (``{"use_mcp": bool, "skills": list}``), or ``None``.
+
+    Returns:
+        Sorted, de-duplicated capability tokens.
+    """
+    caps = capabilities_granted or {}
+    tokens: set[str] = set()
+    if caps.get("use_mcp"):
+        tokens.add("mcp")
+    if caps.get("skills"):
+        tokens.add("skills")
+    return sorted(tokens)
+
+
+def _coerce_int(value: Any) -> int | None:
+    """Return ``value`` as an int, or ``None`` if it is missing/non-numeric."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return None
+
+
+def _first_token(tokens: Mapping[str, Any], keys: tuple[str, ...]) -> int | None:
+    """Return the first integer-coercible value among ``keys`` in ``tokens``."""
+    for key in keys:
+        if key in tokens:
+            coerced = _coerce_int(tokens[key])
+            if coerced is not None:
+                return coerced
+    return None
+
+
+def normalize_tokens(tokens: Mapping[str, Any] | None) -> tuple[int | None, int | None]:
+    """Flatten a provider-defined token dict to ``(input_tokens, output_tokens)``.
+
+    Reads the first present alias for each direction across the known provider
+    shapes; an unreported direction yields ``None`` rather than ``0`` so the
+    dashboard can distinguish "no data" from a genuine zero.
+
+    Args:
+        tokens: The record's ``tokens`` mapping, or ``None``.
+
+    Returns:
+        An ``(input_tokens, output_tokens)`` pair, each ``int`` or ``None``.
+    """
+    usage = tokens or {}
+    return (
+        _first_token(usage, _INPUT_TOKEN_KEYS),
+        _first_token(usage, _OUTPUT_TOKEN_KEYS),
+    )
+
+
+def extract_score(scores: Mapping[str, Any] | None, key: str) -> float | None:
+    """Pull a single continuous metric score out of a record's ``scores`` map.
+
+    Handles both score shapes produced by ``MetricScore.to_entry``: a bare
+    number, or a ``{"score": ..., "success": ..., "reason": ...}`` dict.
+
+    Args:
+        scores: The record's ``scores`` mapping, or ``None``.
+        key: Metric name to read (e.g. :data:`OUTCOME_SCORE_KEY`).
+
+    Returns:
+        The score as a float, or ``None`` when absent or non-numeric.
+    """
+    value: Any = (scores or {}).get(key)
+    if isinstance(value, Mapping):
+        value = value.get("score")
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def build_rows(records: Iterable[Mapping[str, Any]], manifest: Manifest) -> list[ResultRow]:
+    """Flatten harness result records into :class:`ResultRow` rows for one run.
+
+    Run-level identity comes from ``manifest``; per-task fields are read from
+    each record. Every record yields exactly one row at ``iteration = 0``
+    (single run per task today); failed records pass through with ``None`` scores
+    so the failure stays visible downstream.
+
+    Args:
+        records: The harness's per-task result dicts (the ``results.json`` list).
+        manifest: Run-level identity shared by every emitted row.
+
+    Returns:
+        One :class:`ResultRow` per record, in input order.
+    """
+    rows: list[ResultRow] = []
+    for record in records:
+        scores = record.get("scores")
+        input_tokens, output_tokens = normalize_tokens(record.get("tokens"))
+        rows.append(
+            ResultRow(
+                setup_id=manifest.setup_id,
+                model=manifest.model,
+                harness=manifest.harness,
+                augmentation=list(manifest.augmentation),
+                run_id=manifest.run_id,
+                t=manifest.t,
+                task_folder=record.get("folder", "") or "",
+                task_name=record.get("name", "") or "",
+                iteration=0,
+                outcome_score=extract_score(scores, OUTCOME_SCORE_KEY),
+                tool_score=extract_score(scores, TOOL_SCORE_KEY),
+                latency_sec=float(record.get("latency") or 0.0),
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                status=record.get("status", "") or "",
+                validated=bool(record.get("validated", False)),
+            )
+        )
+    return rows

--- a/devops_bench/results/row.py
+++ b/devops_bench/results/row.py
@@ -1,0 +1,137 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Flattened, ingest-ready result rows bridging the harness and the dashboard.
+
+The harness writes a nested, metric-keyed ``results.json`` per run. The
+leaderboard instead consumes one flat row per ``(setup × task × run ×
+iteration)`` carrying continuous scores. :class:`ResultRow` is that flat row and
+:class:`Manifest` is the run-level identity shared by every row in a run; the
+normalizer in :mod:`devops_bench.results.normalize` turns harness records into
+``ResultRow`` instances. This module owns the on-disk shape only — it performs
+no scoring and reads no environment.
+
+Both models are frozen and serialize through a camelCase alias generator, so
+``to_dict()`` emits exactly the field names of the dashboard's ``ResultRow`` /
+manifest interfaces while the Python attributes stay snake_case.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+__all__ = ["SCHEMA_VERSION", "Manifest", "ResultRow"]
+
+#: Version of the ``rows.json`` / ``manifest.json`` contract. Bump on any
+#: breaking field change so a downstream ingest can detect a shape mismatch.
+SCHEMA_VERSION = 1
+
+# Frozen + camelCase aliases. ``populate_by_name`` keeps the snake_case
+# attribute names usable as constructor kwargs (the normalizer builds rows that
+# way), while ``to_dict`` dumps the camelCase aliases the dashboard expects.
+_MODEL_CONFIG = ConfigDict(frozen=True, alias_generator=to_camel, populate_by_name=True)
+
+
+class Manifest(BaseModel):
+    """Run-level identity shared by every :class:`ResultRow` in a run.
+
+    Attributes:
+        schema_version: Contract version; mirrors :data:`SCHEMA_VERSION`.
+        run_id: Run directory suffix, ``run_YYYYMMDD_HHMMSS``.
+        t: Run timestamp as a UTC ISO-8601 string (e.g. ``2026-06-01T00:00:00Z``).
+        setup_id: Deterministic id for the ``(model, harness, augmentation)``
+            arm; the join key the dashboard groups rows by.
+        model: Model identifier under test (e.g. ``AGENT_MODEL``).
+        harness: Canonical agent/harness key (e.g. ``gemini`` / ``openclaw`` /
+            ``api``).
+        augmentation: Capability tokens active for the run (e.g.
+            ``["mcp", "skills"]``); an empty list denotes the baseline arm.
+    """
+
+    model_config = _MODEL_CONFIG
+
+    schema_version: int
+    run_id: str
+    t: str
+    setup_id: str
+    model: str
+    harness: str
+    augmentation: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON-serializable mapping written to ``manifest.json``."""
+        return self.model_dump(by_alias=True)
+
+
+class ResultRow(BaseModel):
+    """One flattened iteration row, the producer-side leaderboard contract.
+
+    Mirrors the ``ResultRow`` TypeScript interface the dashboard reads field for
+    field (the contract version lives once on the run :class:`Manifest`, not on
+    every row). Scores and token counts are nullable because a failed or unscored
+    iteration carries no judged value; ``outcome_score`` stays continuous (never
+    a precomputed pass flag) so any pass threshold / pass@k formula remains
+    computable downstream.
+
+    Attributes:
+        setup_id: Run arm id; matches :attr:`Manifest.setup_id`.
+        model: Model identifier; matches :attr:`Manifest.model`.
+        harness: Canonical harness key; matches :attr:`Manifest.harness`.
+        augmentation: Capability tokens; matches :attr:`Manifest.augmentation`.
+        run_id: Run directory suffix; matches :attr:`Manifest.run_id`.
+        t: UTC ISO-8601 run timestamp; matches :attr:`Manifest.t`.
+        task_folder: The task's directory name.
+        task_name: The task's human-readable name (the spec ``name:`` field).
+        iteration: Zero-based repeat index; always ``0`` until multi-iteration
+            runs land.
+        outcome_score: Outcome-validity judge score in ``[0, 1]``, or ``None``
+            when the metric did not run (e.g. a failed task).
+        tool_score: Tool-invocation judge score in ``[0, 1]``, or ``None``.
+        latency_sec: Agent wall-clock seconds for the iteration.
+        input_tokens: Prompt token count, or ``None`` when unreported.
+        output_tokens: Completion token count, or ``None`` when unreported.
+        status: Terminal record status, ``"success"`` or ``"failed"``.
+        validated: Whether the task is vetted as correct and eligible for the
+            leaderboard; ingest gates promotion on this (default ``False``).
+    """
+
+    model_config = _MODEL_CONFIG
+
+    setup_id: str
+    model: str
+    harness: str
+    augmentation: list[str]
+    run_id: str
+    t: str
+    task_folder: str
+    task_name: str
+    iteration: int
+    outcome_score: float | None
+    tool_score: float | None
+    latency_sec: float
+    input_tokens: int | None
+    output_tokens: int | None
+    status: str
+    validated: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON-serializable mapping written to ``rows.json``.
+
+        Keys use the camelCase names of the dashboard ``ResultRow`` interface so
+        the row round-trips into Firestore without a rename step.
+        """
+        return self.model_dump(by_alias=True)

--- a/tests/unit/results/test_results_aggregate.py
+++ b/tests/unit/results/test_results_aggregate.py
@@ -1,0 +1,117 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for combining per-task parallel runs into one batch run."""
+
+import json
+
+from devops_bench.results import (
+    aggregate,
+    build_manifests,
+    dedupe_latest,
+    discover_row_files,
+    rebatch_rows,
+)
+
+
+def _row(**overrides):
+    """One per-task row dict in the reporter's camelCase shape."""
+    base = dict(
+        setupId="m-h-mcp",
+        model="m",
+        harness="h",
+        augmentation=["mcp"],
+        runId="run_20260601_000001_taskA__m__h",
+        t="2026-06-01T00:00:01Z",
+        taskFolder="task-a",
+        taskName="task-a",
+        iteration=0,
+        outcomeScore=1.0,
+        toolScore=None,
+        latencySec=1.0,
+        inputTokens=10,
+        outputTokens=5,
+        status="success",
+        validated=False,
+    )
+    base.update(overrides)
+    return base
+
+
+def _write_rows(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(rows), encoding="utf-8")
+
+
+def test_rebatch_stamps_shared_run_id_and_t():
+    rows = [
+        _row(taskFolder="task-a", taskName="task-a", t="2026-06-01T00:00:01Z", runId="run_a"),
+        _row(taskFolder="task-b", taskName="task-b", t="2026-06-01T00:00:09Z", runId="run_b"),
+    ]
+    out = rebatch_rows(rows, run_id="run_20260601_120000_42", t="2026-06-01T12:00:00Z")
+    assert {r.run_id for r in out} == {"run_20260601_120000_42"}
+    assert {r.t for r in out} == {"2026-06-01T12:00:00Z"}
+    # Per-task identity is untouched, so the doc-id stays unique per task.
+    assert [r.task_folder for r in out] == ["task-a", "task-b"]
+
+
+def test_dedupe_keeps_latest_original_t():
+    rows = [
+        _row(taskFolder="task-a", t="2026-06-01T00:00:01Z", outcomeScore=0.0),
+        _row(taskFolder="task-a", t="2026-06-01T05:00:00Z", outcomeScore=1.0),  # retry, newer
+    ]
+    kept = dedupe_latest(rows)
+    assert len(kept) == 1
+    assert kept[0]["outcomeScore"] == 1.0
+
+
+def test_build_manifests_one_per_setup():
+    rows = rebatch_rows(
+        [
+            _row(setupId="m-h-mcp", taskFolder="task-a", taskName="task-a"),
+            _row(setupId="m-h-mcp", taskFolder="task-b", taskName="task-b"),
+            _row(setupId="m-h", augmentation=[], taskFolder="task-a", taskName="task-a"),
+        ],
+        run_id="run_x",
+        t="2026-06-01T12:00:00Z",
+    )
+    manifests = build_manifests(rows, run_id="run_x", t="2026-06-01T12:00:00Z")
+    assert [m.setup_id for m in manifests] == ["m-h-mcp", "m-h"]
+    assert all(m.run_id == "run_x" and m.t == "2026-06-01T12:00:00Z" for m in manifests)
+
+
+def test_aggregate_collapses_per_task_runs_into_one_run(tmp_path):
+    # Two tasks of one arm, run as separate processes (distinct runId + t).
+    _write_rows(tmp_path / "run_1" / "rows.json", [_row(taskFolder="task-a", taskName="task-a")])
+    _write_rows(
+        tmp_path / "run_2" / "rows.json",
+        [_row(taskFolder="task-b", taskName="task-b", runId="run_b", t="2026-06-01T00:00:09Z")],
+    )
+    files = discover_row_files(tmp_path)
+    rows, manifests = aggregate(files, run_id="run_20260601_120000_7", t="2026-06-01T12:00:00Z")
+
+    assert len(rows) == 2
+    assert {r["runId"] for r in rows} == {"run_20260601_120000_7"}
+    assert {r["t"] for r in rows} == {"2026-06-01T12:00:00Z"}
+    assert {r["taskFolder"] for r in rows} == {"task-a", "task-b"}
+    assert len(manifests) == 1  # one setup -> one manifest
+
+
+def test_discover_excludes_given_outputs(tmp_path):
+    _write_rows(tmp_path / "run_1" / "rows.json", [_row()])
+    out = tmp_path / "rows.json"
+    _write_rows(out, [_row()])
+    files = discover_row_files(tmp_path, exclude=(out.resolve(),))
+    assert out.resolve() not in {f.resolve() for f in files}
+    assert (tmp_path / "run_1" / "rows.json").resolve() in {f.resolve() for f in files}

--- a/tests/unit/results/test_results_normalize.py
+++ b/tests/unit/results/test_results_normalize.py
@@ -1,0 +1,265 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the harness-to-dashboard result normalizer."""
+
+from devops_bench.results import (
+    SCHEMA_VERSION,
+    Manifest,
+    build_rows,
+    derive_augmentation,
+    extract_score,
+    normalize_tokens,
+    setup_id,
+)
+from devops_bench.results.normalize import OUTCOME_SCORE_KEY, TOOL_SCORE_KEY
+
+
+def _manifest(**overrides):
+    base = dict(
+        schema_version=SCHEMA_VERSION,
+        run_id="run_20260601_000000",
+        t="2026-06-01T00:00:00Z",
+        setup_id="m-h",
+        model="m",
+        harness="h",
+        augmentation=[],
+    )
+    base.update(overrides)
+    return Manifest(**base)
+
+
+# -- derive_augmentation -----------------------------------------------------
+
+
+def test_derive_augmentation_baseline_is_empty():
+    assert derive_augmentation({"use_mcp": False, "skills": []}) == []
+    assert derive_augmentation(None) == []
+
+
+def test_derive_augmentation_mcp_only():
+    assert derive_augmentation({"use_mcp": True, "skills": []}) == ["mcp"]
+
+
+def test_derive_augmentation_skills_maps_to_skills():
+    assert derive_augmentation({"use_mcp": False, "skills": ["s.md"]}) == ["skills"]
+
+
+def test_derive_augmentation_combined_is_sorted():
+    assert derive_augmentation({"use_mcp": True, "skills": ["s.md"]}) == ["mcp", "skills"]
+
+
+# -- setup_id ----------------------------------------------------------------
+
+
+def test_setup_id_baseline_has_no_trailing_dash():
+    assert setup_id("alpha-pro", "gemini", []) == "alpha-pro-gemini"
+
+
+def test_setup_id_is_order_independent():
+    assert setup_id("m", "h", ["skills", "mcp"]) == setup_id("m", "h", ["mcp", "skills"])
+    assert setup_id("m", "h", ["skills", "mcp"]) == "m-h-mcp-skills"
+
+
+def test_setup_id_strips_unsafe_chars():
+    # Runs of unsafe chars collapse to a single dash and the id is lower-cased,
+    # matching catalog.mjs (NOT dropped, which would give "gemini25pro-api").
+    assert setup_id("gemini 2.5/pro", "api", []) == "gemini-2-5-pro-api"
+
+
+def test_setup_id_matches_catalog_slug_for_dotted_model():
+    # The setup id's model component must equal the model catalog doc key that
+    # catalog.mjs slugify produces, so the rows<->catalog join holds.
+    assert setup_id("gemini-3.1-pro", "gemini-cli", []) == "gemini-3-1-pro-gemini-cli"
+
+
+# -- normalize_tokens --------------------------------------------------------
+
+
+def test_normalize_tokens_api_shape():
+    tokens = {"prompt_tokens": 10, "candidates_tokens": 5, "total_tokens": 15}
+    assert normalize_tokens(tokens) == (10, 5)
+
+
+def test_normalize_tokens_cli_shape():
+    assert normalize_tokens({"input": 7, "output": 3}) == (7, 3)
+
+
+def test_normalize_tokens_google_metadata_shape():
+    tokens = {"prompt_token_count": 8, "candidates_token_count": 4}
+    assert normalize_tokens(tokens) == (8, 4)
+
+
+def test_normalize_tokens_missing_yields_none():
+    assert normalize_tokens({}) == (None, None)
+    assert normalize_tokens(None) == (None, None)
+
+
+def test_normalize_tokens_float_coerced_to_int():
+    assert normalize_tokens({"input": 12.0, "output": 3.9}) == (12, 3)
+
+
+# -- extract_score -----------------------------------------------------------
+
+
+def test_extract_score_dict_shape():
+    scores = {OUTCOME_SCORE_KEY: {"score": 0.83, "success": True, "reason": "ok"}}
+    assert extract_score(scores, OUTCOME_SCORE_KEY) == 0.83
+
+
+def test_extract_score_bare_float_shape():
+    assert extract_score({TOOL_SCORE_KEY: 0.5}, TOOL_SCORE_KEY) == 0.5
+
+
+def test_extract_score_missing_metric_is_none():
+    assert extract_score({}, OUTCOME_SCORE_KEY) is None
+    assert extract_score(None, OUTCOME_SCORE_KEY) is None
+
+
+def test_extract_score_none_score_in_dict_is_none():
+    assert extract_score({OUTCOME_SCORE_KEY: {"score": None}}, OUTCOME_SCORE_KEY) is None
+
+
+# -- build_rows --------------------------------------------------------------
+
+
+def test_build_rows_success_record():
+    manifest = _manifest(
+        setup_id="alpha-gemini-mcp-skills",
+        model="alpha",
+        harness="gemini",
+        augmentation=["mcp", "skills"],
+    )
+    record = {
+        "name": "Rotate Secret",
+        "folder": "task_001",
+        "status": "success",
+        "latency": 42.5,
+        "tokens": {"prompt_tokens": 100, "candidates_tokens": 20},
+        "scores": {
+            OUTCOME_SCORE_KEY: {"score": 0.9, "success": True, "reason": "ok"},
+            TOOL_SCORE_KEY: {"score": 0.7, "success": True, "reason": "ok"},
+        },
+    }
+
+    rows = build_rows([record], manifest)
+
+    assert len(rows) == 1
+    d = rows[0].to_dict()
+    assert d == {
+        "setupId": "alpha-gemini-mcp-skills",
+        "model": "alpha",
+        "harness": "gemini",
+        "augmentation": ["mcp", "skills"],
+        "runId": "run_20260601_000000",
+        "t": "2026-06-01T00:00:00Z",
+        "taskFolder": "task_001",
+        "taskName": "Rotate Secret",
+        "iteration": 0,
+        "outcomeScore": 0.9,
+        "toolScore": 0.7,
+        "latencySec": 42.5,
+        "inputTokens": 100,
+        "outputTokens": 20,
+        "status": "success",
+        "validated": False,
+    }
+
+
+def test_build_rows_failed_record_has_null_scores_and_tokens():
+    record = {
+        "name": "Broken Task",
+        "folder": "task_002",
+        "status": "failed",
+        "latency": 0.0,
+        "tokens": {},
+        "scores": {},
+    }
+
+    row = build_rows([record], _manifest())[0]
+
+    assert row.status == "failed"
+    assert row.outcome_score is None
+    assert row.tool_score is None
+    assert row.input_tokens is None
+    assert row.output_tokens is None
+    assert row.iteration == 0
+
+
+def test_build_rows_preserves_order_and_run_identity():
+    manifest = _manifest(run_id="run_20260101_120000")
+    records = [
+        {"name": "a", "folder": "f-a", "status": "success", "scores": {}, "tokens": {}},
+        {"name": "b", "folder": "f-b", "status": "success", "scores": {}, "tokens": {}},
+    ]
+
+    rows = build_rows(records, manifest)
+
+    assert [r.task_name for r in rows] == ["a", "b"]
+    assert all(r.run_id == "run_20260101_120000" for r in rows)
+
+
+def test_result_row_keys_match_typescript_interface():
+    """``ResultRow.to_dict()`` keys mirror the dashboard ``ResultRow`` interface.
+
+    Pinned so the producer and the ``site/src/lib/schema.d.ts`` consumer
+    cannot drift apart silently. The contract version lives on the manifest, not
+    on each row, so ``schemaVersion`` is intentionally absent here.
+    """
+    ts_result_row_fields = {
+        "setupId",
+        "model",
+        "harness",
+        "augmentation",
+        "runId",
+        "t",
+        "taskFolder",
+        "taskName",
+        "iteration",
+        "status",
+        "outcomeScore",
+        "toolScore",
+        "latencySec",
+        "inputTokens",
+        "outputTokens",
+        "validated",
+    }
+    row = build_rows(
+        [{"name": "n", "folder": "f", "status": "success", "scores": {}, "tokens": {}}],
+        _manifest(),
+    )[0]
+    assert set(row.to_dict()) == ts_result_row_fields
+
+
+def test_manifest_to_dict_keys():
+    assert set(_manifest().to_dict()) == {
+        "schemaVersion",
+        "runId",
+        "t",
+        "setupId",
+        "model",
+        "harness",
+        "augmentation",
+    }
+
+
+def test_build_rows_propagates_validated():
+    manifest = _manifest()
+    validated_row = build_rows(
+        [{"name": "t", "folder": "f", "status": "success", "validated": True}], manifest
+    )[0]
+    assert validated_row.to_dict()["validated"] is True
+    # Absent key defaults to False (unvetted tasks don't promote).
+    default_row = build_rows([{"name": "t", "folder": "f", "status": "success"}], manifest)[0]
+    assert default_row.to_dict()["validated"] is False


### PR DESCRIPTION
Adds the `devops_bench.results` package:

- `row.py`: `ResultRow` / `Manifest` models describing one row in tj leaderboard (setup × task × run × iteration).
- `normalize.py`: flattens eval harness result records into rows.
- `aggregate.py`: combines per-task runs produced by eval harness into a single batch run and writes the combined `rows.json` plus per-setup `manifests.json`.
- Unit tests under `tests/unit/results/`.

No new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standardized result format for dashboard and leaderboard ingestion.
  * Added normalization for task results, including identifiers, augmentation details, token usage, scores, latency, status, and validation data.
  * Added aggregation of per-task result files into a single batch, with de-duplication and manifest generation.
  * Added a command-line workflow for producing consolidated result and manifest files.
  * Added stable public imports for result processing capabilities.

* **Tests**
  * Added coverage for normalization, aggregation, de-duplication, manifest creation, and output compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->