### PR TITLE
feat(providers): add the cloud provider abstraction (base, GCP, KinD)

### DIFF
--- a/devops_bench/providers/__init__.py
+++ b/devops_bench/providers/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cloud providers selecting credentials and OpenTofu variables per cloud."""
+
+from __future__ import annotations
+
+# Import for their registration side effects so the registry is populated.
+from devops_bench.providers import gcp as _gcp  # noqa: F401
+from devops_bench.providers import kind as _kind  # noqa: F401
+from devops_bench.providers.base import PROVIDERS, Provider, ResolveContext
+
+__all__ = ["PROVIDERS", "Provider", "ResolveContext"]

--- a/devops_bench/providers/base.py
+++ b/devops_bench/providers/base.py
@@ -1,0 +1,99 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cloud provider abstraction: identity, cluster access, and OpenTofu variables."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+from devops_bench.core import ClusterInfo, Registry
+
+__all__ = ["PROVIDERS", "Provider", "ResolveContext"]
+
+# The entry-point group lets out-of-tree providers register without code changes.
+PROVIDERS: Registry[type[Provider]] = Registry(
+    "providers", entry_point_group="devops_bench.providers"
+)
+
+
+@dataclass(frozen=True)
+class ResolveContext:
+    """Defaults available to a provider when resolving OpenTofu variables.
+
+    Attributes:
+        stack: Stack name or path being provisioned.
+        project_id: Default cloud project ID.
+        cluster_name: Default cluster name.
+        location: Default cloud region or zone.
+    """
+
+    stack: str
+    project_id: str
+    cluster_name: str
+    location: str
+
+
+class Provider(ABC):
+    """A cloud environment a benchmark task runs against.
+
+    Splits credentials by scope: account-wide identity (needed by any task that
+    calls cloud APIs, with or without a cluster) versus cluster access
+    (kubeconfig). Local providers (e.g. KinD) implement the account methods as
+    no-ops.
+    """
+
+    @abstractmethod
+    def ensure_account_credentials(self) -> None:
+        """Ensure account-wide cloud identity is active.
+
+        Idempotent: safe to call repeatedly before provisioning or before a task
+        calls cloud APIs. Local providers do nothing.
+        """
+
+    @abstractmethod
+    def ensure_cluster_credentials(
+        self, cluster_name: str, location: str, variables: dict[str, Any]
+    ) -> ClusterInfo:
+        """Make a provisioned cluster reachable and describe it.
+
+        Resolves the cluster's project and configures kubeconfig access (e.g. via
+        ``gcloud container clusters get-credentials``) so ``kubectl`` can reach
+        it.
+
+        Args:
+            cluster_name: Cluster name from the stack outputs.
+            location: Cloud region/zone (or ``"local"``) from the stack outputs.
+            variables: OpenTofu input variables the cluster was provisioned with.
+
+        Returns:
+            The cluster's :class:`~devops_bench.core.ClusterInfo`.
+        """
+
+    @abstractmethod
+    def resolve_variables(
+        self, ctx: ResolveContext, custom_variables: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Fill default OpenTofu variables for this provider.
+
+        Args:
+            ctx: Default project/cluster/location values.
+            custom_variables: Task-specified variables; always preserved over
+                defaults.
+
+        Returns:
+            A new mapping with provider defaults filled in where not already set.
+        """

--- a/devops_bench/providers/gcp.py
+++ b/devops_bench/providers/gcp.py
@@ -1,0 +1,126 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GCP provider: identity, GKE cluster access, and stack variable defaults."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from devops_bench.core import ClusterInfo, ConfigError, get_bool, get_env, get_logger
+from devops_bench.core.subprocess import run
+from devops_bench.providers.base import PROVIDERS, Provider, ResolveContext
+
+__all__ = ["GcpProvider"]
+
+_log = get_logger("providers.gcp")
+
+
+@PROVIDERS.register("gcp")
+class GcpProvider(Provider):
+    """Provider for GCP-hosted (GKE) clusters."""
+
+    def ensure_account_credentials(self) -> None:
+        """Ensure GCP application-default credentials are active.
+
+        Currently a no-op: runs assume ambient credentials (ADC, a service
+        account key, or workload identity) configured out of band.
+        """
+        _log.debug("GCP provider: assuming ambient application-default credentials")
+
+    def ensure_cluster_credentials(
+        self, cluster_name: str, location: str, variables: dict[str, Any]
+    ) -> ClusterInfo:
+        """Configure ``kubectl`` for a GKE cluster via ``gcloud``.
+
+        Args:
+            cluster_name: Cluster name from the stack outputs.
+            location: Cloud region or zone from the stack outputs.
+            variables: OpenTofu input variables the cluster was provisioned with.
+
+        Returns:
+            The cluster's :class:`~devops_bench.core.ClusterInfo`.
+
+        Raises:
+            ConfigError: If no project is resolvable from ``variables`` or the
+                ``GCP_PROJECT_ID`` environment variable.
+        """
+        project = variables.get("project_id") or get_env("GCP_PROJECT_ID")
+        if not project:
+            raise ConfigError("Project ID not found in variables or environment (GCP_PROJECT_ID).")
+
+        _log.info("Configuring kubectl for cluster: %s in %s...", cluster_name, location)
+        run(
+            [
+                "gcloud",
+                "container",
+                "clusters",
+                "get-credentials",
+                cluster_name,
+                "--location",
+                location,
+                "--project",
+                project,
+            ],
+            capture=False,
+        )
+
+        context_name = f"gke_{project}_{location}_{cluster_name}"
+        if get_bool("GCP_USE_ADC", False):
+            _log.info(
+                "Enabling application default credentials for auth plugin in context %s",
+                context_name,
+            )
+            run(
+                [
+                    "kubectl",
+                    "config",
+                    "set-credentials",
+                    context_name,
+                    "--exec-arg=--use_application_default_credentials",
+                ],
+                capture=False,
+            )
+        else:
+            _log.info(
+                "Skipping GKE ADC credentials override (GCP_USE_ADC is false) for context %s",
+                context_name,
+            )
+
+        return ClusterInfo.from_dict(
+            {"name": cluster_name, "location": location, "project": project}
+        )
+
+    def resolve_variables(
+        self, ctx: ResolveContext, custom_variables: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Resolve default OpenTofu variables for GCP-based stacks.
+
+        Returns:
+            A new mapping with ``project_id``, ``cluster_name``, and ``location``
+            filled in where not already set, plus ``namespace`` from the
+            ``NAMESPACE`` environment variable when present.
+        """
+        variables = custom_variables.copy()
+        variables.setdefault("infra_provider", "gcp")
+        variables.setdefault("project_id", ctx.project_id)
+        variables.setdefault("cluster_name", ctx.cluster_name)
+        variables.setdefault("location", ctx.location)
+        namespace = get_env("NAMESPACE")
+        if namespace is not None:
+            variables.setdefault("namespace", namespace)
+        kubeconfig_path = get_env("KUBECONFIG")
+        if kubeconfig_path:
+            variables.setdefault("kubeconfig_path", kubeconfig_path)
+        return variables

--- a/devops_bench/providers/kind.py
+++ b/devops_bench/providers/kind.py
@@ -49,8 +49,6 @@ class KindProvider(Provider):
             The cluster's :class:`~devops_bench.core.ClusterInfo`; ``project``
             falls back to ``local-kind`` when none is set.
         """
-        # Stays cloud-vendor neutral: no GCP-specific env vars here. The project
-        # comes from the stack variables, else the local placeholder.
         project = variables.get("project_id") or _LOCAL_PROJECT
         return ClusterInfo.from_dict(
             {

--- a/devops_bench/providers/kind.py
+++ b/devops_bench/providers/kind.py
@@ -49,7 +49,9 @@ class KindProvider(Provider):
             The cluster's :class:`~devops_bench.core.ClusterInfo`; ``project``
             falls back to ``local-kind`` when none is set.
         """
-        project = variables.get("project_id") or get_env("GCP_PROJECT_ID") or _LOCAL_PROJECT
+        # Stays cloud-vendor neutral: no GCP-specific env vars here. The project
+        # comes from the stack variables, else the local placeholder.
+        project = variables.get("project_id") or _LOCAL_PROJECT
         return ClusterInfo.from_dict(
             {
                 "name": cluster_name,

--- a/devops_bench/providers/kind.py
+++ b/devops_bench/providers/kind.py
@@ -1,0 +1,80 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""KinD provider: local clusters with no cloud identity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from devops_bench.core import ClusterInfo, get_env
+from devops_bench.providers.base import PROVIDERS, Provider, ResolveContext
+
+__all__ = ["KindProvider"]
+
+_DEFAULT_CLUSTER_NAME = "devops-bench-kind"
+_LOCAL_PROJECT = "local-kind"
+
+
+@PROVIDERS.register("kind")
+class KindProvider(Provider):
+    """Provider for local KinD clusters; no cloud account is involved."""
+
+    def ensure_account_credentials(self) -> None:
+        """No-op: local clusters require no cloud identity."""
+
+    def ensure_cluster_credentials(
+        self, cluster_name: str, location: str, variables: dict[str, Any]
+    ) -> ClusterInfo:
+        """Describe a local cluster; its kubeconfig is already on disk.
+
+        Args:
+            cluster_name: Cluster name from the stack outputs.
+            location: Location from the stack outputs (typically ``"local"``).
+            variables: OpenTofu input variables the cluster was provisioned with.
+
+        Returns:
+            The cluster's :class:`~devops_bench.core.ClusterInfo`; ``project``
+            falls back to ``local-kind`` when none is set.
+        """
+        project = variables.get("project_id") or get_env("GCP_PROJECT_ID") or _LOCAL_PROJECT
+        return ClusterInfo.from_dict(
+            {
+                "name": cluster_name,
+                "location": location,
+                "project": project,
+                "kubeconfig_path": variables.get("kubeconfig_path"),
+            }
+        )
+
+    def resolve_variables(
+        self, ctx: ResolveContext, custom_variables: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Resolve default OpenTofu variables for local KinD stacks.
+
+        Returns:
+            A new mapping with ``cluster_name``, ``location`` (``"local"``), and
+            ``kubeconfig_path`` filled in where not already set.
+        """
+        variables = custom_variables.copy()
+        variables.setdefault("infra_provider", "kind")
+        variables.setdefault("project_id", ctx.project_id or _LOCAL_PROJECT)
+        variables.setdefault("cluster_name", ctx.cluster_name or _DEFAULT_CLUSTER_NAME)
+        variables.setdefault("location", "local")
+        kubeconfig_path = get_env("KUBECONFIG") or str(
+            Path("~/.kube/config").expanduser().resolve()
+        )
+        variables.setdefault("kubeconfig_path", kubeconfig_path)
+        return variables

--- a/tests/unit/providers/test_providers.py
+++ b/tests/unit/providers/test_providers.py
@@ -1,0 +1,178 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for cloud providers and the provider registry."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from devops_bench.core import ConfigError
+from devops_bench.providers import PROVIDERS, ResolveContext
+from devops_bench.providers.gcp import GcpProvider
+from devops_bench.providers.kind import KindProvider
+
+
+@pytest.fixture
+def ctx():
+    return ResolveContext(
+        stack="custom/stack",
+        project_id="test-project",
+        cluster_name="test-cluster",
+        location="us-central1-a",
+    )
+
+
+def test_registry_populated():
+    assert PROVIDERS.get("gcp") is GcpProvider
+    assert PROVIDERS.get("kind") is KindProvider
+    assert "gcp" in PROVIDERS
+    assert "kind" in PROVIDERS
+
+
+# --- GcpProvider ---------------------------------------------------------------
+
+
+def test_gcp_resolve_variables_fills_defaults(ctx, monkeypatch):
+    monkeypatch.delenv("KUBECONFIG", raising=False)
+    variables = GcpProvider().resolve_variables(ctx, {"node_count": 5, "cluster_name": "override"})
+    assert variables == {
+        "infra_provider": "gcp",
+        "project_id": "test-project",
+        "cluster_name": "override",  # custom value preserved
+        "location": "us-central1-a",
+        "node_count": 5,
+    }
+
+
+def test_gcp_resolve_variables_namespace_from_env(ctx, monkeypatch):
+    monkeypatch.setenv("NAMESPACE", "team-a")
+    variables = GcpProvider().resolve_variables(ctx, {})
+    assert variables["namespace"] == "team-a"
+
+
+def test_gcp_resolve_variables_kubeconfig_from_env(ctx, monkeypatch):
+    monkeypatch.setenv("KUBECONFIG", "/path/to/kubeconfig")
+    variables = GcpProvider().resolve_variables(ctx, {})
+    assert variables["kubeconfig_path"] == "/path/to/kubeconfig"
+
+
+def test_gcp_ensure_cluster_credentials_runs_gcloud_no_adc(mocker, monkeypatch):
+    monkeypatch.delenv("GCP_USE_ADC", raising=False)
+    mock_run = mocker.patch("devops_bench.providers.gcp.run")
+    info = GcpProvider().ensure_cluster_credentials(
+        "test-cluster", "us-central1-a", {"project_id": "test-project"}
+    )
+
+    assert info.name == "test-cluster"
+    assert info.location == "us-central1-a"
+    assert info.project == "test-project"
+    assert mock_run.call_count == 1
+    assert mock_run.call_args_list[0].args[0] == [
+        "gcloud",
+        "container",
+        "clusters",
+        "get-credentials",
+        "test-cluster",
+        "--location",
+        "us-central1-a",
+        "--project",
+        "test-project",
+    ]
+
+
+def test_gcp_ensure_cluster_credentials_runs_gcloud_with_adc(mocker, monkeypatch):
+    monkeypatch.setenv("GCP_USE_ADC", "true")
+    mock_run = mocker.patch("devops_bench.providers.gcp.run")
+    info = GcpProvider().ensure_cluster_credentials(
+        "test-cluster", "us-central1-a", {"project_id": "test-project"}
+    )
+
+    assert info.name == "test-cluster"
+    assert info.location == "us-central1-a"
+    assert info.project == "test-project"
+    assert mock_run.call_count == 2
+    assert mock_run.call_args_list[0].args[0] == [
+        "gcloud",
+        "container",
+        "clusters",
+        "get-credentials",
+        "test-cluster",
+        "--location",
+        "us-central1-a",
+        "--project",
+        "test-project",
+    ]
+    assert mock_run.call_args_list[1].args[0] == [
+        "kubectl",
+        "config",
+        "set-credentials",
+        "gke_test-project_us-central1-a_test-cluster",
+        "--exec-arg=--use_application_default_credentials",
+    ]
+
+
+def test_gcp_ensure_cluster_credentials_project_from_env(mocker, monkeypatch):
+    mocker.patch("devops_bench.providers.gcp.run")
+    monkeypatch.setenv("GCP_PROJECT_ID", "env-project")
+    info = GcpProvider().ensure_cluster_credentials("c", "us-central1-a", {})
+    assert info.project == "env-project"
+
+
+def test_gcp_ensure_cluster_credentials_no_project_raises(mocker, monkeypatch):
+    mocker.patch("devops_bench.providers.gcp.run")
+    monkeypatch.delenv("GCP_PROJECT_ID", raising=False)
+    with pytest.raises(ConfigError, match="Project ID not found"):
+        GcpProvider().ensure_cluster_credentials("c", "us-central1-a", {})
+
+
+def test_gcp_ensure_account_credentials_is_noop():
+    # No exception, no external calls.
+    GcpProvider().ensure_account_credentials()
+
+
+# --- KindProvider --------------------------------------------------------------
+
+
+def test_kind_resolve_variables_fills_defaults(ctx):
+    variables = KindProvider().resolve_variables(ctx, {})
+    assert variables["cluster_name"] == "test-cluster"
+    assert variables["location"] == "local"
+    expected_kubeconfig = os.environ.get("KUBECONFIG") or str(
+        Path("~/.kube/config").expanduser().resolve()
+    )
+    assert variables["kubeconfig_path"] == expected_kubeconfig
+
+
+def test_kind_resolve_variables_default_cluster_name():
+    empty_ctx = ResolveContext(stack="prebuilt/kind", project_id="", cluster_name="", location="")
+    variables = KindProvider().resolve_variables(empty_ctx, {})
+    assert variables["cluster_name"] == "devops-bench-kind"
+
+
+def test_kind_ensure_cluster_credentials_no_gcloud(mocker):
+    # KinD must never shell out for credentials.
+    mock_run = mocker.patch("devops_bench.providers.gcp.run")
+    info = KindProvider().ensure_cluster_credentials("kind-cluster", "local", {})
+    assert info.name == "kind-cluster"
+    assert info.location == "local"
+    assert info.project == "local-kind"  # fallback when no project set
+    mock_run.assert_not_called()
+
+
+def test_kind_ensure_account_credentials_is_noop():
+    KindProvider().ensure_account_credentials()

--- a/tests/unit/providers/test_providers.py
+++ b/tests/unit/providers/test_providers.py
@@ -20,6 +20,7 @@ import os
 from pathlib import Path
 
 import pytest
+from pytest_mock import MockerFixture
 
 from devops_bench.core import ConfigError
 from devops_bench.providers import PROVIDERS, ResolveContext
@@ -28,7 +29,7 @@ from devops_bench.providers.kind import KindProvider
 
 
 @pytest.fixture
-def ctx():
+def ctx() -> ResolveContext:
     return ResolveContext(
         stack="custom/stack",
         project_id="test-project",
@@ -37,7 +38,7 @@ def ctx():
     )
 
 
-def test_registry_populated():
+def test_registry_populated() -> None:
     assert PROVIDERS.get("gcp") is GcpProvider
     assert PROVIDERS.get("kind") is KindProvider
     assert "gcp" in PROVIDERS
@@ -47,7 +48,9 @@ def test_registry_populated():
 # --- GcpProvider ---------------------------------------------------------------
 
 
-def test_gcp_resolve_variables_fills_defaults(ctx, monkeypatch):
+def test_gcp_resolve_variables_fills_defaults(
+    ctx: ResolveContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.delenv("KUBECONFIG", raising=False)
     variables = GcpProvider().resolve_variables(ctx, {"node_count": 5, "cluster_name": "override"})
     assert variables == {
@@ -59,19 +62,25 @@ def test_gcp_resolve_variables_fills_defaults(ctx, monkeypatch):
     }
 
 
-def test_gcp_resolve_variables_namespace_from_env(ctx, monkeypatch):
+def test_gcp_resolve_variables_namespace_from_env(
+    ctx: ResolveContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("NAMESPACE", "team-a")
     variables = GcpProvider().resolve_variables(ctx, {})
     assert variables["namespace"] == "team-a"
 
 
-def test_gcp_resolve_variables_kubeconfig_from_env(ctx, monkeypatch):
+def test_gcp_resolve_variables_kubeconfig_from_env(
+    ctx: ResolveContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("KUBECONFIG", "/path/to/kubeconfig")
     variables = GcpProvider().resolve_variables(ctx, {})
     assert variables["kubeconfig_path"] == "/path/to/kubeconfig"
 
 
-def test_gcp_ensure_cluster_credentials_runs_gcloud_no_adc(mocker, monkeypatch):
+def test_gcp_ensure_cluster_credentials_runs_gcloud_no_adc(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.delenv("GCP_USE_ADC", raising=False)
     mock_run = mocker.patch("devops_bench.providers.gcp.run")
     info = GcpProvider().ensure_cluster_credentials(
@@ -95,7 +104,9 @@ def test_gcp_ensure_cluster_credentials_runs_gcloud_no_adc(mocker, monkeypatch):
     ]
 
 
-def test_gcp_ensure_cluster_credentials_runs_gcloud_with_adc(mocker, monkeypatch):
+def test_gcp_ensure_cluster_credentials_runs_gcloud_with_adc(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("GCP_USE_ADC", "true")
     mock_run = mocker.patch("devops_bench.providers.gcp.run")
     info = GcpProvider().ensure_cluster_credentials(
@@ -126,21 +137,25 @@ def test_gcp_ensure_cluster_credentials_runs_gcloud_with_adc(mocker, monkeypatch
     ]
 
 
-def test_gcp_ensure_cluster_credentials_project_from_env(mocker, monkeypatch):
+def test_gcp_ensure_cluster_credentials_project_from_env(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     mocker.patch("devops_bench.providers.gcp.run")
     monkeypatch.setenv("GCP_PROJECT_ID", "env-project")
     info = GcpProvider().ensure_cluster_credentials("c", "us-central1-a", {})
     assert info.project == "env-project"
 
 
-def test_gcp_ensure_cluster_credentials_no_project_raises(mocker, monkeypatch):
+def test_gcp_ensure_cluster_credentials_no_project_raises(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     mocker.patch("devops_bench.providers.gcp.run")
     monkeypatch.delenv("GCP_PROJECT_ID", raising=False)
     with pytest.raises(ConfigError, match="Project ID not found"):
         GcpProvider().ensure_cluster_credentials("c", "us-central1-a", {})
 
 
-def test_gcp_ensure_account_credentials_is_noop():
+def test_gcp_ensure_account_credentials_is_noop() -> None:
     # No exception, no external calls.
     GcpProvider().ensure_account_credentials()
 
@@ -148,7 +163,7 @@ def test_gcp_ensure_account_credentials_is_noop():
 # --- KindProvider --------------------------------------------------------------
 
 
-def test_kind_resolve_variables_fills_defaults(ctx):
+def test_kind_resolve_variables_fills_defaults(ctx: ResolveContext) -> None:
     variables = KindProvider().resolve_variables(ctx, {})
     assert variables["cluster_name"] == "test-cluster"
     assert variables["location"] == "local"
@@ -158,15 +173,16 @@ def test_kind_resolve_variables_fills_defaults(ctx):
     assert variables["kubeconfig_path"] == expected_kubeconfig
 
 
-def test_kind_resolve_variables_default_cluster_name():
+def test_kind_resolve_variables_default_cluster_name() -> None:
     empty_ctx = ResolveContext(stack="prebuilt/kind", project_id="", cluster_name="", location="")
     variables = KindProvider().resolve_variables(empty_ctx, {})
     assert variables["cluster_name"] == "devops-bench-kind"
 
 
-def test_kind_ensure_cluster_credentials_no_gcloud(mocker):
-    # KinD must never shell out for credentials.
-    mock_run = mocker.patch("devops_bench.providers.gcp.run")
+def test_kind_ensure_cluster_credentials_no_gcloud(mocker: MockerFixture) -> None:
+    # KinD must never shell out for credentials. Patch the shared command runner
+    # at its source so any shell-out is caught regardless of import path.
+    mock_run = mocker.patch("devops_bench.core.subprocess.run")
     info = KindProvider().ensure_cluster_credentials("kind-cluster", "local", {})
     assert info.name == "kind-cluster"
     assert info.location == "local"
@@ -174,5 +190,5 @@ def test_kind_ensure_cluster_credentials_no_gcloud(mocker):
     mock_run.assert_not_called()
 
 
-def test_kind_ensure_account_credentials_is_noop():
+def test_kind_ensure_account_credentials_is_noop() -> None:
     KindProvider().ensure_account_credentials()


### PR DESCRIPTION
Adds the `providers/` package — a pluggable abstraction for the cloud
environments a benchmark run targets: cloud identity, cluster access, and
OpenTofu variable resolution.

- **`base.py`** — the `Provider` ABC, the `PROVIDERS` registry (backed by the
  `devops_bench.providers` entry-point group), and `ResolveContext`, which
  carries the defaults a provider uses when resolving OpenTofu stack variables.
- **`gcp.py`** — `GcpProvider` for GKE-hosted clusters: application-default
  credential handling, cluster credential fetch, and stack variable defaults.
- **`kind.py`** — `KindProvider` for local KinD clusters, which require no
  cloud identity.

Unit tests for the registry, resolution precedence, and both providers are
included under `tests/unit/providers/` (13 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a pluggable provider system with a shared provider interface and variable-resolution context.
  * Added built-in providers for GCP and local KinD, including automatic OpenTofu variable defaulting (with support for namespace and kubeconfig).
  * GCP clusters now get access set up via `gcloud`/`kubectl`, with optional ADC-based auth when enabled.
* **Tests**
  * Added unit coverage for provider registration, defaulting vs overrides, environment-driven kubeconfig/namespace behavior, command invocation patterns, and configuration error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->