### PR TITLE
feat(infra): add reusable OpenTofu modules (cluster, bastion)

### DIFF
--- a/tf/modules/bastion/main.tf
+++ b/tf/modules/bastion/main.tf
@@ -1,0 +1,100 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reusable, harness-agnostic GCE bastion for running the eval harness.
+#
+# The bastion is a plain Compute Engine VM (NOT Cloud Workstations). It runs as a
+# dedicated service account and, via its startup script, installs the full
+# harness toolchain plus the openclaw `oc` binary, so the whole harness runs on
+# the VM and invokes `oc` as a local subprocess. SSH is reached over IAP.
+#
+# It deliberately mirrors the plain-Compute patterns in tf/modules/cluster/gke (the agent
+# service account + the IAP-SSH firewall rule).
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0"
+    }
+  }
+}
+
+# Service account the VM runs as. The harness uses this SA as ADC (via the
+# metadata server) for both `gcloud`/`kubectl` and Secret Manager.
+resource "google_service_account" "bastion" {
+  account_id   = var.sa_account_id
+  display_name = "Bastion SA for the DevOps Bench eval harness (${var.name})"
+  project      = var.project_id
+}
+
+# Provisioning rights so the harness can run tofu AS this SA. See var.sa_roles
+# for the rationale and the least-privilege/owner trade-off.
+resource "google_project_iam_member" "bastion" {
+  for_each = toset(var.sa_roles)
+  project  = var.project_id
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.bastion.email}"
+}
+
+# Allow SSH only from Google's IAP TCP-forwarding range, scoped to this VM's tag.
+resource "google_compute_firewall" "allow_iap_ssh" {
+  name    = "allow-iap-ssh-${var.name}"
+  network = var.network
+  project = var.project_id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["35.235.240.0/20"]
+  target_tags   = [var.name]
+}
+
+resource "google_compute_instance" "bastion" {
+  name         = var.name
+  project      = var.project_id
+  zone         = var.zone
+  machine_type = var.machine_type
+  tags         = [var.name]
+
+  # Let tofu stop/restart the VM to apply machine-type or metadata changes.
+  allow_stopping_for_update = true
+
+  boot_disk {
+    initialize_params {
+      image = var.image
+      size  = var.boot_disk_gb
+    }
+  }
+
+  network_interface {
+    network    = var.network
+    subnetwork = var.subnetwork != "" ? var.subnetwork : null
+
+    # Ephemeral external IP for egress; omit entirely when relying on Cloud NAT.
+    dynamic "access_config" {
+      for_each = var.assign_external_ip ? [1] : []
+      content {}
+    }
+  }
+
+  service_account {
+    email  = google_service_account.bastion.email
+    scopes = ["cloud-platform"]
+  }
+
+  metadata_startup_script = file("${path.module}/startup.sh")
+}

--- a/tf/modules/bastion/main.tf
+++ b/tf/modules/bastion/main.tf
@@ -96,5 +96,11 @@ resource "google_compute_instance" "bastion" {
     scopes = ["cloud-platform"]
   }
 
+  # Block project-wide SSH keys so access relies solely on instance-level keys
+  # injected via IAP/OS Login, limiting blast radius if project keys leak.
+  metadata = {
+    block-project-ssh-keys = "true"
+  }
+
   metadata_startup_script = file("${path.module}/startup.sh")
 }

--- a/tf/modules/bastion/outputs.tf
+++ b/tf/modules/bastion/outputs.tf
@@ -1,0 +1,33 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "sa_email" {
+  description = "Email of the service account the bastion runs as."
+  value       = google_service_account.bastion.email
+}
+
+output "name" {
+  description = "Name of the bastion VM."
+  value       = google_compute_instance.bastion.name
+}
+
+output "zone" {
+  description = "Zone of the bastion VM."
+  value       = google_compute_instance.bastion.zone
+}
+
+output "iap_ssh_command" {
+  description = "Command to SSH into the bastion over IAP."
+  value       = "gcloud compute ssh ${google_compute_instance.bastion.name} --zone ${google_compute_instance.bastion.zone} --project ${var.project_id} --tunnel-through-iap"
+}

--- a/tf/modules/bastion/startup.sh
+++ b/tf/modules/bastion/startup.sh
@@ -35,6 +35,9 @@ NODE_MAJOR="22"
 # Pin openclaw so VM rebuilds are reproducible; bump deliberately when adopting a
 # new release rather than tracking @latest.
 OPENCLAW_VERSION="2026.6.10"
+# Pin gke-mcp too. The upstream install.sh always resolves @latest, so we fetch
+# the tagged release tarball directly instead of running it.
+GKE_MCP_VERSION="0.14.0"
 
 # Already provisioned (e.g. on VM restart)? Skip the heavy install.
 if [ -f /var/lib/bench-bastion-ready ]; then
@@ -75,15 +78,24 @@ npm install -g "openclaw@${OPENCLAW_VERSION}"
 # `oc` is this project's alias for the standard openclaw binary.
 ln -sf "$(command -v openclaw)" /usr/local/bin/oc
 
-echo "==> gke-mcp (GKE MCP server for the agent's MCP capability)"
-# Official prebuilt installer drops an arch-matched binary on PATH (no Go build).
-# Download to a file first, then execute: piping ``curl | bash`` can run a
-# truncated script if the connection drops mid-transfer.
-tmp_mcp="$(mktemp)"
-curl -fsSL https://raw.githubusercontent.com/GoogleCloudPlatform/gke-mcp/main/install.sh \
-  -o "$tmp_mcp"
-bash "$tmp_mcp"
-rm -f "$tmp_mcp"
+echo "==> gke-mcp ${GKE_MCP_VERSION} (GKE MCP server for the agent's MCP capability)"
+# Install the pinned release directly rather than the upstream install.sh, whose
+# `main`-branch script always resolves @latest (non-reproducible). Download the
+# tagged arch-matched tarball, verify its checksum, and drop the binary on PATH.
+case "$ARCH" in
+  amd64) mcp_arch="x86_64" ;;
+  arm64) mcp_arch="arm64" ;;
+  *) echo "unsupported arch for gke-mcp: $ARCH" >&2; exit 1 ;;
+esac
+mcp_tarball="gke-mcp_Linux_${mcp_arch}.tar.gz"
+mcp_base="https://github.com/GoogleCloudPlatform/gke-mcp/releases/download/v${GKE_MCP_VERSION}"
+tmp_mcp="$(mktemp -d)"
+curl -fsSL --retry 3 "${mcp_base}/${mcp_tarball}" -o "${tmp_mcp}/${mcp_tarball}"
+curl -fsSL --retry 3 "${mcp_base}/gke-mcp_${GKE_MCP_VERSION}_checksums.txt" -o "${tmp_mcp}/checksums.txt"
+(cd "$tmp_mcp" && grep -F "${mcp_tarball}" checksums.txt | sha256sum -c -)
+tar --no-same-owner -xzf "${tmp_mcp}/${mcp_tarball}" -C "$tmp_mcp"
+install -m 0755 "${tmp_mcp}/gke-mcp" /usr/local/bin/gke-mcp
+rm -rf "$tmp_mcp"
 
 echo "==> uv (Python package/venv manager used by the harness setup)"
 # Install system-wide so every user's vm-setup.sh can run `uv sync`. Download to

--- a/tf/modules/bastion/startup.sh
+++ b/tf/modules/bastion/startup.sh
@@ -49,12 +49,18 @@ apt-get install -y --no-install-recommends \
 
 echo "==> OpenTofu ${TOFU_VERSION}"
 ARCH="$(dpkg --print-architecture)" # amd64 / arm64
-wget -q "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_linux_${ARCH}.zip" -O /tmp/tofu.zip
-unzip -o /tmp/tofu.zip -d /usr/local/bin/
-rm -f /tmp/tofu.zip
+tmp_tofu="$(mktemp)"
+wget -q "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_linux_${ARCH}.zip" -O "$tmp_tofu"
+unzip -o "$tmp_tofu" -d /usr/local/bin/
+rm -f "$tmp_tofu"
 
 echo "==> Node.js ${NODE_MAJOR} (openclaw requires >=22)"
-curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash -
+# Download to a file first, then execute: a dropped `curl | bash` can run a
+# truncated script if the connection drops mid-transfer.
+tmp_node="$(mktemp)"
+curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" -o "$tmp_node"
+bash "$tmp_node"
+rm -f "$tmp_node"
 apt-get install -y --no-install-recommends nodejs
 
 echo "==> Google Cloud SDK + gke-gcloud-auth-plugin + kubectl"
@@ -73,17 +79,19 @@ echo "==> gke-mcp (GKE MCP server for the agent's MCP capability)"
 # Official prebuilt installer drops an arch-matched binary on PATH (no Go build).
 # Download to a file first, then execute: piping ``curl | bash`` can run a
 # truncated script if the connection drops mid-transfer.
+tmp_mcp="$(mktemp)"
 curl -fsSL https://raw.githubusercontent.com/GoogleCloudPlatform/gke-mcp/main/install.sh \
-  -o /tmp/gke-mcp-install.sh
-bash /tmp/gke-mcp-install.sh
-rm -f /tmp/gke-mcp-install.sh
+  -o "$tmp_mcp"
+bash "$tmp_mcp"
+rm -f "$tmp_mcp"
 
 echo "==> uv (Python package/venv manager used by the harness setup)"
 # Install system-wide so every user's vm-setup.sh can run `uv sync`. Download to
 # a file first (a dropped `curl | sh` can execute a truncated installer).
-curl -fsSL https://astral.sh/uv/install.sh -o /tmp/uv-install.sh
-env UV_INSTALL_DIR=/usr/local/bin INSTALLER_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-rm -f /tmp/uv-install.sh
+tmp_uv="$(mktemp)"
+curl -fsSL https://astral.sh/uv/install.sh -o "$tmp_uv"
+env UV_INSTALL_DIR=/usr/local/bin INSTALLER_NO_MODIFY_PATH=1 sh "$tmp_uv"
+rm -f "$tmp_uv"
 
 echo "==> versions"
 tofu version || true

--- a/tf/modules/bastion/startup.sh
+++ b/tf/modules/bastion/startup.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Bastion startup script (runs as root on first boot via metadata_startup_script).
+#
+# Installs the system-wide toolchain the eval harness drives at runtime, plus the
+# openclaw `oc` binary. Mirrors the install steps in Dockerfile.harness (adapted
+# to Ubuntu apt + Node 22, which openclaw requires). Per-user setup (the repo,
+# the venv, and the openclaw API key) is done separately by scripts/bastion/.
+#
+# Logs to /var/log/bench-bastion-startup.log; on success it touches
+# /var/lib/bench-bastion-ready so callers can poll for readiness.
+set -euxo pipefail
+
+exec > >(tee -a /var/log/bench-bastion-startup.log) 2>&1
+echo "==> bench-bastion startup begin: $(date -u +%FT%TZ)"
+
+export DEBIAN_FRONTEND=noninteractive
+
+TOFU_VERSION="1.8.8"
+NODE_MAJOR="22"
+# Pin openclaw so VM rebuilds are reproducible; bump deliberately when adopting a
+# new release rather than tracking @latest.
+OPENCLAW_VERSION="2026.6.10"
+
+# Already provisioned (e.g. on VM restart)? Skip the heavy install.
+if [ -f /var/lib/bench-bastion-ready ]; then
+  echo "==> already provisioned; nothing to do"
+  exit 0
+fi
+
+echo "==> base packages"
+apt-get update -y
+apt-get install -y --no-install-recommends \
+  curl wget gnupg unzip ca-certificates git jq build-essential python3-venv python3-pip
+
+echo "==> OpenTofu ${TOFU_VERSION}"
+ARCH="$(dpkg --print-architecture)" # amd64 / arm64
+wget -q "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_linux_${ARCH}.zip" -O /tmp/tofu.zip
+unzip -o /tmp/tofu.zip -d /usr/local/bin/
+rm -f /tmp/tofu.zip
+
+echo "==> Node.js ${NODE_MAJOR} (openclaw requires >=22)"
+curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash -
+apt-get install -y --no-install-recommends nodejs
+
+echo "==> Google Cloud SDK + gke-gcloud-auth-plugin + kubectl"
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list
+apt-get update -y
+apt-get install -y --no-install-recommends \
+  google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin kubectl
+
+echo "==> openclaw (oc) ${OPENCLAW_VERSION}"
+npm install -g "openclaw@${OPENCLAW_VERSION}"
+# `oc` is this project's alias for the standard openclaw binary.
+ln -sf "$(command -v openclaw)" /usr/local/bin/oc
+
+echo "==> gke-mcp (GKE MCP server for the agent's MCP capability)"
+# Official prebuilt installer drops an arch-matched binary on PATH (no Go build).
+# Download to a file first, then execute: piping ``curl | bash`` can run a
+# truncated script if the connection drops mid-transfer.
+curl -fsSL https://raw.githubusercontent.com/GoogleCloudPlatform/gke-mcp/main/install.sh \
+  -o /tmp/gke-mcp-install.sh
+bash /tmp/gke-mcp-install.sh
+rm -f /tmp/gke-mcp-install.sh
+
+echo "==> uv (Python package/venv manager used by the harness setup)"
+# Install system-wide so every user's vm-setup.sh can run `uv sync`. Download to
+# a file first (a dropped `curl | sh` can execute a truncated installer).
+curl -fsSL https://astral.sh/uv/install.sh -o /tmp/uv-install.sh
+env UV_INSTALL_DIR=/usr/local/bin INSTALLER_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
+rm -f /tmp/uv-install.sh
+
+echo "==> versions"
+tofu version || true
+node --version || true
+gcloud --version | head -1 || true
+kubectl version --client 2>/dev/null | head -1 || true
+oc --version || true
+python3 --version || true
+uv --version || true
+
+touch /var/lib/bench-bastion-ready
+echo "==> bench-bastion startup complete: $(date -u +%FT%TZ)"

--- a/tf/modules/bastion/variables.tf
+++ b/tf/modules/bastion/variables.tf
@@ -1,0 +1,94 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  type        = string
+  description = "GCP Project ID the bastion and its service account live in."
+}
+
+variable "zone" {
+  type        = string
+  description = "GCE zone for the bastion VM."
+  default     = "us-central1-a"
+}
+
+variable "name" {
+  type        = string
+  description = "Name of the bastion VM (also used to name its firewall rule and network tag)."
+  default     = "bench-bastion"
+}
+
+variable "machine_type" {
+  type        = string
+  description = "Machine type for the bastion VM. Needs headroom for tofu + node + the harness."
+  default     = "e2-standard-4"
+}
+
+variable "boot_disk_gb" {
+  type        = number
+  description = "Boot disk size in GB."
+  default     = 50
+}
+
+variable "image" {
+  type        = string
+  description = "Boot image. Ubuntu 24.04 LTS ships Python 3.12, matching pyproject's requires-python."
+  default     = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"
+}
+
+variable "sa_account_id" {
+  type        = string
+  description = <<-EOT
+    Account id for the bastion's service account (the VM runs as this SA, so the
+    harness uses it as ADC). Defaults to "openclaw-vm-sa" because the existing
+    secret-rotation tofu stack references that literal email
+    (openclaw-vm-sa@<project>.iam.gserviceaccount.com); override it per harness.
+  EOT
+  default     = "openclaw-vm-sa"
+}
+
+variable "sa_roles" {
+  type        = list(string)
+  description = <<-EOT
+    Project roles granted to the bastion SA so the harness can PROVISION infra by
+    running tofu as this SA. Defaults to [] (least privilege) — this reusable
+    module grants nothing unless the caller opts in. The prebuilt secret-rotation
+    consumer passes the roles its stack needs: create GKE/secrets/service-accounts
+    (editor) and set project & SA IAM policy bindings (projectIamAdmin +
+    serviceAccountAdmin).
+  EOT
+  default     = []
+}
+
+variable "network" {
+  type        = string
+  description = "VPC network for the bastion."
+  default     = "default"
+}
+
+variable "subnetwork" {
+  type        = string
+  description = "Optional subnetwork. Leave empty to use the network's auto subnet in the VM's region."
+  default     = ""
+}
+
+variable "assign_external_ip" {
+  type        = bool
+  description = <<-EOT
+    Attach an ephemeral external IP for egress (apt, npm, model APIs). SSH ingress
+    is restricted to the IAP range regardless. Set false only if the network has
+    Cloud NAT for egress.
+  EOT
+  default     = true
+}

--- a/tf/modules/cluster/gke/main.tf
+++ b/tf/modules/cluster/gke/main.tf
@@ -70,7 +70,8 @@ resource "google_compute_firewall" "allow_iap_ssh" {
     ports    = ["22"]
   }
 
-  source_ranges = ["35.235.240.0/20"]
+  source_ranges           = ["35.235.240.0/20"]
+  target_service_accounts = [google_service_account.gke_nodes.email]
 }
 
 resource "google_container_cluster" "primary" {
@@ -104,8 +105,8 @@ locals {
     "a2" = "nvidia-tesla-a100"
   }
 
-  is_g2 = length(regexall("^g2-", var.machine_type)) > 0
-  is_a2 = length(regexall("^a2-", var.machine_type)) > 0
+  is_g2 = startswith(var.machine_type, "g2-")
+  is_a2 = startswith(var.machine_type, "a2-")
 
   # Determine final GPU attachment parameters
   enable_gpu = var.gpu_type != "" || local.is_g2 || local.is_a2

--- a/tf/modules/cluster/gke/main.tf
+++ b/tf/modules/cluster/gke/main.tf
@@ -1,0 +1,174 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# account_id is capped at 30 chars, so we can't fit a long cluster name. Truncating
+# the name alone is unsafe: names that share a prefix but differ only in a suffix past
+# the cutoff (e.g. "<base>-east" vs "<base>-west" when <base> is long) would collapse to
+# the same account_id and collide. Append a short hash of the *full* cluster name so the
+# id stays unique per cluster regardless of where the readable part is truncated.
+resource "google_service_account" "gke_nodes" {
+  account_id   = "gke-nodes-${trim(substr(var.cluster_name, 0, 9), "-")}-${substr(md5(var.cluster_name), 0, 6)}"
+  display_name = "GKE Node Service Account for ${var.cluster_name}"
+}
+
+resource "google_project_iam_member" "gke_nodes_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_metric_writer" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_monitoring_viewer" {
+  project = var.project_id
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_metadata_writer" {
+  project = var.project_id
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_artifact_registry_reader" {
+  project = var.project_id
+  role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "agent_container_admin" {
+  count   = var.agent_service_account != "" ? 1 : 0
+  project = var.project_id
+  role    = "roles/container.admin"
+  member  = "serviceAccount:${var.agent_service_account}"
+}
+
+resource "google_compute_firewall" "allow_iap_ssh" {
+  count   = var.enable_iap_ssh ? 1 : 0
+  name    = "allow-iap-ssh-${var.cluster_name}"
+  network = "default"
+  project = var.project_id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["35.235.240.0/20"]
+}
+
+resource "google_container_cluster" "primary" {
+  name     = var.cluster_name
+  location = var.location
+
+  remove_default_node_pool = true
+  initial_node_count       = 1
+  deletion_protection      = false
+  min_master_version       = var.kubernetes_version
+
+  dynamic "workload_identity_config" {
+    for_each = var.enable_workload_identity ? [1] : []
+    content {
+      workload_pool = "${var.project_id}.svc.id.goog"
+    }
+  }
+}
+
+locals {
+  # Map abstract types to GKE native guest accelerator strings
+  abstract_gpu_map = {
+    "l4"   = "nvidia-l4"
+    "a100" = "nvidia-tesla-a100"
+    "t4"   = "nvidia-tesla-t4"
+  }
+
+  # Map machine family prefix to GKE native guest accelerator strings
+  machine_family_gpu_map = {
+    "g2" = "nvidia-l4"
+    "a2" = "nvidia-tesla-a100"
+  }
+
+  is_g2 = length(regexall("^g2-", var.machine_type)) > 0
+  is_a2 = length(regexall("^a2-", var.machine_type)) > 0
+
+  # Determine final GPU attachment parameters
+  enable_gpu = var.gpu_type != "" || local.is_g2 || local.is_a2
+
+  # Extract machine family (e.g. "g2" from "g2-standard-4")
+  machine_family = split("-", var.machine_type)[0]
+
+  # Deduce GPU type from machine family if not explicitly set but GPU is enabled.
+  # This will fail at plan time if machine_family is not in machine_family_gpu_map.
+  deduced_gpu_type = var.gpu_type == "" && local.enable_gpu ? local.machine_family_gpu_map[local.machine_family] : ""
+
+  gpu_type = var.gpu_type != "" ? lookup(local.abstract_gpu_map, var.gpu_type) : local.deduced_gpu_type
+}
+
+resource "google_container_node_pool" "primary_nodes" {
+  name       = "primary-node-pool"
+  location   = var.location
+  cluster    = google_container_cluster.primary.name
+  node_count = var.node_count
+  version    = var.kubernetes_version
+
+  node_config {
+    preemptible     = false
+    machine_type    = var.machine_type
+    service_account = google_service_account.gke_nodes.email
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+    dynamic "guest_accelerator" {
+      for_each = local.enable_gpu ? [1] : []
+      content {
+        type  = local.gpu_type
+        count = var.gpu_count
+        gpu_driver_installation_config {
+          gpu_driver_version = "DEFAULT"
+        }
+      }
+    }
+
+    dynamic "workload_metadata_config" {
+      for_each = var.enable_workload_identity ? [1] : []
+      content {
+        mode = "GKE_METADATA"
+      }
+    }
+  }
+}
+
+output "cluster_name" {
+  value = google_container_cluster.primary.name
+}
+
+output "cluster_location" {
+  value = google_container_cluster.primary.location
+}
+
+output "endpoint" {
+  value = google_container_cluster.primary.endpoint
+}
+
+output "cluster_ca_certificate" {
+  value = google_container_cluster.primary.master_auth[0].cluster_ca_certificate
+}
+

--- a/tf/modules/cluster/gke/main.tf
+++ b/tf/modules/cluster/gke/main.tf
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0"
+    }
+  }
+}
+
 # account_id is capped at 30 chars, so we can't fit a long cluster name. Truncating
 # the name alone is unsafe: names that share a prefix but differ only in a suffix past
 # the cutoff (e.g. "<base>-east" vs "<base>-west" when <base> is long) would collapse to

--- a/tf/modules/cluster/gke/main.tf
+++ b/tf/modules/cluster/gke/main.tf
@@ -26,8 +26,16 @@ terraform {
 # the cutoff (e.g. "<base>-east" vs "<base>-west" when <base> is long) would collapse to
 # the same account_id and collide. Append a short hash of the *full* cluster name so the
 # id stays unique per cluster regardless of where the readable part is truncated.
+locals {
+  # A GCP IAM account_id must be lowercase letters, digits, and hyphens. Lowercase
+  # the cluster name and collapse any other characters (uppercase, underscores,
+  # dots) into hyphens before slicing so the readable part is always valid. The
+  # md5 hash below is over the *original* name, so distinct names still differ.
+  gke_nodes_name_slug = trim(substr(replace(lower(var.cluster_name), "/[^a-z0-9]+/", "-"), 0, 9), "-")
+}
+
 resource "google_service_account" "gke_nodes" {
-  account_id   = "gke-nodes-${trim(substr(var.cluster_name, 0, 9), "-")}-${substr(md5(var.cluster_name), 0, 6)}"
+  account_id   = "gke-nodes-${local.gke_nodes_name_slug}-${substr(md5(var.cluster_name), 0, 6)}"
   display_name = "GKE Node Service Account for ${var.cluster_name}"
 }
 

--- a/tf/modules/cluster/gke/variables.tf
+++ b/tf/modules/cluster/gke/variables.tf
@@ -1,0 +1,83 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  description = "The GCP project ID"
+  type        = string
+}
+
+variable "location" {
+  description = "The GCP zone or region"
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "cluster_name" {
+  description = "The name of the GKE cluster"
+  type        = string
+}
+
+variable "node_count" {
+  description = "Number of nodes in the standard pool"
+  type        = number
+  default     = 3
+}
+
+variable "machine_type" {
+  description = "Machine type for the nodes"
+  type        = string
+  default     = "e2-standard-2"
+}
+
+variable "enable_workload_identity" {
+  description = "Enable GKE Workload Identity"
+  type        = bool
+  default     = false
+}
+
+variable "kubernetes_version" {
+  description = "The Kubernetes version for the GKE cluster"
+  type        = string
+  default     = null
+}
+
+variable "agent_service_account" {
+  description = "The service account email of the agent"
+  type        = string
+  default     = ""
+}
+
+variable "enable_iap_ssh" {
+  description = "Enable IAP SSH firewall rule for the cluster"
+  type        = bool
+  default     = false
+}
+
+variable "gpu_type" {
+  description = "Abstract GPU family: 'l4', 'a100', 't4', or '' for no GPU"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = contains(["", "l4", "a100", "t4"], var.gpu_type)
+    error_message = "gpu_type must be one of: '', 'l4', 'a100', 't4'."
+  }
+}
+
+variable "gpu_count" {
+  description = "Quantity of GPUs to attach per node"
+  type        = number
+  default     = 1
+}
+

--- a/tf/modules/cluster/kind/main.tf
+++ b/tf/modules/cluster/kind/main.tf
@@ -59,11 +59,11 @@ resource "null_resource" "duplicate_context" {
   }
 
   provisioner "local-exec" {
-    command = "kubectl --kubeconfig=${self.triggers.kubeconfig} config set-context ${self.triggers.gke_context} --cluster=${self.triggers.kind_cluster} --user=${self.triggers.kind_user}"
+    command = "kubectl --kubeconfig='${self.triggers.kubeconfig}' config set-context '${self.triggers.gke_context}' --cluster='${self.triggers.kind_cluster}' --user='${self.triggers.kind_user}'"
   }
 
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl --kubeconfig=${self.triggers.kubeconfig} config delete-context ${self.triggers.gke_context} || true"
+    command = "kubectl --kubeconfig='${self.triggers.kubeconfig}' config delete-context '${self.triggers.gke_context}' || true"
   }
 }

--- a/tf/modules/cluster/kind/main.tf
+++ b/tf/modules/cluster/kind/main.tf
@@ -1,0 +1,69 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    kind = {
+      source  = "tehcyx/kind"
+      version = ">= 0.5.0"
+    }
+  }
+}
+
+resource "kind_cluster" "default" {
+  name            = var.cluster_name
+  node_image      = var.node_image
+  kubeconfig_path = pathexpand(var.kubeconfig_path)
+  wait_for_ready  = true
+
+  kind_config {
+    kind        = "Cluster"
+    api_version = "kind.x-k8s.io/v1alpha4"
+
+    node {
+      role = "control-plane"
+    }
+
+    dynamic "node" {
+      for_each = range(max(0, var.node_count - 1))
+      content {
+        role = "worker"
+      }
+    }
+  }
+}
+
+# Duplicates the KinD context to match a GKE-like name pattern.
+# This is required for third-party gke-mcp tools to resolve the context when
+# running tasks against local KinD clusters, as the MCP client expects the
+# context to conform to the "gke_{project}_{location}_{cluster}" format.
+resource "null_resource" "duplicate_context" {
+  depends_on = [kind_cluster.default]
+
+  triggers = {
+    kubeconfig   = pathexpand(var.kubeconfig_path)
+    kind_cluster = "kind-${var.cluster_name}"
+    kind_user    = "kind-${var.cluster_name}"
+    gke_context  = "gke_${var.project_id}_${var.location}_${var.cluster_name}"
+  }
+
+  provisioner "local-exec" {
+    command = "kubectl --kubeconfig=${self.triggers.kubeconfig} config set-context ${self.triggers.gke_context} --cluster=${self.triggers.kind_cluster} --user=${self.triggers.kind_user}"
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "kubectl --kubeconfig=${self.triggers.kubeconfig} config delete-context ${self.triggers.gke_context} || true"
+  }
+}

--- a/tf/modules/cluster/kind/outputs.tf
+++ b/tf/modules/cluster/kind/outputs.tf
@@ -1,0 +1,42 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "cluster_name" {
+  value = kind_cluster.default.name
+}
+
+output "cluster_location" {
+  value = "local"
+}
+
+output "kubeconfig_path" {
+  value = kind_cluster.default.kubeconfig_path
+}
+
+output "endpoint" {
+  value = kind_cluster.default.endpoint
+}
+
+output "client_certificate" {
+  value = kind_cluster.default.client_certificate
+}
+
+output "client_key" {
+  value = kind_cluster.default.client_key
+}
+
+output "cluster_ca_certificate" {
+  value = kind_cluster.default.cluster_ca_certificate
+}
+

--- a/tf/modules/cluster/kind/variables.tf
+++ b/tf/modules/cluster/kind/variables.tf
@@ -1,0 +1,48 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "cluster_name" {
+  type        = string
+  description = "The name of the KinD cluster"
+}
+
+variable "kubeconfig_path" {
+  type        = string
+  description = "Path to write the kubeconfig file"
+  default     = "~/.kube/config"
+}
+
+variable "node_image" {
+  type        = string
+  description = "The kind node image to use"
+  default     = "kindest/node:v1.29.2"
+}
+
+variable "project_id" {
+  type        = string
+  description = "The GCP project ID (or local-kind)"
+  default     = "local-kind"
+}
+
+variable "location" {
+  type        = string
+  description = "The cluster location (or local)"
+  default     = "local"
+}
+
+variable "node_count" {
+  type        = number
+  description = "Number of nodes (1 control-plane + worker nodes)"
+  default     = 3
+}

--- a/tf/modules/cluster/main.tf
+++ b/tf/modules/cluster/main.tf
@@ -1,0 +1,54 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0"
+    }
+    kind = {
+      source  = "tehcyx/kind"
+      version = ">= 0.5.0"
+    }
+  }
+}
+
+module "gke" {
+  source                   = "./gke"
+  count                    = var.infra_provider == "gcp" ? 1 : 0
+  project_id               = var.project_id
+  location                 = var.location != "" ? var.location : "us-central1-a"
+  cluster_name             = var.cluster_name
+  node_count               = var.node_count
+  machine_type             = var.machine_type != "" ? var.machine_type : "e2-standard-2"
+  kubernetes_version       = var.kubernetes_version
+  enable_workload_identity = var.enable_workload_identity
+  agent_service_account    = var.agent_service_account
+  enable_iap_ssh           = var.enable_iap_ssh
+  gpu_type                 = var.gpu_type
+  gpu_count                = var.gpu_count
+}
+
+module "kind" {
+  source          = "./kind"
+  count           = var.infra_provider == "kind" ? 1 : 0
+  cluster_name    = var.cluster_name
+  kubeconfig_path = var.kubeconfig_path
+  node_image      = var.node_image
+  project_id      = var.project_id
+  location        = var.location != "" ? var.location : "local"
+  node_count      = var.node_count
+}
+

--- a/tf/modules/cluster/main.tf
+++ b/tf/modules/cluster/main.tf
@@ -12,18 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-terraform {
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = ">= 5.0.0"
-    }
-    kind = {
-      source  = "tehcyx/kind"
-      version = ">= 0.5.0"
-    }
-  }
-}
+# This dispatch module instantiates only one concrete cluster sub-module and
+# declares no concrete-provider requirements of its own: each sub-module owns
+# its provider (google in ./gke, tehcyx/kind in ./kind), so a KinD-only run does
+# not pull in the GCP provider plugin.
 
 module "gke" {
   source                   = "./gke"

--- a/tf/modules/cluster/outputs.tf
+++ b/tf/modules/cluster/outputs.tf
@@ -1,0 +1,49 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "cluster_name" {
+  value       = var.infra_provider == "gcp" ? try(module.gke[0].cluster_name, "") : try(module.kind[0].cluster_name, "")
+  description = "The finalized name of the created cluster"
+}
+
+output "location" {
+  value       = var.infra_provider == "gcp" ? try(module.gke[0].cluster_location, "") : try(module.kind[0].cluster_location, "")
+  description = "The region/zone or 'local'"
+}
+
+output "endpoint" {
+  value       = var.infra_provider == "gcp" ? try(module.gke[0].endpoint, "") : try(module.kind[0].endpoint, "")
+  description = "Cluster control plane endpoint"
+}
+
+output "cluster_ca_certificate" {
+  value       = var.infra_provider == "gcp" ? try(module.gke[0].cluster_ca_certificate, "") : try(module.kind[0].cluster_ca_certificate, "")
+  description = "Cluster CA certificate"
+}
+
+output "client_certificate" {
+  value       = var.infra_provider == "kind" ? try(module.kind[0].client_certificate, "") : ""
+  description = "Client certificate for KinD"
+}
+
+output "client_key" {
+  value       = var.infra_provider == "kind" ? try(module.kind[0].client_key, "") : ""
+  description = "Client key for KinD"
+}
+
+output "kubeconfig_path" {
+  value       = var.infra_provider == "kind" ? try(module.kind[0].kubeconfig_path, "") : ""
+  description = "Local path to the kubeconfig file"
+}
+

--- a/tf/modules/cluster/variables.tf
+++ b/tf/modules/cluster/variables.tf
@@ -1,0 +1,106 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "infra_provider" {
+  type        = string
+  description = "The target cloud provider (gcp, kind)"
+
+  validation {
+    condition     = contains(["gcp", "kind"], var.infra_provider)
+    error_message = "infra_provider must be one of: 'gcp', 'kind'."
+  }
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Name of the cluster to provision"
+}
+
+variable "location" {
+  type        = string
+  description = "Region/zone (GCP) or 'local' (KinD)"
+  default     = ""
+}
+
+variable "node_count" {
+  type        = number
+  description = "Number of worker nodes"
+  default     = 3
+}
+
+variable "machine_type" {
+  type        = string
+  description = "VM instance type"
+  default     = ""
+}
+
+variable "gpu_type" {
+  type        = string
+  description = "Abstract GPU family: 'l4', 'a100', 't4', or ''"
+  default     = ""
+
+  validation {
+    condition     = contains(["", "l4", "a100", "t4"], var.gpu_type)
+    error_message = "gpu_type must be one of: '', 'l4', 'a100', 't4'."
+  }
+}
+
+variable "gpu_count" {
+  type        = number
+  description = "Quantity of GPUs to attach per node"
+  default     = 1
+}
+
+variable "project_id" {
+  type        = string
+  description = "GCP Project ID (GCP-only)"
+  default     = ""
+}
+
+variable "kubeconfig_path" {
+  type        = string
+  description = "Target path to write kubeconfig (KinD-only)"
+  default     = "~/.kube/config"
+}
+
+variable "kubernetes_version" {
+  type        = string
+  description = "The Kubernetes version for the cluster"
+  default     = null
+}
+
+variable "enable_workload_identity" {
+  type        = bool
+  description = "Enable GKE Workload Identity (GCP-only)"
+  default     = false
+}
+
+variable "agent_service_account" {
+  type        = string
+  description = "The service account email of the agent (GCP-only)"
+  default     = ""
+}
+
+variable "enable_iap_ssh" {
+  type        = bool
+  description = "Enable IAP SSH firewall rule (GCP-only)"
+  default     = false
+}
+
+variable "node_image" {
+  type        = string
+  description = "The kind node image to use (KinD-only)"
+  default     = "kindest/node:v1.29.2"
+}
+


### PR DESCRIPTION
Adds reusable OpenTofu modules under `tf/modules/` that stacks compose to
provision the environments a benchmark run targets.

- **`cluster/`** — a provider-neutral cluster module that dispatches to a
  concrete engine by variable:
  - **`cluster/gke/`** — a GKE cluster on Google Cloud.
  - **`cluster/kind/`** — a local KinD cluster for no-cloud runs.
- **`bastion/`** — a reusable, harness-agnostic GCE bastion VM (with its
  first-boot `startup.sh`) for running the eval harness.

These are leaf modules with no dependency on the Python packages; they are
consumed by the prebuilt stacks. Apache 2.0 license headers are included on all
files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Terraform-based cluster provisioning for either Google Kubernetes Engine or local KinD, selectable via configuration.
  * Added optional Workload Identity, IAP-based SSH access, and GPU accelerator support for the GKE option.
  * Added a reusable GCE bastion VM with IAP SSH access plus optional external IP assignment.
  * Added automatic bastion bootstrapping (evaluation tooling and required CLI/runtime setup).
  * Added outputs for cluster connection details and an IAP `gcloud compute ssh` command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->