### PR TITLE
feat(models): add LLM client base and shared tool-call loop

### DIFF
--- a/devops_bench/models/__init__.py
+++ b/devops_bench/models/__init__.py
@@ -1,0 +1,27 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LLM provider clients and the provider-selection factory.
+
+Adapter modules are named by model family and register themselves in
+``MODELS`` on import. A provider's SDK is imported only when its adapter is
+constructed, so a missing SDK surfaces as :class:`MissingDependencyError` at
+construction time, not on import.
+"""
+
+from __future__ import annotations
+
+from devops_bench.models.base import MODELS, LLMClient, get_model
+
+__all__ = ["LLMClient", "MODELS", "get_model"]

--- a/devops_bench/models/base.py
+++ b/devops_bench/models/base.py
@@ -1,0 +1,131 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LLM client interface and provider selection for MCP-style agent runs."""
+
+from __future__ import annotations
+
+import importlib.util
+from abc import ABC, abstractmethod
+from typing import Any
+
+from devops_bench.core.config import get_env
+from devops_bench.core.model_providers import resolve_provider
+from devops_bench.core.registry import Registry
+
+__all__ = ["LLMClient", "MODELS", "get_model"]
+
+MODELS: Registry[type[LLMClient]] = Registry("models")
+
+
+class LLMClient(ABC):
+    """Abstract base class for LLM clients supporting MCP tools.
+
+    Concrete adapters wrap a provider SDK and translate between the agent
+    runner's neutral message/tool shapes and the provider's API.
+    """
+
+    @abstractmethod
+    async def generate_content(
+        self,
+        contents: list[dict[str, Any]],
+        tools: Any,
+        system_instruction: str | None,
+    ) -> Any:
+        """Generate content from the model.
+
+        Args:
+            contents: Neutral message dicts with ``role`` and ``content`` keys.
+            tools: Provider-formatted tool spec from :meth:`format_tools`.
+            system_instruction: Optional system prompt.
+
+        Returns:
+            The raw, provider-specific response object.
+        """
+
+    @abstractmethod
+    def format_tools(self, mcp_tools: Any) -> Any:
+        """Convert MCP tools to the format expected by the model.
+
+        Args:
+            mcp_tools: Iterable of MCP tool objects exposing ``name``,
+                ``description``, and ``inputSchema`` (duck-typed).
+
+        Returns:
+            The provider-specific tool representation.
+        """
+
+    @abstractmethod
+    def extract_function_calls(self, response: Any) -> list[dict[str, Any]]:
+        """Extract function calls from the model's response.
+
+        Args:
+            response: The raw response from the model.
+
+        Returns:
+            A list of dicts, each containing ``name``, ``args``, and optionally
+            ``id`` (and provider-specific extras such as ``thought_signature``).
+        """
+
+    @abstractmethod
+    def get_text_content(self, response: Any) -> str:
+        """Extract the text content from the model's response.
+
+        Args:
+            response: The raw response from the model.
+
+        Returns:
+            The concatenated text, or an empty string when there is none.
+        """
+
+
+def get_model(
+    provider: str | None = None, model_name: str | None = None, **kwargs: Any
+) -> LLMClient:
+    """Construct the LLM client for a provider.
+
+    When ``provider`` is omitted it is read from the ``AGENT_PROVIDER``
+    environment variable, defaulting to ``"google"``. The provider is resolved
+    through the shared contract (:func:`devops_bench.core.model_providers.resolve_provider`),
+    which maps it to the adapter family and a backend hint forwarded to the
+    adapter — the same contract the CLI harnesses use.
+
+    Args:
+        provider: Provider alias such as ``"gemini"``/``"google"``/
+            ``"google-vertex"``, ``"claude"``/``"anthropic"``/
+            ``"anthropic-vertex"``, ``"openai"``, or ``"ollama"``.
+            Case-insensitive.
+        model_name: Optional model override passed to the adapter; when omitted
+            the adapter reads ``AGENT_MODEL`` (or its own default).
+        **kwargs: Extra keyword arguments forwarded to the adapter constructor.
+
+    Returns:
+        An instantiated :class:`LLMClient` for the selected provider.
+
+    Raises:
+        ConfigError: If ``provider`` is not a known alias.
+        NotRegisteredError: If the resolved adapter family has no registered
+            adapter (e.g. ``openai``).
+        MissingDependencyError: If the selected provider's SDK is not installed.
+    """
+    spec = resolve_provider(provider if provider is not None else get_env("AGENT_PROVIDER"))
+    key = spec.adapter_family
+    # Import only the resolved adapter family's module so it self-registers. An
+    # unregistered family (e.g. ``openai``) has no module; leave it to surface as
+    # NotRegisteredError from ``MODELS.get``.
+    module = f"{__package__}.{key}"
+    if importlib.util.find_spec(module) is not None:
+        importlib.import_module(module)
+    adapter_cls = MODELS.get(key)
+    return adapter_cls(model_name=model_name, backend=spec.backend, **kwargs)

--- a/devops_bench/models/utils/__init__.py
+++ b/devops_bench/models/utils/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Model-layer utilities shared across agents and chaos.
+
+Importing this package pulls no provider SDK; submodules keep their own imports
+light so callers can depend on a single primitive without the full models chain.
+"""

--- a/devops_bench/models/utils/loop.py
+++ b/devops_bench/models/utils/loop.py
@@ -1,0 +1,151 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared model-agnostic tool-use loop for agents and chaos.
+
+:func:`run_tool_loop` drives an :class:`~devops_bench.models.base.LLMClient`
+through repeated ``generate_content`` turns until the model stops requesting
+tools or a safety cap is reached. Messages use a neutral shape:
+
+- user turn:      ``{"role": "user", "content": goal}``
+- assistant turn: ``{"role": "assistant", "content": text[, "tool_calls": [...]]}``
+- tool result:    ``{"role": "tool", "tool_call_id": id, "name": name, "content": text}``
+
+A function call (an entry in ``tool_calls``) is
+``{"name": ..., "args": ..., "id": ...}``.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from devops_bench.core import get_logger
+from devops_bench.models.base import LLMClient
+
+__all__ = ["LoopResult", "ToolDispatcher", "run_tool_loop"]
+
+_log = get_logger("models.utils.loop")
+
+#: Dispatch a tool call to its implementation.
+#:
+#: Called once per function call the model issues with ``(name, args, call_id)``
+#: and must return the tool's textual result. Raising propagates out of
+#: :func:`run_tool_loop` so the caller controls error handling.
+ToolDispatcher = Callable[[str, Any, str | None], Awaitable[str]]
+
+
+@dataclass
+class LoopResult:
+    """Outcome of a :func:`run_tool_loop` invocation.
+
+    Attributes:
+        response: The last raw provider response object (or ``None`` if the
+            loop never ran a turn).
+        contents: The full conversation history in the neutral message shape.
+        final_text: The model's most recent text content, kept even when the
+            final turn also requests tools.
+        latency: Total seconds spent inside ``generate_content`` across turns.
+        tools_used: Names of every tool the model requested.
+    """
+
+    response: Any
+    contents: list[dict]
+    final_text: str
+    latency: float
+    tools_used: set[str] = field(default_factory=set)
+
+
+async def run_tool_loop(
+    client: LLMClient,
+    goal: str,
+    tools: Any,
+    system_instruction: str | None,
+    dispatch: ToolDispatcher,
+    max_turns: int,
+) -> LoopResult:
+    """Drive ``client`` through a tool-use loop until it stops or the cap hits.
+
+    Args:
+        client: Neutral LLM client.
+        goal: The task prompt that seeds the conversation as the first user
+            message.
+        tools: Pre-formatted tool descriptors (see :meth:`LLMClient.format_tools`).
+        system_instruction: Optional system prompt forwarded to every turn.
+        dispatch: Async callable invoked for each tool call. Exceptions raised
+            by ``dispatch`` propagate to the caller; the loop does not swallow
+            them.
+        max_turns: Safety cap on turns. Reaching the cap ends the loop with a
+            warning rather than looping forever.
+
+    Returns:
+        A :class:`LoopResult` with the last response, full ``contents``,
+        retained ``final_text``, accumulated ``latency``, and the set of
+        ``tools_used``.
+    """
+    contents: list[dict] = [{"role": "user", "content": goal}]
+    tools_used: set[str] = set()
+    response: Any = None
+    final_text = ""
+    total_latency = 0.0
+
+    for turn in range(max_turns):
+        _log.debug("--- Turn %d ---", turn + 1)
+
+        start = time.monotonic()
+        response = await client.generate_content(contents, tools, system_instruction)
+        total_latency += time.monotonic() - start
+
+        # Guard against ``get_text_content`` returning ``None``.
+        text = client.get_text_content(response) or ""
+        function_calls = client.extract_function_calls(response)
+
+        final_text = text
+
+        assistant_message: dict[str, Any] = {"role": "assistant", "content": text}
+        if function_calls:
+            assistant_message["tool_calls"] = function_calls
+        contents.append(assistant_message)
+
+        if not function_calls:
+            _log.debug("No further tool calls; loop finished.")
+            break
+
+        for call in function_calls:
+            name = call["name"]
+            args = call["args"]
+            call_id = call.get("id")
+            tools_used.add(name)
+
+            result_text = await dispatch(name, args, call_id)
+            contents.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "name": name,
+                    "content": result_text,
+                }
+            )
+    else:
+        _log.warning("tool loop stopped after reaching the turn limit (%d)", max_turns)
+
+    return LoopResult(
+        response=response,
+        contents=contents,
+        final_text=final_text,
+        latency=total_latency,
+        tools_used=tools_used,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "ruff>=0.8.2",
     "pre-commit>=3.5.0",
     "pytest>=8.0.0",
+    "pytest-asyncio>=1.0.0",
     "pytest-mock>=3.15.1",
 ]
 

--- a/tests/unit/models/test_loop.py
+++ b/tests/unit/models/test_loop.py
@@ -1,0 +1,379 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the shared tool-use loop primitive."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from devops_bench.models.base import LLMClient
+from devops_bench.models.utils.loop import LoopResult, run_tool_loop
+
+
+@dataclass
+class _Turn:
+    """One scripted response in :class:`FakeLLMClient`.
+
+    Attributes:
+        text: Text returned by ``get_text_content`` for this turn.
+        calls: Function calls returned by ``extract_function_calls`` (each in
+            the neutral ``{"name", "args", "id"}`` shape).
+        latency: Seconds the fake awaits inside ``generate_content`` to make
+            latency accumulation observable.
+    """
+
+    text: str
+    calls: list[dict] = field(default_factory=list)
+    latency: float = 0.0
+
+
+class FakeLLMClient(LLMClient):
+    """Scripted :class:`LLMClient` that plays back ``_Turn`` objects in order.
+
+    Records every ``generate_content`` invocation so tests can inspect the
+    ``contents``/``tools``/``system_instruction`` arguments and confirm the
+    loop forwards them unchanged.
+    """
+
+    def __init__(self, turns: list[_Turn]) -> None:
+        self._turns = list(turns)
+        self.calls: list[dict] = []
+
+    async def generate_content(
+        self,
+        contents: list[dict[str, Any]],
+        tools: Any,
+        system_instruction: str | None,
+    ) -> Any:
+        if not self._turns:
+            raise AssertionError("FakeLLMClient ran out of scripted turns")
+        turn = self._turns.pop(0)
+        # Snapshot the inputs so assertions can verify the loop forwards them.
+        self.calls.append(
+            {
+                "contents": [dict(msg) for msg in contents],
+                "tools": tools,
+                "system_instruction": system_instruction,
+            }
+        )
+        if turn.latency:
+            await asyncio.sleep(turn.latency)
+        return turn
+
+    def format_tools(self, mcp_tools: Any) -> Any:
+        # Not exercised by run_tool_loop (caller-formats-tools).
+        return mcp_tools
+
+    def extract_function_calls(self, response: Any) -> list[dict]:
+        return list(response.calls)
+
+    def get_text_content(self, response: Any) -> str:
+        return response.text
+
+
+def _dispatcher_recording(results: dict[str, str]):
+    """Build a dispatcher that returns scripted text and records calls.
+
+    Args:
+        results: Mapping of tool name to the text to return.
+
+    Returns:
+        A ``(dispatch, log)`` tuple. ``log`` is a list mutated on every call.
+    """
+    log: list[tuple[str, Any, str | None]] = []
+
+    async def dispatch(name: str, args: Any, call_id: str | None) -> str:
+        log.append((name, args, call_id))
+        return results.get(name, f"unhandled:{name}")
+
+    return dispatch, log
+
+
+@pytest.mark.asyncio
+async def test_turn_cap_warns_and_stops_at_max_turns(caplog):
+    # Every turn issues a tool call, so only the cap stops the loop.
+    turns = [
+        _Turn(text=f"turn{i}", calls=[{"name": "t", "args": {}, "id": str(i)}]) for i in range(5)
+    ]
+    client = FakeLLMClient(turns)
+    dispatch, _ = _dispatcher_recording({"t": "ok"})
+
+    with caplog.at_level("WARNING", logger="devops_bench.models.utils.loop"):
+        result = await run_tool_loop(
+            client=client,
+            goal="g",
+            tools=None,
+            system_instruction=None,
+            dispatch=dispatch,
+            max_turns=3,
+        )
+
+    assert len(client.calls) == 3, "loop must stop at max_turns"
+    assert any("turn limit (3)" in rec.message for rec in caplog.records)
+    # The 4th and 5th scripted turns were never requested.
+    assert len(client._turns) == 2
+    assert result.final_text == "turn2"
+
+
+@pytest.mark.asyncio
+async def test_final_text_retained_when_last_turn_issues_tool_call():
+    # The last turn within the cap still issues a tool call: its text must survive.
+    turns = [
+        _Turn(text="thinking", calls=[{"name": "t", "args": {}, "id": "a"}]),
+        _Turn(text="goodbye-with-tool", calls=[{"name": "t", "args": {}, "id": "b"}]),
+    ]
+    client = FakeLLMClient(turns)
+    dispatch, _ = _dispatcher_recording({"t": "ok"})
+
+    result = await run_tool_loop(
+        client=client,
+        goal="g",
+        tools=None,
+        system_instruction=None,
+        dispatch=dispatch,
+        max_turns=2,
+    )
+
+    assert result.final_text == "goodbye-with-tool"
+
+
+@pytest.mark.asyncio
+async def test_final_text_retained_on_natural_exit():
+    # Two turns: first calls a tool, second answers with no calls.
+    turns = [
+        _Turn(text="t1", calls=[{"name": "t", "args": {}, "id": "x"}]),
+        _Turn(text="t2-final", calls=[]),
+    ]
+    client = FakeLLMClient(turns)
+    dispatch, _ = _dispatcher_recording({"t": "ok"})
+
+    result = await run_tool_loop(
+        client=client,
+        goal="g",
+        tools=None,
+        system_instruction=None,
+        dispatch=dispatch,
+        max_turns=10,
+    )
+
+    assert result.final_text == "t2-final"
+    assert len(client.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_latency_accumulates_across_turns():
+    turns = [
+        _Turn(text="t1", calls=[{"name": "t", "args": {}, "id": "1"}], latency=0.02),
+        _Turn(text="t2", calls=[], latency=0.03),
+    ]
+    client = FakeLLMClient(turns)
+    dispatch, _ = _dispatcher_recording({"t": "ok"})
+
+    result = await run_tool_loop(
+        client=client,
+        goal="g",
+        tools=None,
+        system_instruction=None,
+        dispatch=dispatch,
+        max_turns=10,
+    )
+
+    # Each scripted turn slept; the total must cover both, not just one.
+    assert result.latency >= 0.05
+    # And it must reflect summed turns, not a single observation.
+    assert result.latency < 0.5
+
+
+@pytest.mark.asyncio
+async def test_dispatch_error_surfaces_to_caller():
+    turns = [_Turn(text="t1", calls=[{"name": "boom", "args": {}, "id": "1"}])]
+    client = FakeLLMClient(turns)
+
+    async def dispatch(name: str, args: Any, call_id: str | None) -> str:
+        raise RuntimeError("dispatch blew up")
+
+    with pytest.raises(RuntimeError, match="dispatch blew up"):
+        await run_tool_loop(
+            client=client,
+            goal="g",
+            tools=None,
+            system_instruction=None,
+            dispatch=dispatch,
+            max_turns=5,
+        )
+
+
+@pytest.mark.asyncio
+async def test_tools_used_reflects_dispatched_names():
+    turns = [
+        _Turn(
+            text="t1",
+            calls=[
+                {"name": "alpha", "args": {}, "id": "1"},
+                {"name": "beta", "args": {}, "id": "2"},
+            ],
+        ),
+        _Turn(text="t2", calls=[{"name": "alpha", "args": {}, "id": "3"}]),
+        _Turn(text="t3", calls=[]),
+    ]
+    client = FakeLLMClient(turns)
+    dispatch, log = _dispatcher_recording({"alpha": "A", "beta": "B"})
+
+    result = await run_tool_loop(
+        client=client,
+        goal="g",
+        tools=None,
+        system_instruction=None,
+        dispatch=dispatch,
+        max_turns=10,
+    )
+
+    assert result.tools_used == {"alpha", "beta"}
+    assert [name for name, _, _ in log] == ["alpha", "beta", "alpha"]
+
+
+@pytest.mark.asyncio
+async def test_caller_formats_tools_passed_through_unchanged():
+    # The loop must not call format_tools and must forward `tools` verbatim.
+    sentinel = object()
+    turns = [_Turn(text="done", calls=[])]
+    client = FakeLLMClient(turns)
+    dispatch, _ = _dispatcher_recording({})
+
+    result = await run_tool_loop(
+        client=client,
+        goal="hello",
+        tools=sentinel,
+        system_instruction="sys",
+        dispatch=dispatch,
+        max_turns=3,
+    )
+
+    assert len(client.calls) == 1
+    assert client.calls[0]["tools"] is sentinel, "tools must be forwarded unchanged"
+    assert client.calls[0]["system_instruction"] == "sys"
+    # First turn sees only the seeded user message.
+    assert client.calls[0]["contents"] == [{"role": "user", "content": "hello"}]
+    assert isinstance(result, LoopResult)
+
+
+@pytest.mark.asyncio
+async def test_contents_record_user_assistant_and_tool_entries():
+    calls_in = [{"name": "t", "args": {"x": 1}, "id": "abc"}]
+    turns = [
+        _Turn(text="thinking", calls=calls_in),
+        _Turn(text="all done", calls=[]),
+    ]
+    client = FakeLLMClient(turns)
+    dispatch, _ = _dispatcher_recording({"t": "tool-result"})
+
+    result = await run_tool_loop(
+        client=client,
+        goal="do thing",
+        tools=None,
+        system_instruction=None,
+        dispatch=dispatch,
+        max_turns=5,
+    )
+
+    assert result.contents == [
+        {"role": "user", "content": "do thing"},
+        {
+            "role": "assistant",
+            "content": "thinking",
+            "tool_calls": [{"name": "t", "args": {"x": 1}, "id": "abc"}],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "abc",
+            "name": "t",
+            "content": "tool-result",
+        },
+        {"role": "assistant", "content": "all done"},
+    ]
+    # The list returned by ``extract_function_calls`` is forwarded into the
+    # assistant message verbatim; the loop must not copy or rewrap the dicts.
+    # ``FakeLLMClient.extract_function_calls`` returns ``list(response.calls)`` —
+    # a fresh list whose elements are the original dicts. The loop must preserve
+    # the per-element identity (it is allowed to wrap them in its own list).
+    forwarded = result.contents[1]["tool_calls"]
+    assert forwarded == calls_in
+    assert forwarded[0] is calls_in[0], (
+        "loop must forward function-call dicts by identity, not by copy"
+    )
+
+
+@pytest.mark.asyncio
+async def test_loop_with_zero_max_turns_yields_empty_result(caplog):
+    client = FakeLLMClient([])
+    dispatch, _ = _dispatcher_recording({})
+
+    with caplog.at_level("WARNING", logger="devops_bench.models.utils.loop"):
+        result = await run_tool_loop(
+            client=client,
+            goal="g",
+            tools=None,
+            system_instruction=None,
+            dispatch=dispatch,
+            max_turns=0,
+        )
+
+    assert result.final_text == ""
+    assert result.latency == 0.0
+    assert result.response is None
+    assert result.contents == [{"role": "user", "content": "g"}]
+    # `for ... else` runs `else` when the range is empty too.
+    assert any("turn limit (0)" in rec.message for rec in caplog.records)
+
+
+def test_loop_import_pulls_no_provider_sdk():
+    """Importing the loop primitive must not drag in provider SDKs.
+
+    Runs in a fresh interpreter subprocess so prior imports in the pytest
+    process (the adapter SDKs are imported by ``test_models_*`` siblings) do
+    not mask a real import-graph leak.
+    """
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import sys
+        import devops_bench.models.utils.loop  # noqa: F401
+
+        forbidden = ("google.genai", "anthropic", "openai", "ollama")
+        leaked = sorted(
+            m for m in sys.modules
+            if any(m == p or m.startswith(p + ".") for p in forbidden)
+        )
+        if leaked:
+            sys.stderr.write("LEAKED:" + ",".join(leaked))
+            sys.exit(1)
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"provider SDK leaked into devops_bench.models.utils.loop: {result.stderr}"
+    )

--- a/tests/unit/models/test_models_base.py
+++ b/tests/unit/models/test_models_base.py
@@ -1,0 +1,104 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the LLM client interface and the provider factory."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from devops_bench.core.errors import ConfigError, NotRegisteredError
+from devops_bench.core.model_providers import ProviderSpec
+from devops_bench.models import base
+from devops_bench.models.base import MODELS, LLMClient, get_model
+
+
+class _StubClient(LLMClient):
+    """Minimal concrete adapter recording its constructor arguments."""
+
+    def __init__(self, model_name: str | None = None, backend: str | None = None, **kwargs: Any):
+        self.model_name = model_name
+        self.backend = backend
+        self.kwargs = kwargs
+
+    async def generate_content(self, contents, tools, system_instruction):
+        raise NotImplementedError
+
+    def format_tools(self, mcp_tools):
+        raise NotImplementedError
+
+    def extract_function_calls(self, response):
+        raise NotImplementedError
+
+    def get_text_content(self, response):
+        raise NotImplementedError
+
+
+@pytest.fixture
+def fake_family(monkeypatch):
+    """Route provider resolution to a fake adapter family backed by ``_StubClient``.
+
+    The family has no adapter module on disk, so ``get_model`` skips the import
+    step and hits the registry directly — no collision with any real adapter,
+    now or later.
+    """
+
+    def install(backend: str | None = None) -> None:
+        spec = ProviderSpec(
+            canonical="fake-provider",
+            adapter_family="fake_family",
+            oc_provider="fake-provider",
+            api_key_envs=(),
+            keyless_ok=True,
+            backend=backend,
+        )
+        monkeypatch.setattr(base, "resolve_provider", lambda provider: spec)
+        monkeypatch.setitem(MODELS._items, "fake_family", _StubClient)
+
+    return install
+
+
+def test_get_model_constructs_registered_adapter(fake_family):
+    fake_family()
+
+    client = get_model(provider="fake-provider", model_name="fake-model-1", timeout=7)
+
+    assert isinstance(client, _StubClient)
+    assert isinstance(client, LLMClient)
+    assert client.model_name == "fake-model-1"
+    assert client.backend is None
+    assert client.kwargs == {"timeout": 7}
+
+
+def test_get_model_forwards_backend_hint(fake_family):
+    fake_family(backend="fake-backend")
+
+    client = get_model(provider="fake-provider")
+
+    assert isinstance(client, _StubClient)
+    assert client.backend == "fake-backend"
+
+
+def test_get_model_unknown_provider_raises():
+    with pytest.raises(ConfigError):
+        get_model(provider="does-not-exist")
+
+
+def test_get_model_openai_resolves_but_has_no_adapter():
+    # ``openai`` is a known provider in the contract but ships no adapter module,
+    # so resolution succeeds and the registry lookup raises NotRegisteredError.
+    with pytest.raises(NotRegisteredError):
+        get_model(provider="openai")

--- a/uv.lock
+++ b/uv.lock
@@ -243,6 +243,7 @@ dependencies = [
 dev = [
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-mock" },
     { name = "ruff" },
 ]
@@ -257,6 +258,7 @@ requires-dist = [
 dev = [
     { name = "pre-commit", specifier = ">=3.5.0" },
     { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "ruff", specifier = ">=0.8.2" },
 ]
@@ -586,6 +588,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds the foundation of the `devops_bench.models` package:

- `models/base.py` — the `LLMClient` interface, the `MODELS` registry, and the `get_model` factory (provider names resolved via `core.model_providers`; a provider's SDK is only imported when its adapter is constructed).
- `models/utils/loop.py` — `run_tool_loop`, the shared tool-call loop that drives an `LLMClient` against a set of tools and returns a `LoopResult`.
- Unit tests for both, plus `pytest-asyncio` in the dev dependency group for the async loop tests.

Concrete provider adapters (gemini, claude, ollama) will follow in separate PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified model client interface with provider selection and adapter registration.
  * Added a reusable tool-use conversation loop supporting multi-turn calls, tool dispatching, latency tracking, and usage reporting.
  * Added public model-layer exports for easier integration.

* **Bug Fixes**
  * Improved handling of unavailable, unknown, or unregistered model providers with clear errors.

* **Tests**
  * Added coverage for provider selection, tool execution, turn limits, latency, errors, and provider-isolation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->