### PR TITLE
Add CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,7 +17,7 @@ reviews:
   path_instructions:
     - path: "devops_bench/**/*.py"
       instructions: |
-        Review against Python 3.10+ idioms. All Python code must include type hints. Ensure docstrings are provided for public classes and functions. Enforce `uv` for dependency/environment management and `ruff` for linting and formatting. Ensure Apache 2.0 license headers are present on all new source files.
+        Review against Python 3.12+ idioms. All Python code must include type hints. Ensure docstrings are provided for public classes and functions. Enforce `uv` for dependency/environment management and `ruff` for linting and formatting. Ensure Apache 2.0 license headers are present on all new source files.
 
     - path: "tests/**/*.py"
       instructions: |
@@ -27,15 +27,19 @@ reviews:
       instructions: |
         Focus on utility logic correctness, argument handling, file/process management, and compliance with project license header checks.
 
-    - path: "tasks/**"
+    - path: "devops_bench/tasks/**"
       instructions: |
         Focus on benchmarking task definition schema validity, clarity of task descriptions, reproducible setup/teardown steps, and evaluation completeness.
 
-    - path: "skills/**"
+    - path: "devops_bench/skills/**"
       instructions: |
         Focus on clear prompt engineering, explicit tool invocation expectations, and structured guidelines for benchmarked agents.
 
-    - path: "deployers/**"
+    - path: ".agents/skills/**"
+      instructions: |
+        Focus on agent skill definition conventions, clear prompt instructions, and tool schemas.
+
+    - path: "devops_bench/deployers/**"
       instructions: |
         Focus on container deployment workflows, infrastructure automation scripts, error recovery, and security parameters.
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "AGENTS.md"
+
+reviews:
+  request_changes_workflow: true
+
+  path_filters:
+    - "!uv.lock"
+    - "!vendor/**"
+
+  path_instructions:
+    - path: "devops_bench/**/*.py"
+      instructions: |
+        Review against Python 3.10+ idioms. All Python code must include type hints. Ensure docstrings are provided for public classes and functions. Enforce `uv` for dependency/environment management and `ruff` for linting and formatting. Ensure Apache 2.0 license headers are present on all new source files.
+
+    - path: "tests/**/*.py"
+      instructions: |
+        Verify unit test coverage, fixture scoping, mock usage, and pytest assertions. Ensure test functions have proper type annotations and clean structure.
+
+    - path: "hack/**/*.py"
+      instructions: |
+        Focus on utility logic correctness, argument handling, file/process management, and compliance with project license header checks.
+
+    - path: "tasks/**"
+      instructions: |
+        Focus on benchmarking task definition schema validity, clarity of task descriptions, reproducible setup/teardown steps, and evaluation completeness.
+
+    - path: "skills/**"
+      instructions: |
+        Focus on clear prompt engineering, explicit tool invocation expectations, and structured guidelines for benchmarked agents.
+
+    - path: "deployers/**"
+      instructions: |
+        Focus on container deployment workflows, infrastructure automation scripts, error recovery, and security parameters.
+
+    - path: "docs/**/*.md"
+      instructions: |
+        Focus on technical accuracy, clarity, and markdown formatting.
+
+  auto_review:
+    base_branches:
+      - ".*"
+    labels:
+      - "!needs-ok-to-test"
+      - "!do-not-merge/work-in-progress"
+      - "!cncf-cla: no"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -43,7 +43,7 @@ reviews:
       instructions: |
         Focus on container deployment workflows, infrastructure automation scripts, error recovery, and security parameters.
 
-    - path: "docs/**/*.md"
+    - path: "**/*.md"
       instructions: |
         Focus on technical accuracy, clarity, and markdown formatting.
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -31,15 +31,17 @@ reviews:
       instructions: |
         Focus on benchmarking task definition schema validity, clarity of task descriptions, reproducible setup/teardown steps, and evaluation completeness.
 
+    # TODO: Update paths to devops_bench/skills/** and .agents/skills/** when top-level skills are refactored
+    - path: "skills/**"
+      instructions: |
+        Focus on clear prompt engineering, explicit tool invocation expectations, and structured guidelines for benchmarked agents.
+
     - path: "devops_bench/skills/**"
       instructions: |
         Focus on clear prompt engineering, explicit tool invocation expectations, and structured guidelines for benchmarked agents.
 
-    - path: ".agents/skills/**"
-      instructions: |
-        Focus on agent skill definition conventions, clear prompt instructions, and tool schemas.
-
-    - path: "devops_bench/deployers/**"
+    # TODO: Update path to devops_bench/deployers/** when deployers folder refactor lands
+    - path: "deployers/**"
       instructions: |
         Focus on container deployment workflows, infrastructure automation scripts, error recovery, and security parameters.
 


### PR DESCRIPTION
### What changed
- Added `.coderabbit.yaml` to configure CodeRabbit automated code reviews for `kubernetes-sigs/devops-bench`.

### Details
- Set code guidelines reference to `AGENTS.md`.
- Added path-specific review instructions tailored to the repository's existing components, with TODO comments for planned folder refactors:
  - `devops_bench/**/*.py`: Enforces Python 3.12+ type hints, docstrings, `uv` / `ruff` usage, and Apache 2.0 license headers.
  - `tests/**/*.py`: Focuses on pytest coverage, test isolation, fixtures, and assertions.
  - `hack/**/*.py`: Focuses on script utility correctness and boilerplate checks.
  - `devops_bench/tasks/**`: Focuses on benchmarking task schema validity and evaluation reproducibility.
  - `skills/**` & `devops_bench/skills/**`: Focuses on clear prompt engineering and tool invocation expectations (with TODO for future `.agents/skills/**` move).
  - `deployers/**`: Focuses on container deployment workflows and infrastructure automation (with TODO for future `devops_bench/deployers/**` move).
  - `**/*.md`: Focuses on documentation clarity and technical accuracy across all markdown files.
- Added path filters to ignore lock files (`uv.lock`) and vendor files.
- Configured auto-review filters for PR labels and base branches.

### Verification
- Validated file placement and syntax matching `kubernetes-sigs/agent-sandbox`.
- Ran boilerplate check (`python3 hack/boilerplate.py --dry-run`).