### PR TITLE
Add verification base and metrics judge scoring

### DIFF
--- a/devops_bench/metrics/_skills.py
+++ b/devops_bench/metrics/_skills.py
@@ -1,0 +1,43 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Load judge skill markdown packaged under ``devops_bench/skills``."""
+
+from __future__ import annotations
+
+from importlib import resources
+
+__all__ = ["SKILLS_PACKAGE", "load_skill_text"]
+
+# Package (not a filesystem path) holding the judge skill markdown as package
+# data, so the files resolve under ``pip install`` / wheels, not just the repo.
+SKILLS_PACKAGE = "devops_bench.skills"
+
+
+def load_skill_text(filename: str) -> str:
+    """Read a judge skill markdown file from the ``devops_bench.skills`` package.
+
+    Args:
+        filename: Skill file name, e.g. ``"outcome-validity-checklist.md"``.
+
+    Returns:
+        The full markdown text used as a GEval criteria.
+
+    Raises:
+        FileNotFoundError: If the skill file is not present in the package.
+    """
+    resource = resources.files(SKILLS_PACKAGE) / filename
+    if not resource.is_file():
+        raise FileNotFoundError(f"Judge skill {filename!r} not found in package {SKILLS_PACKAGE!r}")
+    return resource.read_text(encoding="utf-8")

--- a/devops_bench/metrics/geval.py
+++ b/devops_bench/metrics/geval.py
@@ -1,0 +1,125 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provider-agnostic DeepEval judge backed by the models layer."""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+from deepeval.models import DeepEvalBaseLLM
+
+from devops_bench.core import get_env, get_logger
+from devops_bench.models import LLMClient, get_model
+
+__all__ = ["ModelLayerJudge", "get_judge_model"]
+
+_log = get_logger("metrics.geval")
+
+
+class ModelLayerJudge(DeepEvalBaseLLM):
+    """DeepEval judge that routes generation through the models layer.
+
+    Routes generation through an :class:`~devops_bench.models.LLMClient`
+    (the models layer), so the judge is provider-agnostic. Judge prompts are
+    text-only: generation issues a single user turn with no tools and returns
+    the response's text content.
+
+    Args:
+        client: Pre-built LLM client to wrap. When omitted, one is constructed
+            from ``provider``/``model_name`` (or the ``JUDGE_PROVIDER`` /
+            ``JUDGE_MODEL`` environment variables) via ``get_model``.
+        provider: Provider key forwarded to ``get_model`` when ``client`` is not
+            supplied. Falls back to the ``JUDGE_PROVIDER`` environment variable.
+        model_name: Model override forwarded to ``get_model`` when ``client`` is
+            not supplied. Falls back to the ``JUDGE_MODEL`` environment variable.
+    """
+
+    def __init__(
+        self,
+        client: LLMClient | None = None,
+        *,
+        provider: str | None = None,
+        model_name: str | None = None,
+    ) -> None:
+        if client is None:
+            provider = provider or get_env("JUDGE_PROVIDER")
+            model_name = model_name or get_env("JUDGE_MODEL")
+            client = get_model(provider=provider, model_name=model_name)
+        self.client = client
+        # Mirror the adapter's resolved model name so DeepEval can label results.
+        self._model_name = model_name or getattr(client, "model_name", None) or "judge"
+
+    def load_model(self) -> LLMClient:
+        """Return the wrapped LLM client (DeepEval contract)."""
+        return self.client
+
+    async def a_generate(self, prompt: str) -> str:
+        """Generate judge text for ``prompt`` asynchronously.
+
+        Args:
+            prompt: The fully rendered judge prompt.
+
+        Returns:
+            The model's text response, or an empty string when none was produced.
+        """
+        response = await self.client.generate_content(
+            contents=[{"role": "user", "content": prompt}],
+            tools=None,
+            system_instruction=None,
+        )
+        return self.client.get_text_content(response) or ""
+
+    def generate(self, prompt: str) -> str:
+        """Generate judge text for ``prompt`` synchronously.
+
+        Runs the async :meth:`a_generate` to completion. This is loop-aware: when
+        called from outside an event loop it uses :func:`asyncio.run`; when an
+        event loop is already running on the calling thread (``asyncio.run`` would
+        raise there) it runs the coroutine on a separate worker thread and blocks
+        for the result.
+
+        Args:
+            prompt: The fully rendered judge prompt.
+
+        Returns:
+            The model's text response, or an empty string when none was produced.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.a_generate(prompt))
+
+        # A loop is already running on this thread; offload to a worker thread
+        # that owns its own loop so we never call asyncio.run() re-entrantly.
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            return executor.submit(lambda: asyncio.run(self.a_generate(prompt))).result()
+
+    def get_model_name(self) -> str:
+        """Return the configured judge model name (DeepEval contract)."""
+        return self._model_name
+
+
+def get_judge_model(provider: str | None = None, model_name: str | None = None) -> ModelLayerJudge:
+    """Build the default judge model from configuration.
+
+    Args:
+        provider: Provider key; falls back to ``JUDGE_PROVIDER``.
+        model_name: Model override; falls back to ``JUDGE_MODEL``.
+
+    Returns:
+        A :class:`ModelLayerJudge` wrapping the selected provider's client.
+    """
+    return ModelLayerJudge(provider=provider, model_name=model_name)

--- a/devops_bench/metrics/pipeline.py
+++ b/devops_bench/metrics/pipeline.py
@@ -1,0 +1,199 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Batch scoring loop that turns execution results into per-task scores."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from deepeval.test_case import LLMTestCase
+
+from devops_bench.core import get_bool, get_logger
+
+# Metric families populate the ``METRICS`` registry via their
+# ``@METRICS.register`` decorators when their modules are imported.
+from devops_bench.metrics.base import (
+    METRICS,
+    MetricContext,
+)
+
+__all__ = [
+    "evaluate_metrics_batch",
+]
+
+_log = get_logger("metrics.pipeline")
+
+# Order in which builtin metric keys appear in results.json.
+_BUILTIN_METRIC_KEYS: tuple[str, ...] = (
+    "outcome_validity",
+    "tool_invocation",
+    "checklist",
+    "grounding",
+    "chaos",
+)
+
+
+def _canonical_tool_name(name: str) -> str:
+    """Strip an MCP server prefix from a tool name for judge matching.
+
+    MCP tools surface as ``<server>__<tool>`` (e.g. ``default__generate_manifest``);
+    tasks reference the canonical ``<tool>``. Returns the segment after the first
+    ``"__"``, or the name unchanged when there is no prefix.
+
+    >>> _canonical_tool_name("default__generate_manifest")
+    'generate_manifest'
+    >>> _canonical_tool_name("run_shell_command")
+    'run_shell_command'
+    """
+    if not isinstance(name, str):
+        return name
+    return name.split("__", 1)[1] if "__" in name else name
+
+
+def _build_context(res: dict[str, Any], judge_model: Any, use_mcp: bool) -> MetricContext:
+    """Build the per-result :class:`MetricContext`, sharing test cases.
+
+    Args:
+        res: One execution result dict.
+        judge_model: A ``DeepEvalBaseLLM`` judge.
+        use_mcp: Whether the run was granted MCP capabilities.
+
+    Returns:
+        A populated :class:`MetricContext` with the three test cases built once.
+    """
+    # ``input`` / ``output`` / ``expected_output`` are the minimum a judge needs
+    # and are always written by the harness. The trajectory / latency /
+    # retrieval-context fields default to empty so a slimmer external result dict
+    # degrades to an unscored case rather than raising an uncaught ``KeyError``
+    # here (before the per-metric ``try`` in the batch loop).
+    prompt = res["input"]
+    actual_output = res["output"]
+    expected_output = res.get("expected_output", "")
+    if not expected_output:
+        _log.warning(
+            "Result %r has an empty expected_output. If this task is scored by "
+            "the LLM judge, this may skew evaluation scores.",
+            res.get("name"),
+        )
+    trajectory = res.get("trajectory", [])
+    latency = res.get("latency")
+    retrieval_context = res.get("retrieval_context")
+
+    # Tool names surface with an MCP server prefix (e.g. ``default__generate_manifest``);
+    # expected-tool checks in tasks reference the canonical name (``generate_manifest``).
+    # Normalize only for the judge test cases so tool-call matching isn't brittle;
+    # the on-disk record keeps the raw names.
+    norm_tools = [_canonical_tool_name(t) for t in res.get("tools", [])]
+    norm_trajectory = [
+        {**entry, "name": _canonical_tool_name(entry.get("name", ""))}
+        if isinstance(entry, dict)
+        else entry
+        for entry in trajectory
+    ]
+
+    outcome_case = LLMTestCase(
+        input=prompt,
+        actual_output=actual_output if actual_output else "No response generated",
+        expected_output=expected_output,
+        retrieval_context=retrieval_context,
+        latency=latency,
+    )
+
+    combined_actual = {
+        "tools_used": norm_tools,
+        "execution_trace": norm_trajectory,
+    }
+    tool_case = LLMTestCase(
+        input=prompt,
+        actual_output=json.dumps(combined_actual, indent=2),
+        expected_output=expected_output,
+        latency=latency,
+    )
+
+    all_context = {
+        "tools_used": norm_tools,
+        "execution_trace": norm_trajectory,
+        "text_output": actual_output if actual_output else "No response generated",
+    }
+    all_case = LLMTestCase(
+        input=prompt,
+        actual_output=json.dumps(all_context, indent=2),
+        expected_output=expected_output,
+        latency=latency,
+    )
+
+    return MetricContext(
+        result=res,
+        judge=judge_model,
+        use_mcp=use_mcp,
+        outcome_case=outcome_case,
+        tool_case=tool_case,
+        all_case=all_case,
+        generation_only=bool(res.get("generation_only", False)),
+    )
+
+
+def evaluate_metrics_batch(
+    detailed_results: list[dict[str, Any]],
+    judge_model: Any,
+    *,
+    use_mcp: bool | None = None,
+) -> None:
+    """Score a batch of execution results in place via the metrics registry.
+
+    Adding a metric is a new ``@METRICS.register(...)`` class in any metric
+    module — there is no orchestration surgery required here. Each registered
+    evaluator's :meth:`MetricEvaluator.applies` gates whether it runs for a
+    given result, and one failing metric never aborts the rest.
+
+    Args:
+        detailed_results: Execution result dicts. ``input``, ``output``, and
+            ``expected_output`` are required; ``trajectory``, ``latency``,
+            ``retrieval_context``, ``name``, ``documentation``, ``chaos_spec`` /
+            ``chaos_report`` / ``perf_report``, and ``tools`` are optional and
+            default to empty when absent.
+        judge_model: A ``DeepEvalBaseLLM`` judge model.
+        use_mcp: Whether the harness granted MCP tool capabilities. ``None``
+            falls back to the ``BENCH_USE_MCP`` env var.
+    """
+    _log.info("Starting batch post-processing evaluation metrics...")
+    if use_mcp is None:
+        use_mcp = get_bool("BENCH_USE_MCP", True)
+
+    builtin_keys = list(_BUILTIN_METRIC_KEYS)
+    builtin_set = set(builtin_keys)
+    # Builtin metrics in the pinned (results.json) order, then any third-party
+    # registrations in registry insertion order.
+    ordered_keys = builtin_keys + [k for k in METRICS if k not in builtin_set]
+    evaluators = [METRICS[k]() for k in ordered_keys]
+
+    for res in detailed_results:
+        ctx = _build_context(res, judge_model, use_mcp)
+        scores: dict[str, Any] = {}
+        _log.info("Evaluating metrics for: %s...", res.get("name"))
+        for ev in evaluators:
+            try:
+                if not ev.applies(ctx):
+                    continue
+                for ms in ev.evaluate(ctx):
+                    scores[ms.name] = ms.to_entry()
+            except Exception:  # noqa: BLE001 - one metric must not abort the rest
+                _log.exception(
+                    "metric %r failed for %s",
+                    getattr(ev, "name", ev),
+                    res.get("name"),
+                )
+        res["scores"] = scores

--- a/devops_bench/metrics/pipeline.py
+++ b/devops_bench/metrics/pipeline.py
@@ -176,11 +176,14 @@ def evaluate_metrics_batch(
     if use_mcp is None:
         use_mcp = get_bool("BENCH_USE_MCP", True)
 
-    builtin_keys = list(_BUILTIN_METRIC_KEYS)
-    builtin_set = set(builtin_keys)
+    builtin_set = set(_BUILTIN_METRIC_KEYS)
     # Builtin metrics in the pinned (results.json) order, then any third-party
-    # registrations in registry insertion order.
-    ordered_keys = builtin_keys + [k for k in METRICS if k not in builtin_set]
+    # registrations in registry insertion order. Builtins absent from the
+    # registry are skipped: the pipeline defers importing concrete families, so
+    # a key may not be registered yet and ``METRICS[k]()`` would otherwise raise.
+    ordered_keys = [k for k in _BUILTIN_METRIC_KEYS if k in METRICS] + [
+        k for k in METRICS if k not in builtin_set
+    ]
     evaluators = [METRICS[k]() for k in ordered_keys]
 
     for res in detailed_results:

--- a/devops_bench/metrics/pipeline.py
+++ b/devops_bench/metrics/pipeline.py
@@ -169,7 +169,10 @@ def evaluate_metrics_batch(
         use_mcp: Whether the harness granted MCP tool capabilities. ``None``
             falls back to the ``BENCH_USE_MCP`` env var.
     """
-    _log.info("Starting batch post-processing evaluation metrics...")
+    _log.info(
+        "Starting batch post-processing evaluation metrics for %d result(s)...",
+        len(detailed_results),
+    )
     if use_mcp is None:
         use_mcp = get_bool("BENCH_USE_MCP", True)
 
@@ -183,7 +186,7 @@ def evaluate_metrics_batch(
     for res in detailed_results:
         ctx = _build_context(res, judge_model, use_mcp)
         scores: dict[str, Any] = {}
-        _log.info("Evaluating metrics for: %s...", res.get("name"))
+        _log.debug("Evaluating metrics for: %s...", res.get("name"))
         for ev in evaluators:
             try:
                 if not ev.applies(ctx):

--- a/devops_bench/verification/__init__.py
+++ b/devops_bench/verification/__init__.py
@@ -1,0 +1,48 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Type-safe verification engine for validating cluster state.
+
+This package exposes the verification spec model
+(:class:`VerificationSpec`, :class:`SequenceSpec`, :class:`ParallelSpec`), its
+typed outcome (:class:`VerificationResult`), the registry-driven extension
+surface (:data:`VERIFIERS`, :func:`parse_node`), and the deadline-based
+:class:`VerifierAgent` that evaluates them. Importing the package pulls no
+heavy SDKs — concrete leaf verifiers register via this package's submodules
+only.
+"""
+
+from devops_bench.verification.base import VERIFIERS, BaseVerifier, VerificationResult
+from devops_bench.verification.runner import VerifierAgent
+from devops_bench.verification.spec import (
+    ParallelSpec,
+    SequenceSpec,
+    VerificationNode,
+    VerificationSpec,
+    json_schema,
+    parse_node,
+)
+
+__all__ = [
+    "BaseVerifier",
+    "ParallelSpec",
+    "SequenceSpec",
+    "VERIFIERS",
+    "VerificationNode",
+    "VerificationResult",
+    "VerificationSpec",
+    "VerifierAgent",
+    "json_schema",
+    "parse_node",
+]

--- a/devops_bench/verification/base.py
+++ b/devops_bench/verification/base.py
@@ -1,0 +1,136 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Result model, abstract base, and registry for verification checks.
+
+Each leaf verifier and each compound spec (``sequence`` / ``parallel``)
+registers itself in the :data:`VERIFIERS` registry by its ``type`` literal.
+"""
+
+from __future__ import annotations
+
+import time
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from devops_bench.core import Registry
+from devops_bench.k8s import poll_until
+
+__all__ = ["VERIFIERS", "VerificationResult", "BaseVerifier"]
+
+# Registry keyed by the ``type`` discriminator literal. Entry-point discovery
+# lets external packages register a verifier without touching this tree.
+VERIFIERS: Registry[type[BaseModel]] = Registry(
+    "verifiers", entry_point_group="devops_bench.verifiers"
+)
+
+
+class VerificationResult(BaseModel):
+    """Structured outcome of a verification check.
+
+    Compound nodes (sequence/parallel) populate ``children`` with one entry per
+    member; leaf checks populate ``raw`` with kubectl diagnostics. ``name`` is
+    echoed from the originating spec node's optional label.
+
+    Attributes:
+        success: True when every condition the check covers was met.
+        elapsed_time: Wall-clock seconds spent evaluating the check.
+        reason: Human-readable summary of the outcome or failure.
+        name: Optional label echoed from the spec node, for result rendering.
+        children: Per-member results from compound (sequence/parallel) nodes.
+        raw: Leaf-only kubectl diagnostics or supporting data.
+    """
+
+    success: bool
+    elapsed_time: float
+    reason: str
+    name: str | None = None
+    children: list[VerificationResult] = Field(default_factory=list)
+    raw: dict | None = None
+
+
+VerificationResult.model_rebuild()
+
+
+class BaseVerifier(BaseModel, ABC):
+    """Abstract base for a single leaf verification check.
+
+    Concrete verifiers carry a ``type`` literal, an optional ``name`` for result
+    labeling, and implement :meth:`verify`.
+
+    Attributes:
+        name: Optional label echoed onto the result; metadata, never structural.
+        kubeconfig: Optional path to a kubeconfig file, forwarded to the
+            ``devops_bench.k8s`` wrappers so a check can target a specific
+            cluster. When ``None`` the wrappers use the ambient kubeconfig.
+    """
+
+    name: str | None = None
+    kubeconfig: str | None = None
+
+    @abstractmethod
+    def verify(self, timeout_sec: float) -> VerificationResult:
+        """Run the check and report the outcome.
+
+        Args:
+            timeout_sec: Maximum seconds the check may spend before giving up.
+
+        Returns:
+            The structured verification result.
+        """
+        raise NotImplementedError
+
+    def _poll_to_result(
+        self,
+        check: Callable[[], tuple[bool, str, dict[str, Any] | None]],
+        timeout_sec: float,
+    ) -> VerificationResult:
+        """Poll ``check`` to a :class:`VerificationResult`.
+
+        Shared scaffolding for predicate-style verifiers: times the run, polls
+        ``check`` via :func:`devops_bench.k8s.poll_until`, and folds the last
+        observation into a result. Verifiers backed by a server-side watch
+        (e.g. ``kubectl wait``) build their result directly instead.
+
+        Args:
+            check: Evaluated once per poll, returning ``(success, reason, raw)``
+                where ``reason`` describes the latest observation and ``raw``
+                carries optional diagnostics.
+            timeout_sec: Maximum seconds to keep polling.
+
+        Returns:
+            A result whose ``success`` reflects whether the predicate held
+            before the timeout, carrying the last observed ``reason`` and
+            ``raw``.
+        """
+        start_time = time.monotonic()
+        last: dict[str, Any] = {"reason": "", "raw": None}
+
+        def predicate() -> bool:
+            success, reason, raw = check()
+            last["reason"] = reason
+            last["raw"] = raw
+            return success
+
+        converged = poll_until(predicate, timeout_sec=timeout_sec)
+        return VerificationResult(
+            success=converged,
+            elapsed_time=time.monotonic() - start_time,
+            reason=last["reason"],
+            name=self.name,
+            raw=last["raw"],
+        )

--- a/devops_bench/verification/runner.py
+++ b/devops_bench/verification/runner.py
@@ -84,7 +84,10 @@ class VerifierAgent:
                 mapping the spec validator can parse.
             timeout_sec: Total wall-clock budget shared across the (possibly
                 nested) checks. A single monotonic deadline is computed from
-                this once at the top.
+                this once at the top. Note: a value below
+                :data:`_MIN_LEAF_BUDGET_SECONDS` (1.0s) short-circuits a bare
+                leaf as failed without ever calling ``verify()``, so callers
+                should not mistake such a result for a check failure.
 
         Returns:
             The aggregated verification result.
@@ -119,26 +122,42 @@ class VerifierAgent:
             return _failed(node, "deadline exhausted before evaluation")
         return node.verify(remaining)
 
+    @staticmethod
+    def _skip_rest(
+        checks: list[Any],
+        start_index: int,
+        reason: str,
+        children: list[VerificationResult],
+        reasons: list[str],
+    ) -> None:
+        """Mark every child from ``start_index`` onward as skipped, in one pass."""
+        for j, rest in enumerate(checks[start_index:], start=start_index):
+            children.append(_failed(rest, reason))
+            reasons.append(f"[{j}] skipped")
+
     def _run_sequence(self, node: SequenceSpec, deadline: float) -> VerificationResult:
-        """Run children in order; stop and skip the rest on the first failure."""
+        """Run children in order; stop and skip the rest on the first failure.
+
+        Both a hit deadline and a failed step halt the walk immediately and
+        bulk-mark every remaining child skipped, so later children never incur a
+        per-item loop iteration (nor a redundant deadline check) once the
+        sequence can no longer make progress.
+        """
         start = time.monotonic()
         children: list[VerificationResult] = []
         reasons: list[str] = []
         ok = True
         for i, child in enumerate(node.checks):
             if time.monotonic() >= deadline:
-                children.append(_failed(child, "deadline exhausted"))
-                reasons.append(f"[{i}] skipped")
                 ok = False
-                continue
+                self._skip_rest(node.checks, i, "deadline exhausted", children, reasons)
+                break
             res = self._run(child, deadline)
             children.append(res)
             if not res.success:
                 ok = False
                 reasons.append(f"[{i}] failed: {res.reason}")
-                for j, rest in enumerate(node.checks[i + 1 :], start=i + 1):
-                    children.append(_failed(rest, "earlier step failed"))
-                    reasons.append(f"[{j}] skipped")
+                self._skip_rest(node.checks, i + 1, "earlier step failed", children, reasons)
                 break  # fail-fast
             reasons.append(f"[{i}] succeeded")
         return VerificationResult(

--- a/devops_bench/verification/runner.py
+++ b/devops_bench/verification/runner.py
@@ -50,18 +50,12 @@ def _node_name(node: Any) -> str | None:
     return getattr(node, "name", None)
 
 
-def _timed_out(node: Any, reason: str) -> VerificationResult:
-    """Build a failed result for a node that ran into the deadline."""
-    return VerificationResult(
-        success=False,
-        elapsed_time=0.0,
-        reason=reason,
-        name=_node_name(node),
-    )
+def _failed(node: Any, reason: str) -> VerificationResult:
+    """Build a failed result for a node not run to completion.
 
-
-def _skipped(node: Any, reason: str) -> VerificationResult:
-    """Build a failed result for a node skipped by sequence fail-fast / deadline."""
+    Covers deadline exhaustion and sequence fail-fast skips alike; ``reason``
+    carries the specific cause.
+    """
     return VerificationResult(
         success=False,
         elapsed_time=0.0,
@@ -122,7 +116,7 @@ class VerifierAgent:
         """
         remaining = deadline - time.monotonic()
         if remaining < _MIN_LEAF_BUDGET_SECONDS:
-            return _timed_out(node, "deadline exhausted before evaluation")
+            return _failed(node, "deadline exhausted before evaluation")
         return node.verify(remaining)
 
     def _run_sequence(self, node: SequenceSpec, deadline: float) -> VerificationResult:
@@ -133,7 +127,7 @@ class VerifierAgent:
         ok = True
         for i, child in enumerate(node.checks):
             if time.monotonic() >= deadline:
-                children.append(_skipped(child, "deadline exhausted"))
+                children.append(_failed(child, "deadline exhausted"))
                 reasons.append(f"[{i}] skipped")
                 ok = False
                 continue
@@ -143,7 +137,7 @@ class VerifierAgent:
                 ok = False
                 reasons.append(f"[{i}] failed: {res.reason}")
                 for j, rest in enumerate(node.checks[i + 1 :], start=i + 1):
-                    children.append(_skipped(rest, "earlier step failed"))
+                    children.append(_failed(rest, "earlier step failed"))
                     reasons.append(f"[{j}] skipped")
                 break  # fail-fast
             reasons.append(f"[{i}] succeeded")
@@ -174,7 +168,7 @@ class VerifierAgent:
                 children=[],
             )
         results: list[VerificationResult] = [
-            _timed_out(child, "deadline reached") for child in node.checks
+            _failed(child, "deadline reached") for child in node.checks
         ]
         workers = min(_MAX_PARALLEL_WORKERS, len(node.checks))
         # ``cancel_futures=True`` (3.9+) drops queued-but-not-started futures so

--- a/devops_bench/verification/runner.py
+++ b/devops_bench/verification/runner.py
@@ -1,0 +1,210 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deadline-based dispatcher that evaluates a verification specification.
+
+The whole verification races a single monotonic deadline computed once at the
+top of :meth:`VerifierAgent.wait_for_condition`. Sequence nodes consume the
+deadline serially and fail fast (later children are recorded as skipped);
+parallel nodes hand each child the full remaining deadline and AND the results.
+Leaves consume the deadline directly via ``leaf.verify(remaining)``.
+"""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import wait as futures_wait
+from typing import Any
+
+from devops_bench.verification.base import BaseVerifier, VerificationResult
+from devops_bench.verification.spec import (
+    ParallelSpec,
+    SequenceSpec,
+    VerificationSpec,
+)
+
+__all__ = ["VerifierAgent"]
+
+_MAX_PARALLEL_WORKERS = 8
+
+# A leaf invoked with less than this many seconds left on the deadline is
+# short-circuited as timed out. Avoids issuing useless ``kubectl wait
+# --timeout=0.001s`` calls at the tail of the budget.
+_MIN_LEAF_BUDGET_SECONDS = 1.0
+
+
+def _node_name(node: Any) -> str | None:
+    """Echo the optional ``name`` label from a spec node, if any."""
+    return getattr(node, "name", None)
+
+
+def _timed_out(node: Any, reason: str) -> VerificationResult:
+    """Build a failed result for a node that ran into the deadline."""
+    return VerificationResult(
+        success=False,
+        elapsed_time=0.0,
+        reason=reason,
+        name=_node_name(node),
+    )
+
+
+def _skipped(node: Any, reason: str) -> VerificationResult:
+    """Build a failed result for a node skipped by sequence fail-fast / deadline."""
+    return VerificationResult(
+        success=False,
+        elapsed_time=0.0,
+        reason=reason,
+        name=_node_name(node),
+    )
+
+
+class VerifierAgent:
+    """Evaluate single or compound verification specs against cluster state.
+
+    All evaluations share a single monotonic deadline established by
+    :meth:`wait_for_condition`. Compound nodes propagate the deadline without
+    rebudgeting; leaves consume it directly via their ``verify`` method.
+    """
+
+    def wait_for_condition(
+        self,
+        spec: VerificationSpec | Any,
+        timeout_sec: float = 120,
+    ) -> VerificationResult:
+        """Wait for a spec to hold within ``timeout_sec``.
+
+        Args:
+            spec: A :class:`VerificationSpec`, an already-parsed node, or a raw
+                mapping the spec validator can parse.
+            timeout_sec: Total wall-clock budget shared across the (possibly
+                nested) checks. A single monotonic deadline is computed from
+                this once at the top.
+
+        Returns:
+            The aggregated verification result.
+        """
+        if isinstance(spec, VerificationSpec):
+            node: Any = spec.root
+        elif isinstance(spec, SequenceSpec | ParallelSpec | BaseVerifier):
+            node = spec  # already-parsed node (compound or leaf)
+        else:
+            node = VerificationSpec(spec).root  # raw mapping -> parse
+
+        deadline = time.monotonic() + timeout_sec
+        return self._run(node, deadline)
+
+    def _run(self, node: Any, deadline: float) -> VerificationResult:
+        """Dispatch a node against the shared deadline."""
+        if isinstance(node, SequenceSpec):
+            return self._run_sequence(node, deadline)
+        if isinstance(node, ParallelSpec):
+            return self._run_parallel(node, deadline)
+        return self._run_leaf(node, deadline)
+
+    def _run_leaf(self, node: Any, deadline: float) -> VerificationResult:
+        """Run a leaf verifier with whatever budget remains on the deadline.
+
+        Short-circuits when the remaining budget is below
+        :data:`_MIN_LEAF_BUDGET_SECONDS` so we never issue a useless
+        sub-second ``kubectl wait`` at the tail of the deadline.
+        """
+        remaining = deadline - time.monotonic()
+        if remaining < _MIN_LEAF_BUDGET_SECONDS:
+            return _timed_out(node, "deadline exhausted before evaluation")
+        return node.verify(remaining)
+
+    def _run_sequence(self, node: SequenceSpec, deadline: float) -> VerificationResult:
+        """Run children in order; stop and skip the rest on the first failure."""
+        start = time.monotonic()
+        children: list[VerificationResult] = []
+        reasons: list[str] = []
+        ok = True
+        for i, child in enumerate(node.checks):
+            if time.monotonic() >= deadline:
+                children.append(_skipped(child, "deadline exhausted"))
+                reasons.append(f"[{i}] skipped")
+                ok = False
+                continue
+            res = self._run(child, deadline)
+            children.append(res)
+            if not res.success:
+                ok = False
+                reasons.append(f"[{i}] failed: {res.reason}")
+                for j, rest in enumerate(node.checks[i + 1 :], start=i + 1):
+                    children.append(_skipped(rest, "earlier step failed"))
+                    reasons.append(f"[{j}] skipped")
+                break  # fail-fast
+            reasons.append(f"[{i}] succeeded")
+        return VerificationResult(
+            success=ok,
+            elapsed_time=time.monotonic() - start,
+            reason="; ".join(reasons),
+            name=node.name,
+            children=children,
+        )
+
+    def _run_parallel(self, node: ParallelSpec, deadline: float) -> VerificationResult:
+        """Run children concurrently; each sees the full remaining deadline.
+
+        A parallel child still blocked in ``kubectl wait`` / ``poll_until`` when
+        the deadline hits is bounded by the ``remaining`` value handed to its
+        ``verify`` call, so worker threads do not linger long past the deadline.
+        A leaf that unexpectedly raises is converted to a failed child result so
+        one bad leaf does not abort the rest of the group.
+        """
+        start = time.monotonic()
+        if not node.checks:
+            return VerificationResult(
+                success=True,
+                elapsed_time=time.monotonic() - start,
+                reason="no checks",
+                name=node.name,
+                children=[],
+            )
+        results: list[VerificationResult] = [
+            _timed_out(child, "deadline reached") for child in node.checks
+        ]
+        workers = min(_MAX_PARALLEL_WORKERS, len(node.checks))
+        # ``cancel_futures=True`` (3.9+) drops queued-but-not-started futures so
+        # an exhausted deadline does not block on workers we never want to wait
+        # for. In-flight workers are still bounded by the deadline-aware
+        # ``verify(remaining)`` call, so they cannot linger long.
+        ex = ThreadPoolExecutor(max_workers=workers)
+        try:
+            futs = {ex.submit(self._run, child, deadline): i for i, child in enumerate(node.checks)}
+            done, _ = futures_wait(futs, timeout=max(0.0, deadline - time.monotonic()))
+            for f, i in futs.items():
+                if f not in done:
+                    continue
+                try:
+                    results[i] = f.result()
+                except Exception as exc:  # noqa: BLE001 - convert to a failed child
+                    results[i] = VerificationResult(
+                        success=False,
+                        elapsed_time=0.0,
+                        reason=f"unhandled error: {exc}",
+                        name=_node_name(node.checks[i]),
+                    )
+        finally:
+            ex.shutdown(wait=False, cancel_futures=True)
+        ok = all(r.success for r in results)
+        reasons = [f"[{i}] {'ok' if r.success else 'fail'}" for i, r in enumerate(results)]
+        return VerificationResult(
+            success=ok,
+            elapsed_time=time.monotonic() - start,
+            reason="; ".join(reasons),
+            name=node.name,
+            children=results,
+        )

--- a/devops_bench/verification/spec.py
+++ b/devops_bench/verification/spec.py
@@ -1,0 +1,207 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Registry-driven schema for verification specs."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, RootModel, ValidationError, model_validator
+from pydantic_core import PydanticCustomError
+
+# Leaf verifiers populate the ``VERIFIERS`` registry via their
+# ``@VERIFIERS.register`` decorators when their modules are imported.
+from devops_bench.core import NotRegisteredError
+from devops_bench.verification.base import VERIFIERS
+
+__all__ = [
+    "ParallelSpec",
+    "SequenceSpec",
+    "VerificationNode",
+    "VerificationSpec",
+    "json_schema",
+    "parse_node",
+]
+
+# Union of every registered verifier; aliased to ``Any`` to satisfy type-checkers.
+VerificationNode = Any
+
+
+def json_schema() -> dict[str, Any]:
+    """Return the JSON Schema for a verification spec.
+
+    The schema is an ``anyOf`` over every model registered in :data:`VERIFIERS`,
+    discriminated by each model's ``type`` literal.
+
+    Returns:
+        A JSON-serializable mapping describing the spec union.
+    """
+    members = list(VERIFIERS.values())
+    return {
+        "title": "VerificationSpec",
+        "anyOf": [m.model_json_schema() for m in members],
+        "discriminator": {"propertyName": "type"},
+    }
+
+
+def _parse_compound_children(cls: type, data: Any) -> Any:
+    """Recurse into ``checks`` so each child is parsed through the registry.
+
+    Args:
+        cls: The compound model class (provided by the pydantic validator).
+        data: The raw payload pydantic is about to validate.
+
+    Returns:
+        The payload unchanged when no ``checks`` key is present; otherwise a
+        shallow copy with each child already parsed through :func:`parse_node`.
+    """
+    if isinstance(data, dict) and "checks" in data:
+        data = {**data, "checks": [parse_node(c) for c in data["checks"]]}
+    return data
+
+
+@VERIFIERS.register("sequence")
+class SequenceSpec(BaseModel):
+    """Ordered, fail-fast group: members run in sequence; stop at first failure.
+
+    Attributes:
+        type: Discriminator literal, always ``"sequence"``.
+        name: Optional label echoed onto the result; metadata, never structural.
+        checks: Ordered child nodes; each is itself a parsed verifier node.
+    """
+
+    type: Literal["sequence"]
+    name: str | None = None
+    checks: list[Any]
+
+    _parse_children = model_validator(mode="before")(_parse_compound_children)
+
+
+@VERIFIERS.register("parallel")
+class ParallelSpec(BaseModel):
+    """Independent group: members run concurrently; all must pass.
+
+    Attributes:
+        type: Discriminator literal, always ``"parallel"``.
+        name: Optional label echoed onto the result; metadata, never structural.
+        checks: Sibling child nodes; each is itself a parsed verifier node.
+    """
+
+    type: Literal["parallel"]
+    name: str | None = None
+    checks: list[Any]
+
+    _parse_children = model_validator(mode="before")(_parse_compound_children)
+
+
+def parse_node(data: Any) -> BaseModel:
+    """Parse one verifier-spec node dict through the registry.
+
+    Args:
+        data: A node mapping carrying a ``type`` discriminator, or an already
+            parsed :class:`pydantic.BaseModel` (returned as-is).
+
+    Returns:
+        The concrete verifier or compound spec selected by ``data["type"]``.
+
+    Raises:
+        pydantic.ValidationError: If ``data`` is not a valid spec node.
+
+    Example:
+        A bare leaf dict discriminates to its concrete model:
+
+        >>> node = parse_node({"type": "pod_healthy", "selector": "app=web"})
+        >>> node.type
+        'pod_healthy'
+
+        A bare list is rejected:
+
+        >>> parse_node(["pod_healthy"])
+        Traceback (most recent call last):
+        ...
+        pydantic_core._pydantic_core.ValidationError: ...
+    """
+    if isinstance(data, BaseModel):
+        type_key = getattr(data, "type", None)
+        if (
+            isinstance(type_key, str)
+            and type_key in VERIFIERS
+            and VERIFIERS.get(type_key) is type(data)
+        ):
+            return data
+        raise _validation_error(
+            "verification_spec_unregistered_model",
+            (f"verification spec node {type(data).__name__!r} is not a registered verifier"),
+            input_value=data,
+        )
+    if not isinstance(data, dict):
+        # Surface as a ValidationError even when the entry is the wrong shape.
+        raise _validation_error(
+            "verification_spec_not_mapping",
+            f"verification spec node must be a mapping, got {type(data).__name__}",
+            input_value=data,
+        )
+
+    type_key = data.get("type")
+    if not isinstance(type_key, str):
+        raise _validation_error(
+            "verification_spec_missing_type",
+            "verification spec node is missing required ``type`` discriminator",
+            input_value=data,
+        )
+
+    try:
+        model_cls = VERIFIERS.get(type_key)
+    except NotRegisteredError as exc:
+        raise _validation_error(
+            "verification_spec_unknown_type",
+            (f"unknown verifier type {type_key!r}; registered: {sorted(VERIFIERS.keys())}"),
+            input_value=data,
+        ) from exc
+
+    return model_cls.model_validate(data)
+
+
+def _validation_error(code: str, message: str, *, input_value: Any) -> ValidationError:
+    """Build a ``ValidationError`` around a single ``PydanticCustomError``."""
+    custom = PydanticCustomError(code, message)
+    return ValidationError.from_exception_data(
+        title=code,
+        line_errors=[
+            {
+                "type": custom,
+                "loc": (),
+                "input": input_value,
+            }
+        ],
+    )
+
+
+class VerificationSpec(RootModel[Any]):
+    """Entry-point wrapper; ``VerificationSpec(data).root`` yields a concrete node.
+
+    Example:
+        >>> spec = VerificationSpec({"type": "pod_healthy", "selector": "app=web"})
+        >>> spec.root.type
+        'pod_healthy'
+    """
+
+    root: Any
+
+    @model_validator(mode="before")
+    @classmethod
+    def _parse(cls, data: Any) -> Any:
+        """Route the raw root payload through the registry parser."""
+        return parse_node(data)

--- a/tests/unit/metrics/test_metrics_geval.py
+++ b/tests/unit/metrics/test_metrics_geval.py
@@ -1,0 +1,124 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the model-agnostic DeepEval judge."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+from devops_bench.metrics import geval
+from devops_bench.metrics.geval import ModelLayerJudge
+
+
+def _fake_client(text="judged", model_name="judge-model"):
+    client = MagicMock()
+    client.model_name = model_name
+    client.generate_content = AsyncMock(return_value="raw-response")
+    client.get_text_content = MagicMock(return_value=text)
+    return client
+
+
+def test_wraps_supplied_client_without_get_model(mocker):
+    get_model = mocker.patch.object(geval, "get_model")
+    client = _fake_client()
+
+    judge = ModelLayerJudge(client=client, model_name="explicit")
+
+    get_model.assert_not_called()
+    assert judge.load_model() is client
+    assert judge.get_model_name() == "explicit"
+
+
+def test_builds_client_from_config(mocker):
+    get_model = mocker.patch.object(geval, "get_model")
+    client = _fake_client(model_name="from-adapter")
+    get_model.return_value = client
+    mocker.patch.dict(
+        os.environ,
+        {"JUDGE_PROVIDER": "anthropic", "JUDGE_MODEL": "claude-test"},
+        clear=True,
+    )
+
+    judge = ModelLayerJudge()
+
+    get_model.assert_called_once_with(provider="anthropic", model_name="claude-test")
+    assert judge.get_model_name() == "claude-test"
+
+
+def test_model_name_falls_back_to_client(mocker):
+    mocker.patch.object(geval, "get_model")
+    client = _fake_client(model_name="adapter-default")
+
+    judge = ModelLayerJudge(client=client)
+
+    assert judge.get_model_name() == "adapter-default"
+
+
+def test_a_generate_uses_text_only_call():
+    client = _fake_client(text="the verdict")
+    judge = ModelLayerJudge(client=client)
+
+    import asyncio
+
+    out = asyncio.run(judge.a_generate("score this"))
+
+    assert out == "the verdict"
+    client.generate_content.assert_awaited_once_with(
+        contents=[{"role": "user", "content": "score this"}],
+        tools=None,
+        system_instruction=None,
+    )
+
+
+def test_a_generate_returns_empty_string_for_none():
+    client = _fake_client()
+    client.get_text_content.return_value = None
+    judge = ModelLayerJudge(client=client)
+
+    import asyncio
+
+    assert asyncio.run(judge.a_generate("x")) == ""
+
+
+def test_generate_runs_async():
+    client = _fake_client(text="sync result")
+    judge = ModelLayerJudge(client=client)
+
+    assert judge.generate("prompt") == "sync result"
+
+
+def test_generate_is_loop_aware():
+    # When a loop is already running, generate() must not call asyncio.run()
+    # re-entrantly; it offloads to a worker thread and still returns the text.
+    import asyncio
+
+    client = _fake_client(text="loop-safe result")
+    judge = ModelLayerJudge(client=client)
+
+    async def _call_from_running_loop():
+        return judge.generate("prompt")
+
+    assert asyncio.run(_call_from_running_loop()) == "loop-safe result"
+
+
+def test_get_judge_model_passes_through(mocker):
+    get_model = mocker.patch.object(geval, "get_model")
+    get_model.return_value = _fake_client(model_name="gm")
+
+    judge = geval.get_judge_model(provider="ollama", model_name="gemma")
+
+    get_model.assert_called_once_with(provider="ollama", model_name="gemma")
+    assert judge.get_model_name() == "gemma"

--- a/tests/unit/metrics/test_metrics_pipeline.py
+++ b/tests/unit/metrics/test_metrics_pipeline.py
@@ -22,10 +22,12 @@ and restored so the stubs never leak into sibling tests.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from typing import Any
 
 import pytest
 
+from devops_bench.core import Registry
 from devops_bench.metrics.base import METRICS, MetricContext, MetricScore
 from devops_bench.metrics.pipeline import evaluate_metrics_batch
 
@@ -82,7 +84,7 @@ def _make_stub(key: str) -> type:
 
 
 @pytest.fixture
-def registry():
+def registry() -> Iterator[Registry[Any]]:
     """Yield the ``METRICS`` registry emptied for the test, then restored."""
     saved = dict(METRICS._items)
     METRICS._items.clear()
@@ -93,12 +95,13 @@ def registry():
         METRICS._items.update(saved)
 
 
-def _result(name: str = "t1") -> dict:
+def _result(name: str = "t1") -> dict[str, Any]:
     """Minimal execution-result dict the pipeline can build a context from."""
     return {"name": name, "input": "q", "output": "a", "expected_output": "a"}
 
 
-def test_scores_written_from_registered_evaluator(registry):
+def test_scores_written_from_registered_evaluator(registry: Registry[Any]) -> None:
+    """A registered evaluator's scores land in the result's ``scores`` map."""
     registry.register("stub")(_StubEvaluator)
     results = [_result()]
 
@@ -107,7 +110,10 @@ def test_scores_written_from_registered_evaluator(registry):
     assert results[0]["scores"] == {"stub_score": {"score": 1.0, "success": True, "reason": "ok"}}
 
 
-def test_one_failing_metric_does_not_abort_others(registry, caplog):
+def test_one_failing_metric_does_not_abort_others(
+    registry: Registry[Any], caplog: pytest.LogCaptureFixture
+) -> None:
+    """A raising metric is isolated and logged; siblings still record scores."""
     registry.register("boom")(_BoomEvaluator)
     registry.register("stub")(_StubEvaluator)
     results = [_result()]
@@ -119,7 +125,8 @@ def test_one_failing_metric_does_not_abort_others(registry, caplog):
     assert "boom" in caplog.text
 
 
-def test_evaluate_skipped_when_applies_false(registry):
+def test_evaluate_skipped_when_applies_false(registry: Registry[Any]) -> None:
+    """An evaluator whose ``applies`` returns False is never evaluated."""
     registry.register("skipped")(_SkippedEvaluator)
     results = [_result()]
 
@@ -128,7 +135,8 @@ def test_evaluate_skipped_when_applies_false(registry):
     assert results[0]["scores"] == {}
 
 
-def test_absent_builtin_keys_are_skipped(registry):
+def test_absent_builtin_keys_are_skipped(registry: Registry[Any]) -> None:
+    """Unregistered builtin keys are skipped rather than instantiated."""
     # None of the pinned builtin keys are registered here; the batch must not
     # raise while building evaluators (the builtin-key filter guards this).
     registry.register("stub")(_StubEvaluator)
@@ -139,7 +147,8 @@ def test_absent_builtin_keys_are_skipped(registry):
     assert results[0]["scores"]["stub_score"]["score"] == 1.0
 
 
-def test_builtin_keys_scored_before_third_party(registry):
+def test_builtin_keys_scored_before_third_party(registry: Registry[Any]) -> None:
+    """Registered builtin keys are ordered ahead of third-party registrations."""
     # A registered builtin ("checklist") is ordered ahead of a third-party
     # metric even though the latter sorts earlier alphabetically.
     registry.register("checklist")(_make_stub("checklist"))
@@ -151,7 +160,8 @@ def test_builtin_keys_scored_before_third_party(registry):
     assert list(results[0]["scores"].keys()) == ["checklist_score", "aaa_custom_score"]
 
 
-def test_each_result_in_batch_is_scored(registry):
+def test_each_result_in_batch_is_scored(registry: Registry[Any]) -> None:
+    """Every result in a multi-item batch is scored in place."""
     registry.register("stub")(_StubEvaluator)
     results = [_result("t1"), _result("t2"), _result("t3")]
 

--- a/tests/unit/metrics/test_metrics_pipeline.py
+++ b/tests/unit/metrics/test_metrics_pipeline.py
@@ -1,0 +1,160 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Self-contained tests for the batch metric scoring pipeline.
+
+Stub evaluators are registered into ``METRICS`` so the dispatch loop, evaluator
+ordering, and per-metric exception isolation are exercised without importing any
+concrete metric family that lands in a follow-up. The registry is snapshotted
+and restored so the stubs never leak into sibling tests.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pytest
+
+from devops_bench.metrics.base import METRICS, MetricContext, MetricScore
+from devops_bench.metrics.pipeline import evaluate_metrics_batch
+
+
+class _StubEvaluator:
+    """Always-applicable evaluator yielding one judged score."""
+
+    name = "stub"
+
+    def applies(self, ctx: MetricContext) -> bool:
+        return True
+
+    def evaluate(self, ctx: MetricContext) -> Iterable[MetricScore]:
+        yield MetricScore(name="stub_score", score=1.0, success=True, reason="ok")
+
+
+class _BoomEvaluator:
+    """Applicable evaluator whose :meth:`evaluate` raises."""
+
+    name = "boom"
+
+    def applies(self, ctx: MetricContext) -> bool:
+        return True
+
+    def evaluate(self, ctx: MetricContext) -> Iterable[MetricScore]:
+        raise RuntimeError("metric exploded")
+
+
+class _SkippedEvaluator:
+    """Non-applicable evaluator; :meth:`evaluate` must never be called."""
+
+    name = "skipped"
+
+    def applies(self, ctx: MetricContext) -> bool:
+        return False
+
+    def evaluate(self, ctx: MetricContext) -> Iterable[MetricScore]:
+        raise AssertionError("evaluate() must not run when applies() is False")
+
+
+def _make_stub(key: str) -> type:
+    """Build a stub evaluator class that yields a bare score named after ``key``."""
+
+    class _Stub:
+        name = key
+
+        def applies(self, ctx: MetricContext) -> bool:
+            return True
+
+        def evaluate(self, ctx: MetricContext) -> Iterable[MetricScore]:
+            yield MetricScore(name=f"{key}_score", score=1.0)
+
+    return _Stub
+
+
+@pytest.fixture
+def registry():
+    """Yield the ``METRICS`` registry emptied for the test, then restored."""
+    saved = dict(METRICS._items)
+    METRICS._items.clear()
+    try:
+        yield METRICS
+    finally:
+        METRICS._items.clear()
+        METRICS._items.update(saved)
+
+
+def _result(name: str = "t1") -> dict:
+    """Minimal execution-result dict the pipeline can build a context from."""
+    return {"name": name, "input": "q", "output": "a", "expected_output": "a"}
+
+
+def test_scores_written_from_registered_evaluator(registry):
+    registry.register("stub")(_StubEvaluator)
+    results = [_result()]
+
+    evaluate_metrics_batch(results, None, use_mcp=False)
+
+    assert results[0]["scores"] == {"stub_score": {"score": 1.0, "success": True, "reason": "ok"}}
+
+
+def test_one_failing_metric_does_not_abort_others(registry, caplog):
+    registry.register("boom")(_BoomEvaluator)
+    registry.register("stub")(_StubEvaluator)
+    results = [_result()]
+
+    evaluate_metrics_batch(results, None, use_mcp=False)
+
+    # The raising metric is isolated: the sibling metric still records a score.
+    assert "stub_score" in results[0]["scores"]
+    assert "boom" in caplog.text
+
+
+def test_evaluate_skipped_when_applies_false(registry):
+    registry.register("skipped")(_SkippedEvaluator)
+    results = [_result()]
+
+    evaluate_metrics_batch(results, None, use_mcp=False)
+
+    assert results[0]["scores"] == {}
+
+
+def test_absent_builtin_keys_are_skipped(registry):
+    # None of the pinned builtin keys are registered here; the batch must not
+    # raise while building evaluators (the builtin-key filter guards this).
+    registry.register("stub")(_StubEvaluator)
+    results = [_result()]
+
+    evaluate_metrics_batch(results, None, use_mcp=False)
+
+    assert results[0]["scores"]["stub_score"]["score"] == 1.0
+
+
+def test_builtin_keys_scored_before_third_party(registry):
+    # A registered builtin ("checklist") is ordered ahead of a third-party
+    # metric even though the latter sorts earlier alphabetically.
+    registry.register("checklist")(_make_stub("checklist"))
+    registry.register("aaa_custom")(_make_stub("aaa_custom"))
+    results = [_result()]
+
+    evaluate_metrics_batch(results, None, use_mcp=False)
+
+    assert list(results[0]["scores"].keys()) == ["checklist_score", "aaa_custom_score"]
+
+
+def test_each_result_in_batch_is_scored(registry):
+    registry.register("stub")(_StubEvaluator)
+    results = [_result("t1"), _result("t2"), _result("t3")]
+
+    evaluate_metrics_batch(results, None, use_mcp=False)
+
+    assert all(r["scores"].get("stub_score") for r in results)

--- a/tests/unit/verification/test_base.py
+++ b/tests/unit/verification/test_base.py
@@ -1,0 +1,66 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the typed ``VerificationResult`` shape."""
+
+from __future__ import annotations
+
+from devops_bench.verification import VerificationResult
+
+
+def test_default_fields_match_contract():
+    result = VerificationResult(success=True, elapsed_time=0.5, reason="ok")
+
+    assert result.success is True
+    assert result.elapsed_time == 0.5
+    assert result.reason == "ok"
+    assert result.name is None
+    assert result.children == []
+    assert result.raw is None
+
+
+def test_compound_result_carries_children_not_raw():
+    child = VerificationResult(success=True, elapsed_time=0.1, reason="leaf ok")
+    compound = VerificationResult(
+        success=True,
+        elapsed_time=0.2,
+        reason="all ok",
+        name="group",
+        children=[child],
+    )
+
+    assert compound.name == "group"
+    assert compound.children == [child]
+    assert compound.raw is None
+
+
+def test_leaf_result_carries_raw_not_children():
+    leaf = VerificationResult(
+        success=False,
+        elapsed_time=1.0,
+        reason="kubectl failed",
+        name="pods",
+        raw={"items": []},
+    )
+
+    assert leaf.raw == {"items": []}
+    assert leaf.children == []
+
+
+def test_no_details_field():
+    # The legacy loose ``details`` field is replaced by ``children`` + ``raw``.
+    fields = set(VerificationResult.model_fields.keys())
+
+    assert "details" not in fields
+    assert {"success", "elapsed_time", "reason", "name", "children", "raw"} <= fields

--- a/tests/unit/verification/test_package_import.py
+++ b/tests/unit/verification/test_package_import.py
@@ -1,0 +1,39 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Lightweight-import guard: ``devops_bench.verification`` pulls no heavy SDKs.
+
+The harness/agents tier may import the verification package eagerly; it must
+not transitively load provider SDKs, ``deepeval``, or ``mcp``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_import_pulls_no_heavy_sdks():
+    # Run in a fresh interpreter so other tests cannot pollute sys.modules.
+    code = (
+        "import sys\n"
+        "import devops_bench.verification  # noqa: F401\n"
+        "loaded = set(sys.modules)\n"
+        "for forbidden in ('deepeval', 'mcp', 'anthropic', 'google.genai', 'openai'):\n"
+        "    assert forbidden not in loaded, forbidden\n"
+        "print('ok')\n"
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, proc.stderr
+    assert "ok" in proc.stdout

--- a/tests/unit/verification/test_runner.py
+++ b/tests/unit/verification/test_runner.py
@@ -22,7 +22,8 @@ on any concrete verifier module that lands in a follow-up.
 from __future__ import annotations
 
 import time
-from typing import Literal
+from collections.abc import Iterator
+from typing import Any, Literal
 
 import pytest
 
@@ -66,7 +67,7 @@ class _FakeLeaf(BaseVerifier):
 
 
 @pytest.fixture(autouse=True)
-def _register_fake_leaf():
+def _register_fake_leaf() -> Iterator[None]:
     """Register the fake leaf for one test, then drop it from the registry."""
     VERIFIERS.register("fake_leaf")(_FakeLeaf)
     try:
@@ -81,7 +82,7 @@ def agent() -> VerifierAgent:
     return VerifierAgent()
 
 
-def _leaf(**kwargs) -> dict:
+def _leaf(**kwargs: Any) -> dict[str, Any]:
     """Build a raw fake-leaf spec node."""
     return {"type": "fake_leaf", **kwargs}
 
@@ -89,21 +90,24 @@ def _leaf(**kwargs) -> dict:
 # --- leaf dispatch --------------------------------------------------------
 
 
-def test_leaf_success_passes_through(agent):
+def test_leaf_success_passes_through(agent: VerifierAgent) -> None:
+    """A passing leaf result is returned unchanged."""
     res = agent.wait_for_condition(_leaf(succeed=True, tag="a"))
 
     assert res.success is True
     assert res.reason == "leaf:a"
 
 
-def test_leaf_failure_passes_through(agent):
+def test_leaf_failure_passes_through(agent: VerifierAgent) -> None:
+    """A failing leaf result is returned unchanged."""
     res = agent.wait_for_condition(_leaf(succeed=False, tag="b"))
 
     assert res.success is False
     assert res.reason == "leaf:b"
 
 
-def test_leaf_receives_remaining_deadline_budget(agent):
+def test_leaf_receives_remaining_deadline_budget(agent: VerifierAgent) -> None:
+    """A leaf is handed the budget remaining on the shared deadline."""
     # The leaf is handed the budget left on the shared deadline, not the raw
     # ``timeout_sec`` verbatim, but for a bare leaf they are within epsilon.
     res = agent.wait_for_condition(_leaf(), timeout_sec=30)
@@ -112,7 +116,8 @@ def test_leaf_receives_remaining_deadline_budget(agent):
     assert 0 < res.raw["timeout_sec"] <= 30
 
 
-def test_leaf_short_circuits_below_min_budget(agent):
+def test_leaf_short_circuits_below_min_budget(agent: VerifierAgent) -> None:
+    """A sub-floor budget fails the leaf without ever calling ``verify()``."""
     # A sub-``_MIN_LEAF_BUDGET_SECONDS`` budget fails the leaf without ever
     # running verify() (raw stays None because verify() was skipped).
     res = agent.wait_for_condition(_leaf(succeed=True), timeout_sec=0.0)
@@ -125,7 +130,8 @@ def test_leaf_short_circuits_below_min_budget(agent):
 # --- sequence dispatch ----------------------------------------------------
 
 
-def test_sequence_all_pass(agent):
+def test_sequence_all_pass(agent: VerifierAgent) -> None:
+    """A sequence whose children all pass succeeds and echoes its name."""
     spec = {
         "type": "sequence",
         "name": "seq",
@@ -139,7 +145,8 @@ def test_sequence_all_pass(agent):
     assert [c.success for c in res.children] == [True, True]
 
 
-def test_sequence_fail_fast_skips_remaining(agent):
+def test_sequence_fail_fast_skips_remaining(agent: VerifierAgent) -> None:
+    """The first failure halts the sequence and marks the rest skipped."""
     spec = {
         "type": "sequence",
         "checks": [
@@ -162,7 +169,8 @@ def test_sequence_fail_fast_skips_remaining(agent):
     assert "[2] skipped" in res.reason
 
 
-def test_sequence_bulk_skips_all_when_deadline_already_passed(agent):
+def test_sequence_bulk_skips_all_when_deadline_already_passed(agent: VerifierAgent) -> None:
+    """An already-passed deadline bulk-skips every child without running them."""
     # A non-positive budget puts the deadline in the past, so the first loop
     # iteration bulk-marks every child skipped without running any of them.
     spec = {
@@ -183,7 +191,8 @@ def test_sequence_bulk_skips_all_when_deadline_already_passed(agent):
 # --- parallel dispatch ----------------------------------------------------
 
 
-def test_parallel_all_pass(agent):
+def test_parallel_all_pass(agent: VerifierAgent) -> None:
+    """A parallel group whose children all pass succeeds."""
     spec = {
         "type": "parallel",
         "checks": [_leaf(succeed=True, tag="1"), _leaf(succeed=True, tag="2")],
@@ -195,7 +204,8 @@ def test_parallel_all_pass(agent):
     assert [c.success for c in res.children] == [True, True]
 
 
-def test_parallel_one_failure_fails_group(agent):
+def test_parallel_one_failure_fails_group(agent: VerifierAgent) -> None:
+    """A single failing child fails the parallel group as a whole."""
     spec = {
         "type": "parallel",
         "checks": [_leaf(succeed=True, tag="1"), _leaf(succeed=False, tag="2")],
@@ -207,7 +217,8 @@ def test_parallel_one_failure_fails_group(agent):
     assert {c.success for c in res.children} == {True, False}
 
 
-def test_parallel_leaf_exception_becomes_failed_child(agent):
+def test_parallel_leaf_exception_becomes_failed_child(agent: VerifierAgent) -> None:
+    """A raising leaf is converted to a failed child, not propagated."""
     spec = {
         "type": "parallel",
         "checks": [_leaf(succeed=True, tag="1"), _leaf(boom=True, tag="2")],
@@ -222,7 +233,8 @@ def test_parallel_leaf_exception_becomes_failed_child(agent):
     assert "boom:2" in failed[0].reason
 
 
-def test_parallel_empty_checks_is_vacuously_true(agent):
+def test_parallel_empty_checks_is_vacuously_true(agent: VerifierAgent) -> None:
+    """An empty parallel group succeeds vacuously."""
     res = agent.wait_for_condition({"type": "parallel", "checks": []})
 
     assert res.success is True
@@ -233,7 +245,8 @@ def test_parallel_empty_checks_is_vacuously_true(agent):
 # --- nesting --------------------------------------------------------------
 
 
-def test_nested_parallel_inside_sequence(agent):
+def test_nested_parallel_inside_sequence(agent: VerifierAgent) -> None:
+    """Compound nodes nest: a parallel group runs as a sequence child."""
     spec = {
         "type": "sequence",
         "checks": [

--- a/tests/unit/verification/test_runner.py
+++ b/tests/unit/verification/test_runner.py
@@ -1,0 +1,252 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Self-contained tests for the deadline-aware verification runner.
+
+The runner's dispatch, fail-fast, deadline-skip, and exception-conversion paths
+are exercised with an in-memory fake leaf verifier, so these tests do not depend
+on any concrete verifier module that lands in a follow-up.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Literal
+
+import pytest
+
+from devops_bench.verification import (
+    VERIFIERS,
+    BaseVerifier,
+    VerificationResult,
+)
+from devops_bench.verification.runner import VerifierAgent
+
+
+class _FakeLeaf(BaseVerifier):
+    """In-memory leaf verifier whose outcome is fixed by its fields.
+
+    Attributes:
+        succeed: Value of the returned result's ``success``.
+        boom: When true, :meth:`verify` raises instead of returning a result.
+        sleep_for: Seconds to block inside :meth:`verify` before returning.
+        tag: Label folded into the result ``reason`` for assertions.
+    """
+
+    type: Literal["fake_leaf"] = "fake_leaf"
+    succeed: bool = True
+    boom: bool = False
+    sleep_for: float = 0.0
+    tag: str = ""
+
+    def verify(self, timeout_sec: float) -> VerificationResult:
+        """Return (or raise) a canned result, echoing the budget it was given."""
+        if self.boom:
+            raise RuntimeError(f"boom:{self.tag}")
+        if self.sleep_for:
+            time.sleep(self.sleep_for)
+        return VerificationResult(
+            success=self.succeed,
+            elapsed_time=0.0,
+            reason=f"leaf:{self.tag}",
+            name=self.name,
+            raw={"timeout_sec": timeout_sec},
+        )
+
+
+@pytest.fixture(autouse=True)
+def _register_fake_leaf():
+    """Register the fake leaf for one test, then drop it from the registry."""
+    VERIFIERS.register("fake_leaf")(_FakeLeaf)
+    try:
+        yield
+    finally:
+        VERIFIERS._items.pop("fake_leaf", None)
+
+
+@pytest.fixture
+def agent() -> VerifierAgent:
+    """A fresh runner under test."""
+    return VerifierAgent()
+
+
+def _leaf(**kwargs) -> dict:
+    """Build a raw fake-leaf spec node."""
+    return {"type": "fake_leaf", **kwargs}
+
+
+# --- leaf dispatch --------------------------------------------------------
+
+
+def test_leaf_success_passes_through(agent):
+    res = agent.wait_for_condition(_leaf(succeed=True, tag="a"))
+
+    assert res.success is True
+    assert res.reason == "leaf:a"
+
+
+def test_leaf_failure_passes_through(agent):
+    res = agent.wait_for_condition(_leaf(succeed=False, tag="b"))
+
+    assert res.success is False
+    assert res.reason == "leaf:b"
+
+
+def test_leaf_receives_remaining_deadline_budget(agent):
+    # The leaf is handed the budget left on the shared deadline, not the raw
+    # ``timeout_sec`` verbatim, but for a bare leaf they are within epsilon.
+    res = agent.wait_for_condition(_leaf(), timeout_sec=30)
+
+    assert res.raw is not None
+    assert 0 < res.raw["timeout_sec"] <= 30
+
+
+def test_leaf_short_circuits_below_min_budget(agent):
+    # A sub-``_MIN_LEAF_BUDGET_SECONDS`` budget fails the leaf without ever
+    # running verify() (raw stays None because verify() was skipped).
+    res = agent.wait_for_condition(_leaf(succeed=True), timeout_sec=0.0)
+
+    assert res.success is False
+    assert res.reason == "deadline exhausted before evaluation"
+    assert res.raw is None
+
+
+# --- sequence dispatch ----------------------------------------------------
+
+
+def test_sequence_all_pass(agent):
+    spec = {
+        "type": "sequence",
+        "name": "seq",
+        "checks": [_leaf(succeed=True, tag="1"), _leaf(succeed=True, tag="2")],
+    }
+
+    res = agent.wait_for_condition(spec)
+
+    assert res.success is True
+    assert res.name == "seq"
+    assert [c.success for c in res.children] == [True, True]
+
+
+def test_sequence_fail_fast_skips_remaining(agent):
+    spec = {
+        "type": "sequence",
+        "checks": [
+            _leaf(succeed=False, tag="1"),
+            _leaf(succeed=True, tag="2"),
+            _leaf(succeed=True, tag="3"),
+        ],
+    }
+
+    res = agent.wait_for_condition(spec)
+
+    assert res.success is False
+    assert len(res.children) == 3
+    assert res.children[0].success is False
+    # The trailing checks are marked skipped rather than executed.
+    assert res.children[1].reason == "earlier step failed"
+    assert res.children[2].reason == "earlier step failed"
+    assert "[0] failed" in res.reason
+    assert "[1] skipped" in res.reason
+    assert "[2] skipped" in res.reason
+
+
+def test_sequence_bulk_skips_all_when_deadline_already_passed(agent):
+    # A non-positive budget puts the deadline in the past, so the first loop
+    # iteration bulk-marks every child skipped without running any of them.
+    spec = {
+        "type": "sequence",
+        "checks": [_leaf(succeed=True, tag="1"), _leaf(succeed=True, tag="2")],
+    }
+
+    res = agent.wait_for_condition(spec, timeout_sec=-1)
+
+    assert res.success is False
+    assert len(res.children) == 2
+    assert all(not c.success for c in res.children)
+    assert all(c.reason == "deadline exhausted" for c in res.children)
+    assert "[0] skipped" in res.reason
+    assert "[1] skipped" in res.reason
+
+
+# --- parallel dispatch ----------------------------------------------------
+
+
+def test_parallel_all_pass(agent):
+    spec = {
+        "type": "parallel",
+        "checks": [_leaf(succeed=True, tag="1"), _leaf(succeed=True, tag="2")],
+    }
+
+    res = agent.wait_for_condition(spec)
+
+    assert res.success is True
+    assert [c.success for c in res.children] == [True, True]
+
+
+def test_parallel_one_failure_fails_group(agent):
+    spec = {
+        "type": "parallel",
+        "checks": [_leaf(succeed=True, tag="1"), _leaf(succeed=False, tag="2")],
+    }
+
+    res = agent.wait_for_condition(spec)
+
+    assert res.success is False
+    assert {c.success for c in res.children} == {True, False}
+
+
+def test_parallel_leaf_exception_becomes_failed_child(agent):
+    spec = {
+        "type": "parallel",
+        "checks": [_leaf(succeed=True, tag="1"), _leaf(boom=True, tag="2")],
+    }
+
+    res = agent.wait_for_condition(spec)
+
+    assert res.success is False
+    failed = [c for c in res.children if not c.success]
+    assert len(failed) == 1
+    assert "unhandled error" in failed[0].reason
+    assert "boom:2" in failed[0].reason
+
+
+def test_parallel_empty_checks_is_vacuously_true(agent):
+    res = agent.wait_for_condition({"type": "parallel", "checks": []})
+
+    assert res.success is True
+    assert res.reason == "no checks"
+    assert res.children == []
+
+
+# --- nesting --------------------------------------------------------------
+
+
+def test_nested_parallel_inside_sequence(agent):
+    spec = {
+        "type": "sequence",
+        "checks": [
+            {
+                "type": "parallel",
+                "checks": [_leaf(succeed=True, tag="a"), _leaf(succeed=True, tag="b")],
+            },
+            _leaf(succeed=True, tag="c"),
+        ],
+    }
+
+    res = agent.wait_for_condition(spec)
+
+    assert res.success is True
+    assert res.children[0].success is True
+    assert len(res.children[0].children) == 2

--- a/tests/unit/verification/test_verifier_registry.py
+++ b/tests/unit/verification/test_verifier_registry.py
@@ -1,0 +1,113 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Extension-axis acceptance: a dummy verifier parses with no central edit."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from devops_bench.verification import (
+    VERIFIERS,
+    BaseVerifier,
+    SequenceSpec,
+    VerificationResult,
+    VerificationSpec,
+)
+
+
+def test_dummy_verifier_parses_without_union_edit():
+    # A new leaf is one decorator away — no edit to a central pydantic
+    # ``Annotated[Union, Field(discriminator="type")]`` is required.
+    @VERIFIERS.register("dummy_check")
+    class _DummyCheck(BaseVerifier):
+        type: Literal["dummy_check"] = "dummy_check"
+        payload: str
+
+        def verify(self, timeout_sec: float) -> VerificationResult:
+            return VerificationResult(
+                success=True,
+                elapsed_time=0.0,
+                reason=f"dummy:{self.payload}",
+                name=self.name,
+            )
+
+    try:
+        spec = VerificationSpec({"type": "dummy_check", "payload": "hello"})
+        assert isinstance(spec.root, _DummyCheck)
+        assert spec.root.payload == "hello"
+
+        # It composes inside compound nodes too, again with no union edit.
+        seq = VerificationSpec(
+            {
+                "type": "sequence",
+                "checks": [
+                    {"type": "dummy_check", "payload": "first"},
+                    {"type": "dummy_check", "payload": "second"},
+                ],
+            }
+        )
+        assert isinstance(seq.root, SequenceSpec)
+        assert [c.payload for c in seq.root.checks] == ["first", "second"]
+    finally:
+        # Keep the global registry clean for sibling tests.
+        VERIFIERS._items.pop("dummy_check", None)
+
+
+def test_unknown_type_lists_registered_keys_in_error():
+    # When the registry lookup misses, the parser must surface as a
+    # ``ValidationError`` (the codebase catches that), and the message should
+    # name the registered keys so authors can self-diagnose typos.
+    with pytest.raises(ValidationError) as excinfo:
+        VerificationSpec({"type": "definitely_not_registered"})
+    msg = str(excinfo.value)
+    assert "definitely_not_registered" in msg
+    # At least one of the builtins must show up in the listed keys.
+    assert "pod_healthy" in msg or "sequence" in msg
+
+
+class _UnregisteredVerifier(BaseModel):
+    """A pydantic model that walks and talks like a verifier but is NOT registered."""
+
+    type: Literal["totally_off_the_books"] = "totally_off_the_books"
+    payload: str = "x"
+
+
+def test_already_parsed_unregistered_basemodel_is_rejected():
+    # ``parse_node`` used to bypass any already-parsed ``BaseModel`` outright,
+    # which let an unregistered model slip through. Guard now requires the
+    # concrete class to be in ``VERIFIERS``; an unregistered instance must
+    # raise the same ``ValidationError`` surface as an unknown ``type`` string.
+    instance = _UnregisteredVerifier(payload="x")
+    with pytest.raises(ValidationError) as excinfo:
+        VerificationSpec(instance)
+    assert "not a registered verifier" in str(excinfo.value)
+
+
+def test_unregistered_basemodel_as_checks_child_is_rejected():
+    # The same guard must fire for compound children: an unregistered
+    # pre-parsed model handed in as a ``checks`` entry must not silently land
+    # in a sequence/parallel node.
+    rogue = _UnregisteredVerifier(payload="x")
+    with pytest.raises(ValidationError) as excinfo:
+        VerificationSpec(
+            {
+                "type": "sequence",
+                "checks": [rogue],
+            }
+        )
+    assert "not a registered verifier" in str(excinfo.value)

--- a/tests/unit/verification/test_verifier_registry.py
+++ b/tests/unit/verification/test_verifier_registry.py
@@ -76,8 +76,8 @@ def test_unknown_type_lists_registered_keys_in_error():
         VerificationSpec({"type": "definitely_not_registered"})
     msg = str(excinfo.value)
     assert "definitely_not_registered" in msg
-    # At least one of the builtins must show up in the listed keys.
-    assert "pod_healthy" in msg or "sequence" in msg
+    # The registered compound builtin must show up in the listed keys.
+    assert "sequence" in msg
 
 
 class _UnregisteredVerifier(BaseModel):


### PR DESCRIPTION
Adds the verification framework base and the LLM-judge scoring pipeline.

**Verification** (`devops_bench/verification/`)
- `base.py` — the `Verifier` abstract base and its registry.
- `spec.py` — pydantic models for declaring verification specs.
- `runner.py` — executes registered verifiers concurrently and aggregates results.

**Metrics judge** (`devops_bench/metrics/`)
- `geval.py` — G-Eval judge model wiring over `deepeval`, resolving the judge
  provider/model from configuration.
- `pipeline.py` — the scoring pipeline that runs judge metrics.
- `_skills.py` — loads the packaged skill guides the judge reads.

Unit tests for the base surface are co-located under `tests/unit/verification/`
and `tests/unit/metrics/`.

Concrete verifiers and concrete metric families build on these bases and land in
follow-ups; see the inline notes on `spec.py` and `pipeline.py` for how they
register.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a model-agnostic DeepEval judge that delegates generation through the project’s model layer and supports async/sync execution.
  * Added a batch metrics scoring pipeline that writes per-metric scores in a deterministic order and isolates metric failures.
  * Added a deadline-aware verification engine with structured results, plus sequential and parallel verification specs from a registry.
  * Added packaged loading for judge skill markdown content.

* **Tests**
  * Added unit tests for the judge wrapper, metrics pipeline behavior, verification parsing/runner semantics, registry validation, and lightweight package imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->