### PR TITLE
feat(deployers): add the infrastructure deployer abstraction and defa…

### DIFF
--- a/devops_bench/deployers/__init__.py
+++ b/devops_bench/deployers/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Infrastructure deployers for provisioning benchmark clusters."""

--- a/devops_bench/deployers/base.py
+++ b/devops_bench/deployers/base.py
@@ -1,0 +1,43 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Abstract interface implemented by infrastructure deployers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from devops_bench.core import ClusterInfo
+
+__all__ = ["Deployer"]
+
+
+class Deployer(ABC):
+    """Provisions and tears down a cluster for a benchmark run."""
+
+    @abstractmethod
+    def up(self) -> None:
+        """Create the cluster."""
+
+    @abstractmethod
+    def down(self) -> None:
+        """Tear down the cluster."""
+
+    @abstractmethod
+    def get_cluster_info(self) -> ClusterInfo:
+        """Return connection details for the provisioned cluster.
+
+        Returns:
+            The cluster's :class:`~devops_bench.core.ClusterInfo`.
+        """

--- a/devops_bench/deployers/factory.py
+++ b/devops_bench/deployers/factory.py
@@ -35,11 +35,13 @@ def _select_provider(infra_config: dict[str, Any], stack: str) -> str:
     """Determine the provider name for a tofu stack.
 
     Precedence: ``INFRA_PROVIDER`` env → explicit ``provider`` config key →
-    substring deduction from the stack name. The env var wins so a task can pin a
-    default ``provider`` in its config while runs stay overridable from the
-    environment (matching ``TARGET_DEPLOYMENT_NAME`` / ``NAMESPACE``). Deduction
-    is only applied to in-repo (relative) stacks; an out-of-repo (absolute or
-    ``~``) stack must name its provider explicitly rather than be guessed at.
+    ``kind`` deduced from an in-repo stack name. The env var wins so a task can
+    pin a default ``provider`` in its config while runs stay overridable from
+    the environment (matching ``TARGET_DEPLOYMENT_NAME`` / ``NAMESPACE``).
+    Deduction is only applied to in-repo (relative) stacks named ``kind``; an
+    out-of-repo (absolute or ``~``) stack, or any in-repo stack not named
+    ``kind``, must name its provider explicitly — no cloud is assumed by
+    default, so a new provider never silently inherits another's defaults.
 
     Args:
         infra_config: Task infrastructure config.
@@ -49,17 +51,18 @@ def _select_provider(infra_config: dict[str, Any], stack: str) -> str:
         The selected provider name.
 
     Raises:
-        ConfigError: If an absolute/external stack has no explicit provider.
+        ConfigError: If no explicit provider is given and the stack does not
+            deduce to ``kind``.
     """
     explicit = (get_env("INFRA_PROVIDER", "") or infra_config.get("provider") or "").strip().lower()
     if explicit:
         return explicit
-    if Path(stack).expanduser().is_absolute():
-        raise ConfigError(
-            f"external stack {stack!r} requires an explicit provider; set 'provider' in task "
-            "config or the INFRA_PROVIDER env var (e.g. 'gcp' or 'kind')"
-        )
-    return "kind" if "kind" in stack else "gcp"
+    if not Path(stack).expanduser().is_absolute() and "kind" in stack:
+        return "kind"
+    raise ConfigError(
+        f"stack {stack!r} requires an explicit provider; set 'provider' in task "
+        "config or the INFRA_PROVIDER env var (e.g. 'gcp' or 'kind')"
+    )
 
 
 def get_deployer(
@@ -78,8 +81,8 @@ def get_deployer(
     * ``BENCH_NO_INFRA=true`` (env) *overrides* any config to skip infra for a
       run (local smoke tests, CI plumbing, running against existing clusters).
 
-    Location precedence: ``global_location`` arg → ``GCP_LOCATION`` env →
-    ``us-central1-a``.
+    Location precedence: ``global_location`` arg → ``INFRA_LOCATION`` env →
+    ``GCP_LOCATION`` env → ``us-central1-a``.
 
     Args:
         infra_config: Task infrastructure config (``deployer``, ``provider``,
@@ -94,8 +97,8 @@ def get_deployer(
     Raises:
         ConfigError: If ``infra_config["deployer"]`` is set to a value other
             than ``tofu`` or ``noop`` (unset/empty defaults to ``tofu``), if
-            an external stack names no provider, or if the selected provider
-            is unknown.
+            ``infra_config["variables"]`` is set but not a mapping, if the
+            stack names no provider, or if the selected provider is unknown.
     """
     deployer_type = (infra_config.get("deployer") or "").lower()
 
@@ -108,9 +111,17 @@ def get_deployer(
             "BENCH_NO_INFRA=true to skip infra"
         )
 
-    location = global_location or get_env("GCP_LOCATION", _DEFAULT_LOCATION)
+    location = (
+        global_location
+        or get_env("INFRA_LOCATION", "")
+        or get_env("GCP_LOCATION", _DEFAULT_LOCATION)
+    )
     stack = infra_config.get("stack") or _DEFAULT_STACK
     custom_variables = infra_config.get("variables") or {}
+    if not isinstance(custom_variables, dict):
+        raise ConfigError(
+            f"'variables' in task config must be a mapping, got {type(custom_variables).__name__}"
+        )
 
     provider_name = _select_provider(infra_config, stack)
     if provider_name not in PROVIDERS:

--- a/devops_bench/deployers/factory.py
+++ b/devops_bench/deployers/factory.py
@@ -57,7 +57,8 @@ def _select_provider(infra_config: dict[str, Any], stack: str) -> str:
     explicit = (get_env("INFRA_PROVIDER", "") or infra_config.get("provider") or "").strip().lower()
     if explicit:
         return explicit
-    if not Path(stack).expanduser().is_absolute() and "kind" in stack:
+    stack_path = Path(stack).expanduser()
+    if not stack_path.is_absolute() and stack_path.name == "kind":
         return "kind"
     raise ConfigError(
         f"stack {stack!r} requires an explicit provider; set 'provider' in task "

--- a/devops_bench/deployers/factory.py
+++ b/devops_bench/deployers/factory.py
@@ -54,11 +54,6 @@ def _select_provider(infra_config: dict[str, Any], stack: str) -> str:
     explicit = (get_env("INFRA_PROVIDER", "") or infra_config.get("provider") or "").strip().lower()
     if explicit:
         return explicit
-    if get_env("CLOUD_PROVIDER", ""):
-        raise ConfigError(
-            "CLOUD_PROVIDER environment variable has been renamed to INFRA_PROVIDER. "
-            "Please use INFRA_PROVIDER instead."
-        )
     if Path(stack).expanduser().is_absolute():
         raise ConfigError(
             f"external stack {stack!r} requires an explicit provider; set 'provider' in task "
@@ -115,7 +110,7 @@ def get_deployer(
 
     location = global_location or get_env("GCP_LOCATION", _DEFAULT_LOCATION)
     stack = infra_config.get("stack") or _DEFAULT_STACK
-    custom_variables = infra_config.get("variables", {})
+    custom_variables = infra_config.get("variables") or {}
 
     provider_name = _select_provider(infra_config, stack)
     if provider_name not in PROVIDERS:

--- a/devops_bench/deployers/factory.py
+++ b/devops_bench/deployers/factory.py
@@ -1,0 +1,137 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Factory selecting an infrastructure deployer from task config and env."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from devops_bench.core import ConfigError, get_bool, get_env
+from devops_bench.deployers.base import Deployer
+from devops_bench.deployers.noop import NoOpDeployer
+from devops_bench.deployers.tofu import TFDeployer
+from devops_bench.providers import PROVIDERS, ResolveContext
+
+__all__ = ["get_deployer"]
+
+_DEFAULT_LOCATION = "us-central1-a"
+_DEFAULT_STACK = "prebuilt/kind"
+
+
+def _select_provider(infra_config: dict[str, Any], stack: str) -> str:
+    """Determine the provider name for a tofu stack.
+
+    Precedence: ``INFRA_PROVIDER`` env → explicit ``provider`` config key →
+    substring deduction from the stack name. The env var wins so a task can pin a
+    default ``provider`` in its config while runs stay overridable from the
+    environment (matching ``TARGET_DEPLOYMENT_NAME`` / ``NAMESPACE``). Deduction
+    is only applied to in-repo (relative) stacks; an out-of-repo (absolute or
+    ``~``) stack must name its provider explicitly rather than be guessed at.
+
+    Args:
+        infra_config: Task infrastructure config.
+        stack: Resolved stack name or path.
+
+    Returns:
+        The selected provider name.
+
+    Raises:
+        ConfigError: If an absolute/external stack has no explicit provider.
+    """
+    explicit = (get_env("INFRA_PROVIDER", "") or infra_config.get("provider") or "").strip().lower()
+    if explicit:
+        return explicit
+    if get_env("CLOUD_PROVIDER", ""):
+        raise ConfigError(
+            "CLOUD_PROVIDER environment variable has been renamed to INFRA_PROVIDER. "
+            "Please use INFRA_PROVIDER instead."
+        )
+    if Path(stack).expanduser().is_absolute():
+        raise ConfigError(
+            f"external stack {stack!r} requires an explicit provider; set 'provider' in task "
+            "config or the INFRA_PROVIDER env var (e.g. 'gcp' or 'kind')"
+        )
+    return "kind" if "kind" in stack else "gcp"
+
+
+def get_deployer(
+    infra_config: dict[str, Any],
+    global_project_id: str,
+    global_cluster_name: str,
+    global_location: str | None = None,
+) -> Deployer:
+    """Instantiate the deployer selected by task config and environment.
+
+    OpenTofu (``tofu``) is the sole provisioning engine; the provider (``gcp`` or
+    ``kind``) only supplies credentials and stack variable defaults. Two layers
+    can skip provisioning, with the env layer winning:
+
+    * ``deployer: noop`` (config) *declares* a task that needs no infrastructure.
+    * ``BENCH_NO_INFRA=true`` (env) *overrides* any config to skip infra for a
+      run (local smoke tests, CI plumbing, running against existing clusters).
+
+    Location precedence: ``global_location`` arg → ``GCP_LOCATION`` env →
+    ``us-central1-a``.
+
+    Args:
+        infra_config: Task infrastructure config (``deployer``, ``provider``,
+            ``stack``, ``variables``).
+        global_project_id: Default project ID.
+        global_cluster_name: Default cluster name.
+        global_location: Explicit location override.
+
+    Returns:
+        A configured :class:`~devops_bench.deployers.base.Deployer`.
+
+    Raises:
+        ConfigError: If ``infra_config["deployer"]`` is anything other than
+            ``tofu`` or ``noop``, if an external stack names no provider, or if
+            the selected provider is unknown.
+    """
+    deployer_type = (infra_config.get("deployer") or "").lower()
+
+    if get_bool("BENCH_NO_INFRA") or deployer_type == "noop":
+        return NoOpDeployer(cluster_name=global_cluster_name, project_id=global_project_id)
+
+    if deployer_type and deployer_type != "tofu":
+        raise ConfigError(
+            f"unsupported deployer {deployer_type!r}; use 'tofu', or 'noop' / "
+            "BENCH_NO_INFRA=true to skip infra"
+        )
+
+    location = global_location or get_env("GCP_LOCATION", _DEFAULT_LOCATION)
+    stack = infra_config.get("stack") or _DEFAULT_STACK
+    custom_variables = infra_config.get("variables", {})
+
+    provider_name = _select_provider(infra_config, stack)
+    if provider_name not in PROVIDERS:
+        raise ConfigError(f"unknown provider {provider_name!r}; known: {sorted(PROVIDERS.keys())}")
+    provider = PROVIDERS.get(provider_name)()
+
+    ctx = ResolveContext(
+        stack=stack,
+        project_id=global_project_id,
+        cluster_name=global_cluster_name,
+        location=location,
+    )
+    variables = provider.resolve_variables(ctx, custom_variables)
+
+    return TFDeployer(
+        tf_dir=stack,
+        provider=provider,
+        variables=variables,
+        custom_keys=set(custom_variables.keys()),
+    )

--- a/devops_bench/deployers/factory.py
+++ b/devops_bench/deployers/factory.py
@@ -97,9 +97,10 @@ def get_deployer(
         A configured :class:`~devops_bench.deployers.base.Deployer`.
 
     Raises:
-        ConfigError: If ``infra_config["deployer"]`` is anything other than
-            ``tofu`` or ``noop``, if an external stack names no provider, or if
-            the selected provider is unknown.
+        ConfigError: If ``infra_config["deployer"]`` is set to a value other
+            than ``tofu`` or ``noop`` (unset/empty defaults to ``tofu``), if
+            an external stack names no provider, or if the selected provider
+            is unknown.
     """
     deployer_type = (infra_config.get("deployer") or "").lower()
 

--- a/devops_bench/deployers/noop.py
+++ b/devops_bench/deployers/noop.py
@@ -1,0 +1,64 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deployer that skips provisioning, for runs against existing or absent infra."""
+
+from __future__ import annotations
+
+from devops_bench.core import ClusterInfo, get_logger
+from devops_bench.deployers.base import Deployer
+
+__all__ = ["NoOpDeployer"]
+
+_log = get_logger("deployers.noop")
+
+
+class NoOpDeployer(Deployer):
+    """Deployer that performs no provisioning.
+
+    Useful when infrastructure already exists (or is intentionally absent) and a
+    benchmark run should not create or destroy clusters.
+
+    Args:
+        cluster_name: Name reported by :meth:`get_cluster_info`.
+        project_id: Optional project reported by :meth:`get_cluster_info`.
+    """
+
+    def __init__(self, cluster_name: str, project_id: str | None = None) -> None:
+        self.cluster_name = cluster_name
+        self.project_id = project_id
+
+    def up(self) -> None:
+        """Skip provisioning."""
+        _log.info("BENCH_NO_INFRA/noop: skipping provisioning for %s", self.cluster_name)
+
+    def down(self) -> None:
+        """Skip teardown."""
+        _log.info("BENCH_NO_INFRA/noop: skipping teardown for %s", self.cluster_name)
+
+    def get_cluster_info(self) -> ClusterInfo:
+        """Return connection details for the assumed cluster.
+
+        Returns:
+            A :class:`~devops_bench.core.ClusterInfo` with ``location`` set to
+            ``"local"``; the kubeconfig is resolved from ``KUBECONFIG`` or
+            ``~/.kube/config``.
+        """
+        return ClusterInfo.from_dict(
+            {
+                "name": self.cluster_name,
+                "location": "local",
+                "project": self.project_id,
+            }
+        )

--- a/devops_bench/deployers/tofu.py
+++ b/devops_bench/deployers/tofu.py
@@ -70,11 +70,14 @@ def _get_declared_variables(tf_dir: str) -> set[str]:
     """
     declared: set[str] = set()
     for path in Path(tf_dir).glob("*.tf"):
-        with open(path, encoding="utf-8") as f:
-            for line in f:
-                match = re.match(r'^\s*variable\s+"([^"]+)"', line)
-                if match:
-                    declared.add(match.group(1))
+        try:
+            with open(path, encoding="utf-8") as f:
+                for line in f:
+                    match = re.match(r'^\s*variable\s+"([^"]+)"', line)
+                    if match:
+                        declared.add(match.group(1))
+        except OSError:
+            continue
     for path in Path(tf_dir).glob("*.tf.json"):
         try:
             with open(path, encoding="utf-8") as f:

--- a/devops_bench/deployers/tofu.py
+++ b/devops_bench/deployers/tofu.py
@@ -142,6 +142,9 @@ class TFDeployer(Deployer):
             resolved under ``<repo_root>/tf``.
         provider: Cloud provider supplying credentials and cluster details.
         variables: OpenTofu input variables passed as ``-var`` flags.
+        custom_keys: Subset of ``variables`` that came from task-level config;
+            any of these not declared in the TF stack raises ``ConfigError``
+            in :meth:`_var_flags`.
 
     Raises:
         ConfigError: If the stack directory does not exist.

--- a/devops_bench/deployers/tofu.py
+++ b/devops_bench/deployers/tofu.py
@@ -1,0 +1,283 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenTofu-backed deployer driving repo-local ``tf/`` stacks."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from devops_bench.core import ClusterInfo, ConfigError, get_logger
+from devops_bench.core.subprocess import run
+from devops_bench.deployers.base import Deployer
+
+if TYPE_CHECKING:
+    from devops_bench.providers import Provider
+
+__all__ = ["TFDeployer"]
+
+# This module lives at ``<repo_root>/devops_bench/deployers/tofu.py``; the repo
+# root is therefore three levels up, and Tofu stacks live under ``<repo_root>/tf``.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TF_ROOT = _REPO_ROOT / "tf"
+
+_log = get_logger("deployers.tofu")
+
+
+def _format_var(value: Any) -> str:
+    """Format a Python value as an OpenTofu ``-var`` literal.
+
+    Args:
+        value: Variable value to serialize.
+
+    Returns:
+        ``"true"``/``"false"`` for booleans, JSON for lists and dicts,
+        ``"null"`` for ``None``, and ``str(value)`` otherwise.
+    """
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (list, dict)):
+        return json.dumps(value)
+    if value is None:
+        return "null"
+    return str(value)
+
+
+def _get_declared_variables(tf_dir: str) -> set[str]:
+    """Scan the stack directory for declared variable names.
+
+    Scans HCL ``.tf`` files with a fast line-based regex and ``.tf.json`` files
+    by parsing their top-level ``variable`` object. The HCL scan is a heuristic
+    and can be fooled by a ``variable`` block commented out inside a ``/* ... */``
+    span; such a false positive only downgrades a clean drop to a tofu-side
+    error, never the reverse.
+    """
+    declared: set[str] = set()
+    for path in Path(tf_dir).glob("*.tf"):
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                match = re.match(r'^\s*variable\s+"([^"]+)"', line)
+                if match:
+                    declared.add(match.group(1))
+    for path in Path(tf_dir).glob("*.tf.json"):
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        variables = data.get("variable") if isinstance(data, dict) else None
+        if isinstance(variables, dict):
+            declared.update(variables)
+    return declared
+
+
+def _isolated_work_dir(stack_dir: str, tf_root: Path) -> str:
+    """Return a per-run private copy of the stack dir, or ``stack_dir`` unchanged.
+
+    Per-run isolation already keys ``TF_DATA_DIR`` and the state file per run, but
+    both still ran ``tofu`` in the *shared* ``tf/prebuilt/<stack>`` directory, so
+    two concurrent runs of the SAME stack contend on its ``.terraform.lock.hcl``
+    (no lock file is committed, so every ``init`` rewrites it). To give each run a
+    private working directory, copy the WHOLE ``tf/`` tree — stacks reference
+    modules via relative ``../../`` paths, so a leaf-only copy would break — into
+    the run's scratch dir (the parent of ``TF_DATA_DIR``, beside the per-run
+    state file) and run tofu in the copied stack.
+
+    Only applies to in-repo stacks under an isolated (parallel) run; external or
+    absolute stacks and single (non-isolated) runs keep the original directory.
+    Any copy failure falls back to the original directory so provisioning still
+    proceeds (degrading to the shared-dir behavior, never failing).
+    """
+    tf_data_dir = os.environ.get("TF_DATA_DIR")
+    if not tf_data_dir or not tf_data_dir.strip():
+        return stack_dir
+    try:
+        rel = Path(stack_dir).resolve().relative_to(tf_root.resolve())
+    except ValueError:
+        return stack_dir  # external/absolute stack: cannot relocate safely
+    try:
+        run_dir = Path(tf_data_dir).resolve().parent
+        dest_tf = run_dir / "tf"
+        shutil.copytree(tf_root, dest_tf, dirs_exist_ok=True)
+        return str(dest_tf / rel)
+    except OSError as exc:
+        _log.warning(
+            "could not isolate tofu stack dir (%s); falling back to shared %s",
+            exc,
+            stack_dir,
+        )
+        return stack_dir
+
+
+class TFDeployer(Deployer):
+    """Deployer that provisions a cluster via an OpenTofu stack.
+
+    A pure provisioning engine: it runs ``tofu`` and delegates all cloud-specific
+    behavior (account credentials, cluster credentials, project resolution) to
+    its :class:`~devops_bench.providers.Provider`. Honors the ``TF_DATA_DIR``
+    environment variable so OpenTofu state can be redirected for idempotent runs.
+
+    Path resolution: a relative ``tf_dir`` is resolved under ``<repo_root>/tf``;
+    an absolute path (``~`` is expanded) is used as-is, so stacks may live outside
+    the repository.
+
+    Args:
+        tf_dir: Stack directory; an absolute/``~`` path used as-is, or a name
+            resolved under ``<repo_root>/tf``.
+        provider: Cloud provider supplying credentials and cluster details.
+        variables: OpenTofu input variables passed as ``-var`` flags.
+
+    Raises:
+        ConfigError: If the stack directory does not exist.
+    """
+
+    def __init__(
+        self,
+        tf_dir: str,
+        provider: Provider,
+        variables: dict[str, Any] | None = None,
+        custom_keys: set[str] | None = None,
+    ) -> None:
+        tf_path = Path(tf_dir).expanduser()
+        if tf_path.is_absolute():
+            if not tf_path.exists():
+                raise ConfigError(f"Absolute TF directory not found: {tf_dir}")
+            self.tf_dir = str(tf_path)
+        else:
+            repo_tf_path = _TF_ROOT / tf_path
+            if not repo_tf_path.exists():
+                raise ConfigError(f"TF stack not found in repo: {tf_dir} (checked {repo_tf_path})")
+            self.tf_dir = str(repo_tf_path)
+
+        # Per-run private working directory (a copy of the tf/ tree under the
+        # run's scratch dir) when isolated; otherwise the shared stack dir.
+        self.work_dir = _isolated_work_dir(self.tf_dir, _TF_ROOT)
+
+        self.provider = provider
+        self.variables = variables or {}
+        self.custom_keys = custom_keys or set()
+
+    def _var_flags(self) -> list[str]:
+        # Scan the directory tofu actually runs in (the isolated per-run copy
+        # under parallel runs; the shared stack dir otherwise), not self.tf_dir.
+        declared = _get_declared_variables(self.work_dir)
+        flags: list[str] = []
+        for key, value in self.variables.items():
+            if key in declared:
+                flags.extend(["-var", f"{key}={_format_var(value)}"])
+            elif key in self.custom_keys:
+                raise ConfigError(
+                    f"Variable {key!r} defined in task config is not declared in TF stack {self.tf_dir!r}"
+                )
+            else:
+                _log.warning(
+                    "dropping variable %r passed to tofu stack %r: not declared in tf files",
+                    key,
+                    self.tf_dir,
+                )
+        return flags
+
+    @staticmethod
+    def _state_flags() -> list[str]:
+        """Return ``-state`` flags placing per-run state beside ``TF_DATA_DIR``.
+
+        When ``TF_DATA_DIR`` is set (the parallel-isolation path keys it to a
+        per-run ``<run>/tf-data`` dir), the local state file is written to
+        ``<run>/terraform.tfstate`` — the *parent* of ``TF_DATA_DIR``, NOT
+        inside it. ``<TF_DATA_DIR>/terraform.tfstate`` is OpenTofu's reserved
+        backend-state path; writing the full resource state there makes a later
+        ``tofu init``/``output`` fail with "does not support state version 4".
+        Returns an empty list when ``TF_DATA_DIR`` is unset, so a single run
+        keeps OpenTofu's default in-directory state.
+        """
+        tf_data_dir = os.environ.get("TF_DATA_DIR")
+        if not tf_data_dir or not tf_data_dir.strip():
+            return []
+        return ["-state", str(Path(tf_data_dir).resolve().parent / "terraform.tfstate")]
+
+    def up(self) -> None:
+        tf_path = Path(self.work_dir)
+        if not tf_path.exists():
+            raise ConfigError(f"TF directory not found: {self.work_dir}")
+
+        self.provider.ensure_account_credentials()
+        run(["tofu", "init", "-input=false"], cwd=self.work_dir, capture=False)
+
+        cmd = [
+            "tofu",
+            "apply",
+            "-auto-approve",
+            "-input=false",
+            *self._state_flags(),
+            *self._var_flags(),
+        ]
+        run(cmd, cwd=self.work_dir, capture=False)
+
+    def down(self) -> None:
+        tf_path = Path(self.work_dir)
+        if not tf_path.exists():
+            _log.warning("TF directory %s not found. Skipping teardown.", self.work_dir)
+            return
+
+        self.provider.ensure_account_credentials()
+        run(["tofu", "init", "-input=false"], cwd=self.work_dir, capture=False)
+
+        cmd = [
+            "tofu",
+            "destroy",
+            "-auto-approve",
+            "-input=false",
+            *self._state_flags(),
+            *self._var_flags(),
+        ]
+        run(cmd, cwd=self.work_dir, capture=False)
+
+    def get_cluster_info(self) -> ClusterInfo:
+        """Read cluster details from the stack outputs.
+
+        Parses the stack outputs (no side effects) and delegates project
+        resolution and kubeconfig setup to the provider.
+
+        Returns:
+            The provisioned cluster's :class:`~devops_bench.core.ClusterInfo`.
+
+        Raises:
+            ConfigError: If required outputs are missing or unparseable.
+        """
+        run(["tofu", "init", "-input=false"], cwd=self.work_dir, capture=False)
+
+        result = run(
+            ["tofu", "output", "-json", *self._state_flags()],
+            cwd=self.work_dir,
+            capture=True,
+        )
+        try:
+            outputs = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise ConfigError("failed to parse 'tofu output -json'") from exc
+
+        cluster_name = outputs.get("cluster_name", {}).get("value")
+        if not cluster_name:
+            raise ConfigError("Failed to retrieve 'cluster_name' from TF outputs.")
+
+        location = outputs.get("cluster_location", {}).get("value")
+        if not location:
+            raise ConfigError("Failed to retrieve 'cluster_location' from TF outputs.")
+
+        return self.provider.ensure_cluster_credentials(cluster_name, location, self.variables)

--- a/devops_bench/deployers/tofu.py
+++ b/devops_bench/deployers/tofu.py
@@ -217,7 +217,7 @@ class TFDeployer(Deployer):
     def up(self) -> None:
         tf_path = Path(self.work_dir)
         if not tf_path.exists():
-            raise ConfigError(f"TF directory not found: {self.work_dir}")
+            raise ConfigError(f"TF directory not found: {self.work_dir} (stack: {self.tf_dir})")
 
         self.provider.ensure_account_credentials()
         run(["tofu", "init", "-input=false"], cwd=self.work_dir, capture=False)
@@ -235,7 +235,11 @@ class TFDeployer(Deployer):
     def down(self) -> None:
         tf_path = Path(self.work_dir)
         if not tf_path.exists():
-            _log.warning("TF directory %s not found. Skipping teardown.", self.work_dir)
+            _log.warning(
+                "TF directory %s (stack: %s) not found. Skipping teardown.",
+                self.work_dir,
+                self.tf_dir,
+            )
             return
 
         self.provider.ensure_account_credentials()

--- a/tests/unit/deployers/test_deployers_factory.py
+++ b/tests/unit/deployers/test_deployers_factory.py
@@ -253,6 +253,17 @@ def test_get_deployer_non_kind_stack_requires_explicit_provider(base_config):
         )
 
 
+def test_get_deployer_kind_like_stack_name_requires_explicit_provider(base_config):
+    # Deduction matches the final path component exactly, not a substring.
+    with pytest.raises(ConfigError, match="requires an explicit provider"):
+        get_deployer(
+            {"deployer": "tofu", "stack": "custom/kindness"},
+            base_config["project_id"],
+            base_config["cluster_name"],
+            base_config["location"],
+        )
+
+
 def test_get_deployer_unknown_provider_raises(mocker, base_config):
     mocker.patch("devops_bench.deployers.tofu.Path.exists", return_value=True)
     with pytest.raises(ConfigError, match="unknown provider"):

--- a/tests/unit/deployers/test_deployers_factory.py
+++ b/tests/unit/deployers/test_deployers_factory.py
@@ -94,12 +94,23 @@ def test_get_deployer_null_variables_key(mocker, base_config):
     assert deployer.custom_keys == set()
 
 
+def test_get_deployer_non_dict_variables_raises(base_config):
+    with pytest.raises(ConfigError, match="must be a mapping"):
+        get_deployer(
+            {"deployer": "tofu", "variables": "not-a-mapping"},
+            base_config["project_id"],
+            base_config["cluster_name"],
+            base_config["location"],
+        )
+
+
 def test_get_deployer_tofu_custom_stack_and_vars(mocker, base_config, monkeypatch):
     monkeypatch.delenv("KUBECONFIG", raising=False)
     mocker.patch("devops_bench.deployers.tofu.Path.exists", return_value=True)
     infra_config = {
         "deployer": "tofu",
         "stack": "custom/stack",
+        "provider": "gcp",
         "variables": {
             "node_count": 5,
             "machine_type": "n2-standard-4",
@@ -215,6 +226,31 @@ def test_get_deployer_infra_provider_env(mocker, base_config):
     )
     assert isinstance(deployer, TFDeployer)
     assert deployer.variables["project_id"] == base_config["project_id"]
+
+
+def test_get_deployer_infra_location_env_overrides_gcp_location(mocker, base_config, monkeypatch):
+    # INFRA_LOCATION outranks the vendor-specific GCP_LOCATION env var.
+    mocker.patch("devops_bench.deployers.tofu.Path.exists", return_value=True)
+    monkeypatch.setenv("GCP_LOCATION", "us-east1-b")
+    monkeypatch.setenv("INFRA_LOCATION", "europe-west1-b")
+    deployer = get_deployer(
+        {"deployer": "tofu", "stack": "custom/stack", "provider": "gcp"},
+        base_config["project_id"],
+        base_config["cluster_name"],
+        None,
+    )
+    assert deployer.variables["location"] == "europe-west1-b"
+
+
+def test_get_deployer_non_kind_stack_requires_explicit_provider(base_config):
+    # No cloud is assumed by default; only a stack named "kind" deduces one.
+    with pytest.raises(ConfigError, match="requires an explicit provider"):
+        get_deployer(
+            {"deployer": "tofu", "stack": "custom/stack"},
+            base_config["project_id"],
+            base_config["cluster_name"],
+            base_config["location"],
+        )
 
 
 def test_get_deployer_unknown_provider_raises(mocker, base_config):

--- a/tests/unit/deployers/test_deployers_factory.py
+++ b/tests/unit/deployers/test_deployers_factory.py
@@ -81,6 +81,19 @@ def test_get_deployer_tofu_default_stack(mocker, base_config):
     assert deployer.tf_dir == str(_TF_ROOT / "prebuilt/kind")
 
 
+def test_get_deployer_null_variables_key(mocker, base_config):
+    # A YAML "variables:" key with no value parses to None, not a missing key.
+    mocker.patch("devops_bench.deployers.tofu.Path.exists", return_value=True)
+    deployer = get_deployer(
+        {"deployer": "tofu", "variables": None},
+        base_config["project_id"],
+        base_config["cluster_name"],
+        base_config["location"],
+    )
+    assert isinstance(deployer, TFDeployer)
+    assert deployer.custom_keys == set()
+
+
 def test_get_deployer_tofu_custom_stack_and_vars(mocker, base_config, monkeypatch):
     monkeypatch.delenv("KUBECONFIG", raising=False)
     mocker.patch("devops_bench.deployers.tofu.Path.exists", return_value=True)
@@ -204,18 +217,6 @@ def test_get_deployer_infra_provider_env(mocker, base_config):
     assert deployer.variables["project_id"] == base_config["project_id"]
 
 
-def test_get_deployer_cloud_provider_raises_rename_error(mocker, base_config):
-    mocker.patch("devops_bench.deployers.tofu.Path.exists", return_value=True)
-    mocker.patch.dict(os.environ, {"CLOUD_PROVIDER": "gcp"})
-    with pytest.raises(ConfigError, match="has been renamed to INFRA_PROVIDER"):
-        get_deployer(
-            {"deployer": "tofu", "stack": "prebuilt/kind"},
-            base_config["project_id"],
-            base_config["cluster_name"],
-            base_config["location"],
-        )
-
-
 def test_get_deployer_unknown_provider_raises(mocker, base_config):
     mocker.patch("devops_bench.deployers.tofu.Path.exists", return_value=True)
     with pytest.raises(ConfigError, match="unknown provider"):
@@ -241,7 +242,6 @@ def test_get_deployer_absolute_stack_requires_explicit_provider(tmp_path, base_c
     err_msg = str(exc_info.value)
     assert "requires an explicit provider" in err_msg
     assert "INFRA_PROVIDER" in err_msg
-    assert "CLOUD_PROVIDER" not in err_msg
 
 
 def test_get_deployer_absolute_stack_with_provider(tmp_path, base_config):

--- a/tests/unit/deployers/test_deployers_factory.py
+++ b/tests/unit/deployers/test_deployers_factory.py
@@ -1,0 +1,257 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the deployer factory."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from devops_bench.core import ConfigError
+from devops_bench.deployers.factory import get_deployer
+from devops_bench.deployers.noop import NoOpDeployer
+from devops_bench.deployers.tofu import _TF_ROOT, TFDeployer
+
+
+@pytest.fixture
+def base_config():
+    return {
+        "project_id": "test-project",
+        "cluster_name": "test-cluster",
+        "location": "us-central1-a",
+    }
+
+
+def _expected_kubeconfig():
+    return os.environ.get("KUBECONFIG") or str(Path("~/.kube/config").expanduser().resolve())
+
+
+def test_get_deployer_default(mocker, base_config):
+    mocker.patch("devops_bench.deployers.tofu.Path.exists", return_value=True)
+    deployer = get_deployer(
+        {},
+        base_config["project_id"],
+        base_config["cluster_name"],
+        base_config["location"],
+    )
+    assert isinstance(deployer, TFDeployer)
+    assert deployer.tf_dir == str(_TF_ROOT / "prebuilt/kind")
+
+
+def test_get_deployer_unsupported(base_config):
+    with pytest.raises(ConfigError):
+        get_deployer(
+            {"deployer": "kubetest2"},
+            base_config["project_id"],
+            base_config["cluster_name"],
+            base_config["location"],
+        )
+
+
+def test_get_deployer_tofu_default_stack(mocker, base_config):
+    mocker.patch("devops_bench.deployers.tofu.Path.exists", return_value=True)
+    deployer = get_deployer(
+        {"deployer": "tofu"},
+        base_config["project_id"],
+        base_config["cluster_name"],
+        base_config["location"],
+    )
+    assert isinstance(deployer, TFDeployer)
+    assert deployer.variables == {
+        "infra_provider": "kind",
+        "project_id": base_config["project_id"],
+        "cluster_name": base_config["cluster_name"],
+        "location": "local",
+        "kubeconfig_path": _expected_kubeconfig(),
+    }
+    assert deployer.tf_dir == str(_TF_ROOT / "prebuilt/kind")
+
+
+def test_get_deployer_tofu_custom_stack_and_vars(mocker, base_config, monkeypatch):
+    monkeypatch.delenv("KUBECONFIG", raising=False)
+    mocker.patch("devops_bench.deployers.tofu.Path.exists", return_value=True)
+    infra_config = {
+        "deployer": "tofu",
+        "stack": "custom/stack",
+        "variables": {
+            "node_count": 5,
+            "machine_type": "n2-standard-4",
+            "cluster_name": "custom-cluster",  # overrides global
+        },
+    }
+    deployer = get_deployer(
+        infra_config,
+        base_config["project_id"],
+        base_config["cluster_name"],
+        base_config["location"],
+    )
+    assert isinstance(deployer, TFDeployer)
+    assert deployer.variables == {
+        "infra_provider": "gcp",
+        "project_id": base_config["project_id"],
+        "cluster_name": "custom-cluster",
+        "location": base_config["location"],
+        "node_count": 5,
+        "machine_type": "n2-standard-4",
+    }
+    assert deployer.tf_dir == str(_TF_ROOT / "custom/stack")
+
+
+def test_get_deployer_tofu_kind_stack(mocker, base_config):
+    mocker.patch("devops_bench.deployers.tofu.Path.exists", return_value=True)
+    deployer = get_deployer(
+        {"deployer": "tofu", "stack": "prebuilt/kind"},
+        base_config["project_id"],
+        base_config["cluster_name"],
+        base_config["location"],
+    )
+    assert isinstance(deployer, TFDeployer)
+    assert deployer.variables == {
+        "infra_provider": "kind",
+        "project_id": base_config["project_id"],
+        "cluster_name": base_config["cluster_name"],
+        "location": "local",
+        "kubeconfig_path": _expected_kubeconfig(),
+    }
+    assert deployer.tf_dir == str(_TF_ROOT / "prebuilt/kind")
+
+
+def test_get_deployer_noop(base_config):
+    deployer = get_deployer(
+        {"deployer": "noop"},
+        base_config["project_id"],
+        base_config["cluster_name"],
+        base_config["location"],
+    )
+    assert isinstance(deployer, NoOpDeployer)
+    assert deployer.cluster_name == base_config["cluster_name"]
+    assert deployer.project_id == base_config["project_id"]
+
+
+def test_get_deployer_no_infra_env_precedence(mocker, base_config):
+    # BENCH_NO_INFRA wins even when a tofu deployer/stack is configured.
+    mocker.patch.dict(os.environ, {"BENCH_NO_INFRA": "true"})
+    deployer = get_deployer(
+        {"deployer": "tofu", "stack": "prebuilt/kind"},
+        base_config["project_id"],
+        base_config["cluster_name"],
+        base_config["location"],
+    )
+    assert isinstance(deployer, NoOpDeployer)
+    assert deployer.cluster_name == base_config["cluster_name"]
+    assert deployer.project_id == base_config["project_id"]
+
+
+def test_get_deployer_explicit_provider_overrides_deduction(mocker, base_config, monkeypatch):
+    monkeypatch.delenv("KUBECONFIG", raising=False)
+    # A 'kind'-looking stack name is forced to the gcp provider via config.
+    mocker.patch("devops_bench.deployers.tofu.Path.exists", return_value=True)
+    deployer = get_deployer(
+        {"deployer": "tofu", "stack": "prebuilt/kind", "provider": "gcp"},
+        base_config["project_id"],
+        base_config["cluster_name"],
+        base_config["location"],
+    )
+    assert isinstance(deployer, TFDeployer)
+    # GCP variables (project_id/location), not the kind kubeconfig defaults.
+    assert deployer.variables["project_id"] == base_config["project_id"]
+    assert deployer.variables["location"] == base_config["location"]
+    assert "kubeconfig_path" not in deployer.variables
+
+
+def test_get_deployer_infra_provider_env_overrides_config(mocker, base_config, monkeypatch):
+    # INFRA_PROVIDER outranks a pinned 'provider:' key so runs stay overridable.
+    monkeypatch.delenv("KUBECONFIG", raising=False)
+    mocker.patch("devops_bench.deployers.tofu.Path.exists", return_value=True)
+    mocker.patch.dict(os.environ, {"INFRA_PROVIDER": "gcp"})
+    deployer = get_deployer(
+        {"deployer": "tofu", "stack": "prebuilt/kind", "provider": "kind"},
+        base_config["project_id"],
+        base_config["cluster_name"],
+        base_config["location"],
+    )
+    assert isinstance(deployer, TFDeployer)
+    # GCP variables win over the pinned kind provider.
+    assert deployer.variables["project_id"] == base_config["project_id"]
+    assert deployer.variables["location"] == base_config["location"]
+    assert "kubeconfig_path" not in deployer.variables
+
+
+def test_get_deployer_infra_provider_env(mocker, base_config):
+    mocker.patch("devops_bench.deployers.tofu.Path.exists", return_value=True)
+    mocker.patch.dict(os.environ, {"INFRA_PROVIDER": "gcp"})
+    deployer = get_deployer(
+        {"deployer": "tofu", "stack": "prebuilt/kind"},
+        base_config["project_id"],
+        base_config["cluster_name"],
+        base_config["location"],
+    )
+    assert isinstance(deployer, TFDeployer)
+    assert deployer.variables["project_id"] == base_config["project_id"]
+
+
+def test_get_deployer_cloud_provider_raises_rename_error(mocker, base_config):
+    mocker.patch("devops_bench.deployers.tofu.Path.exists", return_value=True)
+    mocker.patch.dict(os.environ, {"CLOUD_PROVIDER": "gcp"})
+    with pytest.raises(ConfigError, match="has been renamed to INFRA_PROVIDER"):
+        get_deployer(
+            {"deployer": "tofu", "stack": "prebuilt/kind"},
+            base_config["project_id"],
+            base_config["cluster_name"],
+            base_config["location"],
+        )
+
+
+def test_get_deployer_unknown_provider_raises(mocker, base_config):
+    mocker.patch("devops_bench.deployers.tofu.Path.exists", return_value=True)
+    with pytest.raises(ConfigError, match="unknown provider"):
+        get_deployer(
+            {"deployer": "tofu", "stack": "custom/stack", "provider": "aws"},
+            base_config["project_id"],
+            base_config["cluster_name"],
+            base_config["location"],
+        )
+
+
+def test_get_deployer_absolute_stack_requires_explicit_provider(tmp_path, base_config):
+    # An out-of-repo stack must not have its provider guessed from the path.
+    abs_stack = tmp_path / "ext" / "stack"
+    abs_stack.mkdir(parents=True)
+    with pytest.raises(ConfigError) as exc_info:
+        get_deployer(
+            {"deployer": "tofu", "stack": str(abs_stack)},
+            base_config["project_id"],
+            base_config["cluster_name"],
+            base_config["location"],
+        )
+    err_msg = str(exc_info.value)
+    assert "requires an explicit provider" in err_msg
+    assert "INFRA_PROVIDER" in err_msg
+    assert "CLOUD_PROVIDER" not in err_msg
+
+
+def test_get_deployer_absolute_stack_with_provider(tmp_path, base_config):
+    abs_stack = tmp_path / "ext" / "stack"
+    abs_stack.mkdir(parents=True)
+    deployer = get_deployer(
+        {"deployer": "tofu", "stack": str(abs_stack), "provider": "gcp"},
+        base_config["project_id"],
+        base_config["cluster_name"],
+        base_config["location"],
+    )
+    assert isinstance(deployer, TFDeployer)
+    assert deployer.tf_dir == str(abs_stack)

--- a/tests/unit/deployers/test_deployers_noop.py
+++ b/tests/unit/deployers/test_deployers_noop.py
@@ -1,0 +1,58 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the no-op deployer."""
+
+from __future__ import annotations
+
+from devops_bench.core import ClusterInfo
+from devops_bench.deployers.noop import NoOpDeployer
+
+
+def test_up_is_noop(mocker):
+    # No provisioning subprocess should ever be spawned.
+    mock_run = mocker.patch("devops_bench.core.subprocess.run")
+    mock_popen = mocker.patch("subprocess.Popen")
+    deployer = NoOpDeployer(cluster_name="test-cluster", project_id="test-project")
+    assert deployer.up() is None
+    mock_run.assert_not_called()
+    mock_popen.assert_not_called()
+
+
+def test_down_is_noop(mocker):
+    mock_run = mocker.patch("devops_bench.core.subprocess.run")
+    mock_popen = mocker.patch("subprocess.Popen")
+    deployer = NoOpDeployer(cluster_name="test-cluster", project_id="test-project")
+    assert deployer.down() is None
+    mock_run.assert_not_called()
+    mock_popen.assert_not_called()
+
+
+def test_get_cluster_info():
+    deployer = NoOpDeployer(cluster_name="test-cluster", project_id="test-project")
+    info = deployer.get_cluster_info()
+
+    assert isinstance(info, ClusterInfo)
+    assert info.name == "test-cluster"
+    assert info.location == "local"
+    assert info.project == "test-project"
+
+
+def test_get_cluster_info_without_project():
+    deployer = NoOpDeployer(cluster_name="test-cluster")
+    info = deployer.get_cluster_info()
+
+    assert isinstance(info, ClusterInfo)
+    assert info.name == "test-cluster"
+    assert info.location == "local"

--- a/tests/unit/deployers/test_deployers_tofu.py
+++ b/tests/unit/deployers/test_deployers_tofu.py
@@ -1,0 +1,332 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the OpenTofu deployer engine.
+
+The engine is provider-agnostic: it runs ``tofu`` and delegates credentials and
+project resolution to its provider. These tests use a recording stub provider;
+credential behavior is covered in ``tests/unit/providers``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from devops_bench.core import ClusterInfo, ConfigError
+from devops_bench.deployers.tofu import _TF_ROOT, TFDeployer
+from devops_bench.providers.base import Provider, ResolveContext
+
+
+class StubProvider(Provider):
+    """Provider that records delegation and returns a canned ClusterInfo."""
+
+    def __init__(self) -> None:
+        self.account_calls = 0
+        self.cluster_calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def ensure_account_credentials(self) -> None:
+        self.account_calls += 1
+
+    def ensure_cluster_credentials(
+        self, cluster_name: str, location: str, variables: dict[str, Any]
+    ) -> ClusterInfo:
+        self.cluster_calls.append((cluster_name, location, variables))
+        return ClusterInfo.from_dict(
+            {"name": cluster_name, "location": location, "project": variables.get("project_id")}
+        )
+
+    def resolve_variables(
+        self, ctx: ResolveContext, custom_variables: dict[str, Any]
+    ) -> dict[str, Any]:
+        return dict(custom_variables)
+
+
+@pytest.fixture
+def stack_dir(tmp_path):
+    path = tmp_path / "prebuilt" / "minimum"
+    path.mkdir(parents=True)
+    (path / "variables.tf").write_text("""
+variable "project_id" {}
+variable "cluster_name" {}
+variable "location" {}
+variable "node_count" {}
+""")
+    return path
+
+
+@pytest.fixture
+def provider():
+    return StubProvider()
+
+
+@pytest.fixture
+def tf_deployer(stack_dir, provider):
+    variables = {
+        "project_id": "test-project",
+        "cluster_name": "test-cluster",
+        "location": "us-central1-a",
+        "node_count": 3,
+    }
+    return TFDeployer(tf_dir=str(stack_dir), provider=provider, variables=variables)
+
+
+def test_up(mocker, monkeypatch, tf_deployer, provider):
+    monkeypatch.delenv("TF_DATA_DIR", raising=False)
+    mock_run = mocker.patch("devops_bench.deployers.tofu.run")
+    tf_deployer.up()
+
+    assert provider.account_calls == 1
+    calls = mock_run.call_args_list
+    assert len(calls) == 2
+    assert calls[0].args[0] == ["tofu", "init", "-input=false"]
+    assert calls[0].kwargs["cwd"] == tf_deployer.tf_dir
+    assert calls[1].args[0] == [
+        "tofu",
+        "apply",
+        "-auto-approve",
+        "-input=false",
+        "-var",
+        "project_id=test-project",
+        "-var",
+        "cluster_name=test-cluster",
+        "-var",
+        "location=us-central1-a",
+        "-var",
+        "node_count=3",
+    ]
+    assert calls[1].kwargs["cwd"] == tf_deployer.tf_dir
+
+
+def test_down(mocker, monkeypatch, tf_deployer, provider):
+    monkeypatch.delenv("TF_DATA_DIR", raising=False)
+    mock_run = mocker.patch("devops_bench.deployers.tofu.run")
+    tf_deployer.down()
+
+    assert provider.account_calls == 1
+    calls = mock_run.call_args_list
+    assert len(calls) == 2
+    assert calls[0].args[0] == ["tofu", "init", "-input=false"]
+    assert calls[1].args[0] == [
+        "tofu",
+        "destroy",
+        "-auto-approve",
+        "-input=false",
+        "-var",
+        "project_id=test-project",
+        "-var",
+        "cluster_name=test-cluster",
+        "-var",
+        "location=us-central1-a",
+        "-var",
+        "node_count=3",
+    ]
+
+
+def test_up_isolates_state_beside_tf_data_dir(mocker, monkeypatch, tmp_path, tf_deployer):
+    monkeypatch.setenv("TF_DATA_DIR", str(tmp_path / "tf-data"))
+    mock_run = mocker.patch("devops_bench.deployers.tofu.run")
+    tf_deployer.up()
+
+    apply_argv = mock_run.call_args_list[1].args[0]
+    expected_state = str((tmp_path / "tf-data").resolve().parent / "terraform.tfstate")
+    assert "-state" in apply_argv
+    state_path = apply_argv[apply_argv.index("-state") + 1]
+    assert state_path == expected_state
+    # Must NOT be inside TF_DATA_DIR (that path is reserved by OpenTofu).
+    assert f"{os.sep}tf-data{os.sep}" not in state_path
+    # init carries no -state (it does not touch state).
+    assert "-state" not in mock_run.call_args_list[0].args[0]
+
+
+def test_down_isolates_state_beside_tf_data_dir(mocker, monkeypatch, tmp_path, tf_deployer):
+    monkeypatch.setenv("TF_DATA_DIR", str(tmp_path / "tf-data"))
+    mock_run = mocker.patch("devops_bench.deployers.tofu.run")
+    tf_deployer.down()
+
+    destroy_argv = mock_run.call_args_list[1].args[0]
+    expected_state = str((tmp_path / "tf-data").resolve().parent / "terraform.tfstate")
+    assert destroy_argv[destroy_argv.index("-state") + 1] == expected_state
+
+
+def _output_process(location):
+    proc = MagicMock()
+    proc.stdout = json.dumps(
+        {
+            "cluster_name": {"value": "test-cluster"},
+            "cluster_location": {"value": location},
+        }
+    )
+    return proc
+
+
+def test_get_cluster_info_parses_and_delegates(mocker, monkeypatch, tf_deployer, provider):
+    monkeypatch.delenv("TF_DATA_DIR", raising=False)
+    mock_run = mocker.patch("devops_bench.deployers.tofu.run")
+    mock_run.side_effect = [MagicMock(), _output_process("us-central1-a")]
+
+    info = tf_deployer.get_cluster_info()
+
+    # Engine runs only init + output; no credential side effects of its own.
+    calls = mock_run.call_args_list
+    assert len(calls) == 2
+    assert calls[0].args[0] == ["tofu", "init", "-input=false"]
+    assert calls[1].args[0] == ["tofu", "output", "-json"]
+    for call in calls:
+        assert "gcloud" not in call.args[0]
+
+    # Parsed outputs are handed to the provider, which builds the ClusterInfo.
+    assert provider.cluster_calls == [("test-cluster", "us-central1-a", tf_deployer.variables)]
+    assert info.name == "test-cluster"
+    assert info.location == "us-central1-a"
+    assert info.project == "test-project"
+
+
+def test_get_cluster_info_reads_isolated_state(mocker, monkeypatch, tmp_path, tf_deployer):
+    monkeypatch.setenv("TF_DATA_DIR", str(tmp_path / "tf-data"))
+    mock_run = mocker.patch("devops_bench.deployers.tofu.run")
+    mock_run.side_effect = [MagicMock(), _output_process("us-central1-a")]
+
+    tf_deployer.get_cluster_info()
+
+    output_argv = mock_run.call_args_list[1].args[0]
+    expected_state = str((tmp_path / "tf-data").resolve().parent / "terraform.tfstate")
+    assert output_argv[:3] == ["tofu", "output", "-json"]
+    assert output_argv[output_argv.index("-state") + 1] == expected_state
+
+
+def test_get_cluster_info_missing_name_raises(mocker, tf_deployer):
+    proc = MagicMock()
+    proc.stdout = json.dumps({"cluster_location": {"value": "us-central1-a"}})
+    mocker.patch("devops_bench.deployers.tofu.run", side_effect=[MagicMock(), proc])
+
+    with pytest.raises(ConfigError, match="cluster_name"):
+        tf_deployer.get_cluster_info()
+
+
+def test_get_cluster_info_bad_json_raises(mocker, tf_deployer):
+    proc = MagicMock()
+    proc.stdout = "not-json"
+    mocker.patch("devops_bench.deployers.tofu.run", side_effect=[MagicMock(), proc])
+
+    with pytest.raises(ConfigError, match="tofu output"):
+        tf_deployer.get_cluster_info()
+
+
+def test_init_path_resolution(tmp_path, mocker, provider):
+    # Absolute path that exists on disk is used as-is.
+    abs_path = tmp_path / "my-tf-stack"
+    abs_path.mkdir()
+    deployer = TFDeployer(tf_dir=str(abs_path), provider=provider)
+    assert deployer.tf_dir == str(abs_path)
+
+    # Relative path resolved under <repo_root>/tf.
+    mocker.patch("devops_bench.deployers.tofu.Path.exists", return_value=True)
+    deployer = TFDeployer(tf_dir="my-repo-stack", provider=provider)
+    assert deployer.tf_dir == str(_TF_ROOT / "my-repo-stack")
+    assert Path(deployer.tf_dir) == _TF_ROOT / "my-repo-stack"
+
+
+def test_init_expands_user_path(tmp_path, monkeypatch, provider):
+    # A ``~`` path expands to an absolute path and is used as-is (out-of-repo).
+    monkeypatch.setenv("HOME", str(tmp_path))
+    stack = tmp_path / "ext-stack"
+    stack.mkdir()
+    deployer = TFDeployer(tf_dir="~/ext-stack", provider=provider)
+    assert deployer.tf_dir == str(stack)
+
+
+def test_init_missing_dir_raises(provider):
+    with pytest.raises(ConfigError, match="TF stack not found in repo"):
+        TFDeployer(tf_dir="non-existent-stack-xyz", provider=provider)
+
+
+def test_get_declared_variables_robustness(tmp_path):
+    tf_file = tmp_path / "variables.tf"
+    tf_file.write_text("""
+variable "var1" {}
+  variable "var2" {
+    type = string
+  }
+variable "var3" { } # trailing comment
+# variable "commented_var" {}
+// variable "commented_var2" {}
+/* variable "commented_var3" {} */
+""")
+    # Variables declared in .tf.json files are also discovered.
+    (tmp_path / "extra.tf.json").write_text('{"variable": {"json_var": {"type": "string"}}}')
+    # Malformed .tf.json is skipped, not fatal.
+    (tmp_path / "broken.tf.json").write_text("{ not json")
+
+    from devops_bench.deployers.tofu import _get_declared_variables
+
+    declared = _get_declared_variables(str(tmp_path))
+    assert "var1" in declared
+    assert "var2" in declared
+    assert "var3" in declared
+    assert "json_var" in declared
+    assert "commented_var" not in declared
+    assert "commented_var2" not in declared
+
+
+def test_var_flags_drops_and_logs_undeclared_variables(stack_dir, provider, caplog):
+    import logging
+
+    variables = {
+        "project_id": "test-project",
+        "cluster_name": "test-cluster",
+        "location": "us-central1-a",
+        "node_count": 3,
+        "undeclared_var": "should-be-dropped",
+    }
+    deployer = TFDeployer(tf_dir=str(stack_dir), provider=provider, variables=variables)
+
+    with caplog.at_level(logging.WARNING):
+        flags = deployer._var_flags()
+
+    assert "undeclared_var" not in "".join(flags)
+    assert any(
+        "dropping variable 'undeclared_var'" in record.message
+        and "not declared in tf files" in record.message
+        for record in caplog.records
+    )
+    assert "project_id=test-project" in flags
+
+
+def test_var_flags_raises_on_undeclared_custom_variables(stack_dir, provider):
+    variables = {
+        "project_id": "test-project",
+        "cluster_name": "test-cluster",
+        "location": "us-central1-a",
+        "node_count": 3,
+        "undeclared_custom_var": "should-raise",
+    }
+    # Pass undeclared_custom_var as a custom key (simulating task config variables)
+    custom_keys = {"undeclared_custom_var"}
+    deployer = TFDeployer(
+        tf_dir=str(stack_dir),
+        provider=provider,
+        variables=variables,
+        custom_keys=custom_keys,
+    )
+
+    with pytest.raises(
+        ConfigError, match="Variable 'undeclared_custom_var' defined in task config is not declared"
+    ):
+        deployer._var_flags()

--- a/tf/prebuilt/kind/main.tf
+++ b/tf/prebuilt/kind/main.tf
@@ -1,0 +1,38 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    kind = {
+      source  = "tehcyx/kind"
+      version = ">= 0.5.0"
+    }
+  }
+}
+
+provider "kind" {}
+
+resource "kind_cluster" "default" {
+  name            = var.cluster_name
+  wait_for_ready  = true
+  kubeconfig_path = pathexpand(var.kubeconfig_path)
+}
+
+output "cluster_name" {
+  value = kind_cluster.default.name
+}
+
+output "cluster_location" {
+  value = "local"
+}

--- a/tf/prebuilt/kind/main.tf
+++ b/tf/prebuilt/kind/main.tf
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 terraform {
+  required_version = ">= 1.5.0"
   required_providers {
     kind = {
       source  = "tehcyx/kind"
@@ -34,5 +35,5 @@ output "cluster_name" {
 }
 
 output "cluster_location" {
-  value = "local"
+  value = var.location
 }

--- a/tf/prebuilt/kind/variables.tf
+++ b/tf/prebuilt/kind/variables.tf
@@ -1,0 +1,30 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "cluster_name" {
+  type    = string
+  default = "devops-bench-kind"
+}
+
+variable "location" {
+  type    = string
+  default = "local"
+}
+
+variable "kubeconfig_path" {
+  type        = string
+  description = "Path to write the kubeconfig file"
+  default     = "~/.kube/config"
+}
+

--- a/tf/prebuilt/kind/variables.tf
+++ b/tf/prebuilt/kind/variables.tf
@@ -22,6 +22,10 @@ variable "location" {
   default = "local"
 }
 
+# TODO: cluster_name and kubeconfig_path defaults are static, not per-run-unique.
+# Concurrent runs that don't each get an explicit override collide on the same
+# cluster name / kubeconfig file. Needs per-run-unique value generation from
+# whatever orchestrates runs; not solvable at this stack's variable-default layer.
 variable "kubeconfig_path" {
   type        = string
   description = "Path to write the kubeconfig file"


### PR DESCRIPTION
…ult kind stack

Introduces the Deployer abstract base class and a factory that selects an implementation from task config and environment: a no-op deployer for tasks that need no infrastructure, and an OpenTofu-backed deployer that provisions repo-local tf/ stacks against a resolved cloud provider. Ships with the default local kind stack used when no task-specific stack is configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added infrastructure deployment support using OpenTofu for provisioning and managing local Kubernetes clusters.
  * Introduced a deployer interface plus an automatic deployer selection flow, including a no-infrastructure (no-op) option.
  * Added stack directory configuration, variable handling, and retrieval of cluster connection details.
  * Added a prebuilt “kind” Terraform stack with outputs for cluster name and location.

* **Bug Fixes**
  * Improved validation for unsupported deployers/providers, missing/invalid stack configuration, invalid output parsing, and undeclared custom variables.
  * Added safer state handling when using `TF_DATA_DIR` to isolate per-run state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->