### PR TITLE
feat: add model provider clients and CLI agent harnesses

### DIFF
--- a/devops_bench/agents/base.py
+++ b/devops_bench/agents/base.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable
+from pathlib import Path
 
 from devops_bench.agents.config import AgentConfig
 from devops_bench.agents.result import AgentResult
@@ -73,7 +74,7 @@ class AgentHarness(ABC):
     def __init__(self, config: AgentConfig | None = None) -> None:
         self.config = config or AgentConfig()
 
-    def run(self, prompt: str) -> AgentResult:
+    def run(self, prompt: str, workspace_path: Path | None = None) -> AgentResult:
         """Execute the agent against ``prompt`` and return a typed result.
 
         Template method: wraps :meth:`_execute` in the latency stamp and the
@@ -82,6 +83,10 @@ class AgentHarness(ABC):
 
         Args:
             prompt: Task prompt handed to the agent.
+            workspace_path: Harness-owned working directory the agent should
+                execute in, when the harness supplies one (so files the agent
+                writes can be diffed and collected afterward). ``None`` lets
+                the agent fall back to its own throwaway working directory.
 
         Returns:
             An :class:`AgentResult` with ``latency`` always populated. A
@@ -90,7 +95,7 @@ class AgentHarness(ABC):
         start = time.monotonic()
         try:
             traced = _maybe_observe(self._execute)
-            result = traced(prompt)
+            result = traced(prompt, workspace_path)
             elapsed = time.monotonic() - start
             # Trust _execute when it already stamped latency (e.g. it has finer
             # timing for a sub-step it wants surfaced); only fill in when zero.
@@ -103,7 +108,7 @@ class AgentHarness(ABC):
             return AgentResult.errored(f"{type(exc).__name__}: {exc}", latency=elapsed)
 
     @abstractmethod
-    def _execute(self, prompt: str) -> AgentResult:
+    def _execute(self, prompt: str, workspace_path: Path | None = None) -> AgentResult:
         """Run the agent and return its typed result.
 
         Subclass extension point. Implementations build the provider-specific
@@ -114,6 +119,9 @@ class AgentHarness(ABC):
 
         Args:
             prompt: Task prompt handed to the agent.
+            workspace_path: Harness-owned working directory, or ``None`` when
+                the harness has not supplied one. A subclass with no local
+                filesystem workspace (e.g. a pure API agent) may ignore it.
 
         Returns:
             An :class:`AgentResult` (``latency`` may be left zero — the base
@@ -121,7 +129,9 @@ class AgentHarness(ABC):
         """
 
 
-def _maybe_observe(func: Callable[[str], AgentResult]) -> Callable[[str], AgentResult]:
+def _maybe_observe(
+    func: Callable[[str, Path | None], AgentResult],
+) -> Callable[[str, Path | None], AgentResult]:
     """Return ``func`` wrapped in ``deepeval.tracing.observe`` when available.
 
     The wrap is performed once per ``run()`` call rather than at import time so

--- a/devops_bench/agents/cli/__init__.py
+++ b/devops_bench/agents/cli/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Concrete CLI-binary agent harnesses (``gemini``, ``oc``).
+
+Each harness lives in its own subpackage (:mod:`.gemini_cli`, :mod:`.openclaw`)
+that splits the run driver (``agent``) from the trajectory parsers (``parsing``)
+and self-registers under its canonical key on import via ``@AGENTS.register``.
+Subpackages are imported by the harness at call time, not by this package's
+``__init__`` — keeping the import graph light.
+"""

--- a/devops_bench/agents/cli/gemini_cli/__init__.py
+++ b/devops_bench/agents/cli/gemini_cli/__init__.py
@@ -1,0 +1,27 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gemini CLI agent harness, named to distinguish it from the Gemini model.
+
+The harness driver lives in :mod:`.agent` and the stream-json parser in
+:mod:`.parsing`. Importing this package self-registers the agent under the
+``"gemini"`` key via ``@AGENTS.register``.
+"""
+
+from __future__ import annotations
+
+from devops_bench.agents.cli.gemini_cli.agent import GeminiCliAgent
+from devops_bench.agents.cli.gemini_cli.parsing import parse_stream_json
+
+__all__ = ["GeminiCliAgent", "parse_stream_json"]

--- a/devops_bench/agents/cli/gemini_cli/agent.py
+++ b/devops_bench/agents/cli/gemini_cli/agent.py
@@ -1,0 +1,273 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gemini CLI agent harness driving the ``gemini`` binary.
+
+Trajectory extraction reads the official ``--output-format stream-json`` event
+stream from stdout (see :mod:`~devops_bench.agents.cli.gemini_cli.parsing`) — no
+``~/.gemini/tmp/...`` disk reads, no session-id glob, no internal-schema parsing.
+
+Capability wiring is delivered through the Gemini CLI's native workspace
+mechanisms, written into the per-run working directory before invocation:
+
+* **Tools** — ``config.capabilities.allowed_tools`` become ``--allowed-tools``
+  arguments, pre-approving them in headless mode.
+* **MCP servers** — command-bearing bindings become ``mcpServers`` entries in
+  ``<cwd>/.gemini/settings.json``.
+* **Skills** — ``config.capabilities.skills.paths`` are materialized under
+  ``<cwd>/.gemini/skills/<name>/SKILL.md``.
+* **Rules** — ``config.capabilities.rules.text`` is written to ``GEMINI.md``,
+  auto-loaded as the startup context.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from devops_bench.agents.base import AGENTS, AgentHarness
+from devops_bench.agents.cli.gemini_cli.parsing import parse_stream_json
+from devops_bench.agents.config import AgentConfig
+from devops_bench.agents.result import AgentResult
+from devops_bench.agents.shared.cli_capabilities import (
+    agent_workdir,
+    build_mcp_servers,
+    materialize_skills,
+)
+from devops_bench.core import SubprocessError, get_logger
+from devops_bench.core.model_providers import resolve_provider
+from devops_bench.core.subprocess import run
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from devops_bench.agents.capabilities import McpBinding
+
+__all__ = ["GeminiCliAgent"]
+
+# Filename the Gemini CLI auto-loads from its working directory as the
+# operator brief / startup context (its native equivalent of a system prompt).
+_GEMINI_RULES_FILE = "GEMINI.md"
+# Workspace config dir/files the CLI reads from its cwd. ``settings.json`` here
+# overrides the user-level ``~/.gemini/settings.json``; ``skills/`` is the
+# workspace skill-discovery root.
+_GEMINI_CONFIG_DIR = ".gemini"
+_GEMINI_SETTINGS_FILE = "settings.json"
+_GEMINI_SKILLS_DIR = "skills"
+
+_log = get_logger("agents.cli.gemini_cli")
+
+
+def _build_settings(mcp_servers: tuple[McpBinding, ...], *, skills_enabled: bool) -> dict:
+    """Assemble the Gemini ``settings.json`` payload for a run.
+
+    Args:
+        mcp_servers: Bindings to render into ``mcpServers`` (empty-command
+            bindings are skipped by :func:`build_mcp_servers`).
+        skills_enabled: Whether any workspace skill was materialized; gates the
+            explicit ``skills.enabled`` flag so the benchmark does not depend on
+            the user-level default.
+
+    Returns:
+        A settings mapping, possibly empty (caller skips the write when empty).
+    """
+    settings: dict = {}
+    servers = build_mcp_servers(mcp_servers)
+    if servers:
+        settings["mcpServers"] = servers
+    if skills_enabled:
+        settings["skills"] = {"enabled": True}
+    return settings
+
+
+def _build_argv(target: str, prompt: str, allowed_tools: tuple[str, ...]) -> list[str]:
+    """Build the ``gemini`` invocation for ``prompt``.
+
+    ``--approval-mode yolo`` is always passed so the CLI auto-approves every tool
+    call (built-in *and* MCP) instead of blocking on interactive confirmation —
+    without it, MCP tool calls hang until the run hits its timeout.
+
+    When ``allowed_tools`` is empty, gemini *extensions* are disabled via
+    ``--extensions=`` — this is orthogonal to MCP (servers come from
+    ``settings.json`` and stay available). The short ``-e=`` / ``-e=""`` forms
+    print help and exit non-zero on gemini >= 0.47 (the literal value, quotes
+    included, reaches the parser since argv bypasses the shell), and ``-e none``
+    loads an extension literally named "none" rather than disabling.
+
+    Note: MCP servers only load when the workspace is *trusted*. The per-run temp
+    cwd is untrusted by default, so the bastion sets
+    ``security.folderTrust.enabled = false`` in the user-level
+    ``~/.gemini/settings.json`` (``--skip-trust`` alone does not lift the MCP
+    gate). See ``scripts/bastion/vm-setup.sh``.
+
+    Args:
+        target: Path to the ``gemini`` binary (already user-expanded).
+        prompt: Task prompt.
+        allowed_tools: Pre-approved tool names; each yields a separate
+            ``--allowed-tools <name>`` pair (redundant under yolo).
+
+    Returns:
+        The argv list ready to hand to ``core.subprocess.run``.
+    """
+    argv = [target, "--output-format", "stream-json", "--skip-trust"]
+    argv.extend(["--approval-mode", "yolo"])
+    if allowed_tools:
+        for tool in allowed_tools:
+            argv.extend(["--allowed-tools", tool])
+    else:
+        # `--extensions=` disables extensions; `-e=`/`-e=""` print help + exit 1
+        # on gemini >= 0.47, and `-e none` loads an extension named "none".
+        argv.append("--extensions=")
+    argv.extend(["-p", prompt])
+    return argv
+
+
+def _build_env(config: AgentConfig) -> dict[str, str]:
+    """Build the env overlay that makes the Gemini CLI run model-agnostic.
+
+    Maps the benchmark's neutral ``AGENT_*`` fields onto the variables the
+    Gemini CLI expects: ``config.api_key`` is routed onto the provider's API-key
+    env var(s) via the shared contract
+    (:func:`~devops_bench.core.model_providers.resolve_provider`), and
+    ``config.model`` onto ``GEMINI_MODEL``. OTLP telemetry exporters are disabled
+    so they don't hang on broken endpoints. The model is never hardcoded; it
+    flows from ``config.model``. A keyless backend (e.g. Vertex/ADC) writes no
+    key.
+
+    Args:
+        config: Resolved :class:`AgentConfig` for this run.
+
+    Returns:
+        A mapping suitable for ``core.subprocess.run``'s ``extra_env``.
+
+    Raises:
+        ConfigError: If ``config.provider`` is not a known provider.
+    """
+    # Resolve unconditionally so an unknown provider fails loud even on a keyless
+    # (Vertex/ADC) run, not only when a key happens to be set.
+    spec = resolve_provider(config.provider)
+    overlay: dict[str, str] = {
+        # Disable the Gemini CLI's OTLP exporters; otherwise they block/hang
+        # trying to reach an unreachable collector endpoint in headless runs.
+        "OTEL_TRACES_EXPORTER": "none",
+        "OTEL_METRICS_EXPORTER": "none",
+        "OTEL_LOGS_EXPORTER": "none",
+        "OTEL_SDK_DISABLED": "true",
+    }
+    if config.api_key:
+        for var in spec.api_key_envs:
+            overlay[var] = config.api_key
+    if config.model:
+        overlay["GEMINI_MODEL"] = config.model
+    if config.extra_env:
+        overlay.update(config.extra_env)
+    return overlay
+
+
+@AGENTS.register("gemini")
+class GeminiCliAgent(AgentHarness):
+    """Gemini CLI agent harness driving the ``gemini`` binary.
+
+    The binary path is resolved from ``config.target``, falling back to
+    ``"gemini"`` on ``$PATH``. Model / API key flow from
+    ``config.model`` / ``config.api_key`` via the env overlay — never
+    hardcoded. ``config.capabilities.allowed_tools`` (aggregated across every
+    bound MCP server) selects between the ``--allowed-tools`` overlay and the
+    ``--extensions=`` extensions-disabled path.
+
+    ``__init__`` assigns ``self.mcp_servers``, ``self.skills`` and ``self.rules``
+    from the granted config bindings, which is what makes
+    ``isinstance(agent, SupportsMcp / SupportsSkills / SupportsRules)`` return
+    ``True`` for orchestrator-side capability negotiation (the Protocols are
+    structural).
+
+    The full canonical trajectory is parsed from the official
+    ``--output-format stream-json`` event stream; no session files are read
+    from disk.
+    """
+
+    def __init__(self, config: AgentConfig | None = None) -> None:
+        AgentHarness.__init__(self, config)
+        caps = self.config.capabilities
+        self.mcp_servers = caps.mcp_servers
+        self.skills = caps.skills
+        self.rules = caps.rules
+
+    def _execute(self, prompt: str, workspace_path: Path | None = None) -> AgentResult:
+        """Build argv, run the CLI, and parse the stream-json output.
+
+        The agent runs the binary inside ``workspace_path`` when the harness
+        supplies one, else its own per-run temp working directory, and lays
+        down the granted capabilities there before invocation, using the
+        CLI's native workspace channels (all auto-loaded from the cwd, so the
+        user's ``~/.gemini`` stays untouched and concurrent runs never race):
+
+        * ``GEMINI.md`` — the operator brief, when ``rules.text`` is set.
+        * ``.gemini/settings.json`` — ``mcpServers`` for each command-bearing
+          MCP binding, plus ``skills.enabled`` when skills were materialized.
+        * ``.gemini/skills/<name>/SKILL.md`` — one per discovered skill.
+
+        A temp working directory (used when ``workspace_path`` is ``None``) is
+        cleaned up when ``_execute`` returns; a harness-supplied
+        ``workspace_path`` is left for the harness to collect and clean up.
+        """
+        caps = self.config.capabilities
+        target = os.path.expanduser(self.config.target or "gemini")
+        argv = _build_argv(target, prompt, caps.allowed_tools)
+        env_overlay = _build_env(self.config)
+        rules_text = caps.rules.text
+
+        with agent_workdir(workspace_path, prefix="gemini-run-") as workdir:
+            if rules_text:
+                (workdir / _GEMINI_RULES_FILE).write_text(rules_text, encoding="utf-8")
+
+            gemini_dir = workdir / _GEMINI_CONFIG_DIR
+            skill_names = materialize_skills(gemini_dir / _GEMINI_SKILLS_DIR, caps.skills.paths)
+            settings = _build_settings(caps.mcp_servers, skills_enabled=bool(skill_names))
+            if settings:
+                gemini_dir.mkdir(parents=True, exist_ok=True)
+                (gemini_dir / _GEMINI_SETTINGS_FILE).write_text(
+                    json.dumps(settings, indent=2), encoding="utf-8"
+                )
+            try:
+                completed = run(
+                    argv,
+                    extra_env=env_overlay,
+                    cwd=workdir,
+                    check=False,
+                    timeout=self.config.timeout_sec,
+                )
+            except SubprocessError as exc:
+                return AgentResult.errored(f"gemini subprocess error: {exc}")
+            except OSError as exc:
+                # Missing / non-executable binary; core.subprocess.run does not wrap.
+                return AgentResult.errored(f"gemini binary unavailable: {exc}")
+
+        output, trajectory, tokens, parse_errors = parse_stream_json(completed.stdout or "")
+        errors: list[str] = list(parse_errors)
+        if completed.returncode != 0:
+            stderr = (completed.stderr or "").strip()
+            errors.append(f"gemini exited {completed.returncode}: {stderr or '<no stderr>'}")
+            if not output:
+                output = f"Error: gemini exited {completed.returncode}"
+        metadata: dict = {}
+        if completed.returncode != 0:
+            metadata["returncode"] = completed.returncode
+        return AgentResult(
+            output=output,
+            trajectory=trajectory,
+            tokens=tokens,
+            errors=errors,
+            metadata=metadata,
+        )

--- a/devops_bench/agents/cli/gemini_cli/parsing.py
+++ b/devops_bench/agents/cli/gemini_cli/parsing.py
@@ -1,0 +1,139 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parser for the Gemini CLI ``--output-format stream-json`` event stream.
+
+Folds ``tool_use``/``tool_result`` events into the canonical :class:`ToolCall`
+list and pulls the final text and aggregated token usage from ``result`` events.
+"""
+
+from __future__ import annotations
+
+import json
+
+from devops_bench.agents.result import ToolCall
+
+__all__ = ["parse_stream_json"]
+
+
+def parse_stream_json(stdout: str) -> tuple[str, list[dict], dict, list[str]]:
+    """Parse a Gemini ``--output-format stream-json`` stdout stream.
+
+    The stream is newline-delimited JSON events. The parser is intentionally
+    lenient (an unknown event type is skipped) and surfaces both per-line JSON
+    decode errors and unmatched ``tool_result`` events on the ``errors`` list
+    rather than silently dropping them.
+
+    | Event type      | Fields read                                              |
+    |-----------------|---------------------------------------------------------|
+    | ``init``        | (ignored)                                               |
+    | ``message``     | ``role`` (assistant text accumulated into the output)   |
+    | ``tool_use``    | ``tool_name``, ``tool_id``, ``parameters``              |
+    | ``tool_result`` | ``tool_id``, ``status`` (no payload in the stream)      |
+    | ``error``       | recorded on the errors list                             |
+    | ``result``      | ``stats`` (token usage); terminal status                |
+
+    Args:
+        stdout: Raw process stdout, possibly empty.
+
+    Returns:
+        A ``(output, trajectory, tokens, errors)`` tuple. ``trajectory`` is a
+        list of ``ToolCall.to_dict()`` mappings ordered as emitted.
+    """
+    output_parts: list[str] = []
+    tokens: dict = {}
+    errors: list[str] = []
+    pending: dict[str, ToolCall] = {}
+    trajectory: list[ToolCall] = []
+
+    for lineno, raw in enumerate(stdout.splitlines(), start=1):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as exc:
+            errors.append(f"stream-json line {lineno} parse error: {exc}")
+            continue
+        if not isinstance(event, dict):
+            continue
+
+        etype = event.get("type")
+        if etype == "message":
+            # ``role="user"`` echoes the prompt and is skipped.
+            if event.get("role") in ("assistant", "model"):
+                content = event.get("content")
+                if isinstance(content, str):
+                    output_parts.append(content)
+                elif isinstance(content, list):
+                    # Defensive: a parts-list shape (``[{"text": ...}]``).
+                    for part in content:
+                        if isinstance(part, dict) and isinstance(part.get("text"), str):
+                            output_parts.append(part["text"])
+        elif etype == "tool_use":
+            call_id = event.get("tool_id") or event.get("id") or event.get("tool_use_id") or ""
+            args = event.get("parameters")
+            if args is None:
+                args = event.get("input")
+            if args is None:
+                args = event.get("args")
+            call = ToolCall(
+                name=event.get("tool_name") or event.get("name", ""),
+                args=args if isinstance(args, dict) else {},
+                status="called",
+            )
+            trajectory.append(call)
+            if call_id:
+                pending[str(call_id)] = call
+        elif etype == "tool_result":
+            call_id = event.get("tool_id") or event.get("tool_use_id") or event.get("id") or ""
+            target = pending.pop(str(call_id), None) if call_id else None
+            if target is None:
+                errors.append(f"stream-json tool_result without matching tool_use (id={call_id!r})")
+                continue
+            # tool_result carries only a status; accept a content/output
+            # payload as a fallback when present.
+            content = event.get("content")
+            if content is None:
+                content = event.get("output")
+            if content is not None:
+                target.result = (
+                    content if isinstance(content, str) else json.dumps(content, default=str)
+                )
+            status = str(event.get("status", "")).lower()
+            failed = bool(event.get("is_error")) or status in ("error", "failed", "failure")
+            target.status = "error" if failed else "completed"
+        elif etype == "error":
+            msg = event.get("message") or event.get("error") or str(event)
+            errors.append(f"stream-json error event: {msg}")
+        elif etype == "result":
+            # Terminal event: answer streams via ``message`` events and token
+            # usage rides under ``stats``; accept ``output``/``response`` and
+            # ``tokens``/``usage`` as fallbacks.
+            tail = event.get("output") or event.get("response")
+            if isinstance(tail, str) and tail:
+                output_parts.append(tail)
+            stats = event.get("stats")
+            usage = event.get("tokens") or event.get("usage")
+            if isinstance(stats, dict):
+                tokens = {
+                    "input": stats.get("input_tokens"),
+                    "output": stats.get("output_tokens"),
+                    "total": stats.get("total_tokens"),
+                    "cached": stats.get("cached"),
+                }
+            elif isinstance(usage, dict):
+                tokens = usage
+
+    return "".join(output_parts), [call.to_dict() for call in trajectory], tokens, errors

--- a/devops_bench/agents/cli/openclaw/__init__.py
+++ b/devops_bench/agents/cli/openclaw/__init__.py
@@ -1,0 +1,27 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenClaw CLI agent harness driving the local ``oc`` binary.
+
+The harness driver lives in :mod:`.agent` and the trajectory-bundle parsers in
+:mod:`.parsing`. Importing this package self-registers the agent under the
+``"openclaw"`` key via ``@AGENTS.register``.
+"""
+
+from __future__ import annotations
+
+from devops_bench.agents.cli.openclaw.agent import OpenClawAgent
+from devops_bench.agents.cli.openclaw.parsing import parse_trajectory_export
+
+__all__ = ["OpenClawAgent", "parse_trajectory_export"]

--- a/devops_bench/agents/cli/openclaw/agent.py
+++ b/devops_bench/agents/cli/openclaw/agent.py
@@ -1,0 +1,585 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenClaw CLI agent harness driving the ``oc`` binary (local-only).
+
+Capability wiring is delivered through openclaw's native channels, laid down in
+a per-run temp dir:
+
+* **State isolation** — ``OPENCLAW_STATE_DIR`` points at ``<run>/state`` so
+  sessions and the skills root live in the per-run dir.
+* **MCP servers** — command-bearing bindings become ``mcp.servers`` entries in
+  ``<run>/openclaw.json``, selected via ``OPENCLAW_CONFIG_PATH``.
+* **Skills** — ``config.capabilities.skills.paths`` are materialized under
+  ``<OPENCLAW_STATE_DIR>/skills/<name>/SKILL.md``.
+* **Rules** — ``config.capabilities.rules.text`` is prepended to the prompt
+  (the ``oc`` build has no dedicated system-prompt flag).
+* **Model catalog** — models openclaw doesn't ship in its built-in catalog
+  (e.g. ``gemini-3.5-flash``) are registered in the same per-run
+  ``<run>/openclaw.json`` so a run never depends on a global
+  ``oc models``/``configure-oc.sh`` step. The entry is written for whichever
+  Google backend ``config.provider`` selects — ``google`` (google-genai) or
+  ``google-vertex`` (Vertex AI).
+* **Model auth** — ``config.api_key`` is threaded into the provider env var
+  (``GEMINI_API_KEY``/``GOOGLE_CLOUD_API_KEY``/``ANTHROPIC_API_KEY``/...) that
+  ``oc agent --local`` reads.
+
+Trajectory extraction uses the official session commands documented in
+``docs/openclaw/sessions.md``: run ``oc agent --local``, locate the single
+session with ``oc sessions --json``, export it with
+``oc sessions export-trajectory``, and parse the bundle. On any extraction miss
+the failure is recorded on ``AgentResult.errors`` rather than returning a
+silent-empty trajectory.
+
+The bundle parsing lives in :mod:`~devops_bench.agents.cli.openclaw.parsing`.
+
+``__init__`` assigns ``self.rules``, ``self.mcp_servers`` and ``self.skills``
+from the granted bindings, so the agent structurally satisfies
+``SupportsRules`` / ``SupportsMcp`` / ``SupportsSkills``.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import shlex
+import shutil
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from devops_bench.agents.base import AGENTS, AgentHarness
+from devops_bench.agents.cli.openclaw.parsing import (
+    _pick_session_key,
+    _read_export_bundle,
+    _strip_ansi,
+    parse_trajectory_export,
+)
+from devops_bench.agents.config import AgentConfig
+from devops_bench.agents.result import AgentResult
+from devops_bench.agents.shared.cli_capabilities import (
+    agent_workdir,
+    build_mcp_servers,
+    materialize_skills,
+)
+from devops_bench.core import SubprocessError, get_logger
+from devops_bench.core.errors import ConfigError
+from devops_bench.core.model_providers import resolve_provider
+from devops_bench.core.subprocess import run
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from devops_bench.agents.capabilities import McpBinding
+
+__all__ = ["OpenClawAgent"]
+
+
+def _node_version_key(bin_path: str) -> tuple[int, ...]:
+    """Numeric sort key for an nvm bin path (``.../node/v18.17.0/bin`` -> ``(18, 17, 0)``).
+
+    A plain string sort puts ``v18...`` before ``v8...``; comparing numeric
+    tuples picks the truly newest version. Non-numeric segments (aliases,
+    partial installs) sort lowest.
+    """
+    version = os.path.basename(os.path.dirname(bin_path)).lstrip("v")
+    return tuple(int(chunk) if chunk.isdigit() else -1 for chunk in version.split("."))
+
+
+def _ensure_node_on_path(env_overlay: dict[str, str]) -> dict[str, str]:
+    """Return ``env_overlay`` with the nvm Node bin dir prepended to ``PATH``.
+
+    The agent *turn* runs ``oc`` through a bash command that sources nvm, but the
+    ``oc sessions`` / ``export-trajectory`` extraction calls run ``oc`` as a direct
+    argv subprocess (``run()`` never uses a shell). On an nvm-managed host Node is
+    not on the inherited ``PATH``, so those calls fail with
+    ``exit 127: /usr/bin/env: 'node': No such file or directory`` and the
+    trajectory comes back **silently empty** (deflating every tool/trajectory
+    score). Prepend the nvm Node bin dir so the direct subprocess finds Node too.
+
+    No-op when Node is already discoverable on ``PATH`` or nvm is absent.
+    """
+    if shutil.which("node"):
+        return env_overlay
+    nvm_dir = os.path.expanduser(os.environ.get("NVM_DIR") or "~/.nvm")
+    bins = glob.glob(os.path.join(nvm_dir, "versions", "node", "*", "bin"))
+    if not bins:
+        return env_overlay
+    node_bin = max(bins, key=_node_version_key)  # newest installed Node version
+    merged = dict(env_overlay)
+    existing = merged.get("PATH") or os.environ.get("PATH", "")
+    merged["PATH"] = f"{node_bin}{os.pathsep}{existing}" if existing else node_bin
+    return merged
+
+
+_log = get_logger("agents.cli.openclaw.agent")
+
+# Per-run layout under the temp working dir. ``state`` is openclaw's state root
+# (sessions + the managed skills tree); ``openclaw.json`` is the isolated config
+# carrying ``mcp.servers``.
+_OPENCLAW_STATE_DIRNAME = "state"
+_OPENCLAW_SKILLS_DIRNAME = "skills"
+_OPENCLAW_CONFIG_FILE = "openclaw.json"
+
+# Bare model ids (the part after ``provider/``) absent from openclaw's built-in
+# catalog; the harness registers these per-run (see :func:`_build_model_override`).
+# TODO(deferred): supported-model-name maintenance is tracked separately (#147).
+_CATALOG_OVERRIDES: frozenset[str] = frozenset({"gemini-3.5-flash"})
+
+# Transport each per-run provider entry must pin: such an entry *replaces* oc's
+# built-in provider rather than merging, so without ``api`` oc falls back to the
+# OpenAI transport and 401s. ``google`` needs no ``baseUrl``; for ``google-vertex``
+# ``{location}`` is expanded by oc, so it stays literal here.
+_PROVIDER_TRANSPORT: dict[str, dict[str, str]] = {
+    "google": {
+        "api": "google-generative-ai",
+    },
+    "google-vertex": {
+        "api": "google-vertex",
+        "baseUrl": "https://{location}-aiplatform.googleapis.com",
+    },
+}
+
+
+def _oc_model_id(config: AgentConfig) -> str:
+    """Resolve the canonical ``provider/model`` id ``oc agent --model`` expects.
+
+    Returns ``""`` when no model is configured (oc's stored default is left
+    untouched). The provider is normalized through the shared contract
+    (:func:`~devops_bench.core.model_providers.resolve_provider`) so the openclaw
+    id matches the rest of the pipeline (e.g. ``gemini`` → ``google``). A full id
+    (``provider/model``) has its provider segment normalized too; an unknown wire
+    passes through unchanged for oc to validate.
+
+    >>> _oc_model_id(AgentConfig(model="gemini-2.5-pro", provider="gemini"))
+    'google/gemini-2.5-pro'
+    >>> _oc_model_id(AgentConfig(model="gemini/gemini-2.5-pro"))
+    'google/gemini-2.5-pro'
+    >>> _oc_model_id(AgentConfig(model="anthropic/claude-opus-4"))
+    'anthropic/claude-opus-4'
+    >>> _oc_model_id(AgentConfig(model="gpt-5", provider="openai"))
+    'openai/gpt-5'
+    >>> _oc_model_id(AgentConfig())
+    ''
+    """
+    model = (config.model or "").strip()
+    if not model:
+        return ""
+    if "/" in model:  # already a full oc id; normalize the provider segment
+        wire, _, bare = model.partition("/")
+        try:
+            wire = resolve_provider(wire, default=wire).oc_provider
+        except ConfigError:
+            return model  # unknown wire: leave as-is, let oc validate
+        return f"{wire}/{bare}"
+    return f"{resolve_provider(config.provider).oc_provider}/{model}"
+
+
+def _build_model_override(config: AgentConfig) -> dict:
+    """Register a catalog entry for a model openclaw doesn't ship by default.
+
+    openclaw resolves ``--model provider/id`` against its built-in catalog;
+    ids absent from it (e.g. ``gemini-3.5-flash``) abort the run unless the
+    provider's catalog is patched. Rather than depend on a global
+    ``oc models``/``configure-oc.sh`` step — which races across parallel runs
+    and mutates the operator's shared config — the harness writes the catalog
+    entry into the per-run isolated ``openclaw.json`` selected via
+    ``OPENCLAW_CONFIG_PATH``.
+
+    The entry is provider-agnostic across Google's two backends: the provider is
+    read from the resolved oc model id, so the *same* model id works on
+    ``google`` (google-genai, API key) or ``google-vertex`` (Vertex AI, ADC) by
+    flipping ``config.provider`` alone. Both pin their transport (see
+    :data:`_PROVIDER_TRANSPORT`) because a per-run provider entry replaces oc's
+    built-in one rather than merging into it.
+
+    No auth is written here — it flows from the env: an API key
+    (``GEMINI_API_KEY``/``GOOGLE_API_KEY``) for google-genai, or, when no key is
+    set, the Vertex **ADC** path (the ``GOOGLE_CLOUD_API_KEY=gcp-vertex-credentials``
+    marker → metadata-server credentials). So the override stands on its own for
+    a keyless ADC run.
+
+    Returns an empty dict when no model is configured or the model is already in
+    oc's catalog (caller then writes no ``models``/``agents`` sections).
+    """
+    model_id = _oc_model_id(config)
+    if not model_id:
+        return {}
+    provider, _, bare = model_id.partition("/")
+    if bare not in _CATALOG_OVERRIDES:
+        return {}
+    # A per-run provider entry *replaces* oc's built-in one, so it must pin a
+    # transport; without one oc falls back to the OpenAI transport and 401s. Fail
+    # loud rather than ship a broken (transport-less) entry for a provider we have
+    # not pinned.
+    if provider not in _PROVIDER_TRANSPORT:
+        raise ConfigError(
+            f"openclaw catalog override {model_id!r} has no pinned transport for "
+            f"provider {provider!r}; add it to _PROVIDER_TRANSPORT (known: "
+            f"{', '.join(sorted(_PROVIDER_TRANSPORT))})"
+        )
+    provider_entry: dict = dict(_PROVIDER_TRANSPORT[provider])
+    provider_entry["models"] = [{"id": bare, "name": bare}]
+    return {
+        "models": {"providers": {provider: provider_entry}},
+        # Allowlist ``provider/id`` for the agent's per-run ``--model`` override.
+        "agents": {"defaults": {"models": {model_id: {}}}},
+    }
+
+
+def _build_openclaw_config(config: AgentConfig, mcp_servers: tuple[McpBinding, ...]) -> dict:
+    """Assemble the isolated ``openclaw.json`` payload for a run.
+
+    Merges the two per-run config concerns the harness owns: command-bearing MCP
+    bindings (``mcp.servers``) and a catalog entry for a model openclaw doesn't
+    ship by default (``models``/``agents``; see :func:`_build_model_override`).
+    Their key spaces are disjoint, so either, both, or neither may be present.
+
+    Args:
+        config: Resolved :class:`AgentConfig` (drives the model-catalog entry).
+        mcp_servers: Bindings to render into ``mcp.servers`` (empty-command
+            bindings are skipped by :func:`build_mcp_servers`).
+
+    Returns:
+        A config mapping, or an empty dict when there is neither a launchable MCP
+        binding nor a model needing a catalog entry (caller then skips the config
+        write and leaves ``OPENCLAW_CONFIG_PATH`` unset).
+
+    Each MCP server entry inherits the run's ``KUBECONFIG`` (set by ``RunEnv``) as
+    an explicit ``env`` so the MCP server (e.g. gke-mcp) reads the run-scoped
+    cluster credentials directly instead of forcing the agent to re-fetch them.
+    """
+    payload: dict = {}
+    servers = build_mcp_servers(mcp_servers)
+    if servers:
+        kubeconfig = os.environ.get("KUBECONFIG")
+        if kubeconfig:
+            for entry in servers.values():
+                entry.setdefault("env", {})["KUBECONFIG"] = kubeconfig
+        payload["mcp"] = {"servers": servers}
+    payload.update(_build_model_override(config))
+    return payload
+
+
+def _build_env(config: AgentConfig) -> dict[str, str]:
+    """Build the env overlay that gives ``oc agent --local`` its model API key.
+
+    ``oc agent --local`` reads the model provider's API key from the shell. The
+    benchmark's neutral ``config.api_key`` is mapped onto the provider-specific
+    variable(s) openclaw expects; the model itself is never hardcoded (it flows
+    from ``config.model`` via ``oc agent --model``).
+
+    The key is routed onto the provider's API-key env var(s) from the shared
+    contract (:func:`~devops_bench.core.model_providers.resolve_provider`). When
+    ``config.api_key`` is unset the overlay carries no key — the **Vertex / ADC**
+    path: ``google-vertex`` resolves credentials from the metadata-server
+    Application Default Credentials at request time (the matrix exports the
+    ``GOOGLE_CLOUD_API_KEY=gcp-vertex-credentials`` ADC marker), and the contract
+    marks such backends keyless (empty ``api_key_envs``) so no key is ever forced
+    onto them. A provided ``google-vertex`` key lands on ``GOOGLE_CLOUD_API_KEY``
+    (the vertex transport), not ``GEMINI_API_KEY`` (google-genai).
+
+    Args:
+        config: Resolved :class:`AgentConfig` for this run.
+
+    Returns:
+        A mapping suitable for the subprocess environment overlay. The caller
+        adds ``OPENCLAW_STATE_DIR`` / ``OPENCLAW_CONFIG_PATH`` on top.
+
+    Raises:
+        ConfigError: If ``config.provider`` is not a known provider.
+    """
+    # Resolve unconditionally so an unknown provider fails loud even on a keyless
+    # (Vertex/ADC) run, not only when a key happens to be set.
+    spec = resolve_provider(config.provider)
+    overlay: dict[str, str] = {}
+    if config.api_key:
+        for var in spec.api_key_envs:
+            overlay[var] = config.api_key
+    if config.extra_env:
+        overlay.update(config.extra_env)
+    return overlay
+
+
+def _oc_model_flag(config: AgentConfig) -> str:
+    """Return ``--model <id> `` for ``oc agent``, or ``""`` when no model is set.
+
+    The model is selected per-run with ``oc agent --model`` rather than the
+    global ``oc models set``: the latter writes oc's *shared* config whenever no
+    isolated ``OPENCLAW_CONFIG_PATH`` is in play (e.g. MCP off), which both races
+    across concurrent runs and pollutes the operator's default model. An invalid
+    id still aborts the run via ``oc agent``'s own non-zero exit, which surfaces
+    on ``AgentResult.errors``.
+    """
+    model_id = _oc_model_id(config)
+    if not model_id:
+        return ""
+    return f"--model {shlex.quote(model_id)} "
+
+
+def _prepend_rules(rules_text: str, prompt: str) -> str:
+    """Return ``prompt`` with ``rules_text`` prepended as an operator brief.
+
+    Empty / whitespace-only rules pass the prompt through unchanged so a default
+    :class:`AgentRules` is indistinguishable from "no preamble". A non-empty
+    brief is separated from the prompt by a blank line.
+
+    Args:
+        rules_text: The bound rules text (``capabilities.rules.text``).
+        prompt: The task prompt for this run.
+
+    Returns:
+        The combined string to hand to ``oc agent -m``.
+    """
+    if not rules_text or not rules_text.strip():
+        return prompt
+    return f"{rules_text.rstrip()}\n\n{prompt}"
+
+
+def _build_local_command(config: AgentConfig, prompt: str, agent_name: str, oc_bin: str) -> str:
+    """Build the bash command that sets the model and runs ``oc agent --local``.
+
+    Every interpolated value is ``shlex.quote``d so prompts/agent names
+    containing single quotes, spaces, or newlines neither break parsing nor
+    inject commands. ``bash -c`` is required so ``nvm.sh`` can be sourced to
+    expose the right Node toolchain before invoking ``oc`` (a no-op when Node is
+    installed system-wide). Session state is isolated via ``OPENCLAW_STATE_DIR``
+    (set by the caller's env overlay).
+
+    Args:
+        config: Resolved :class:`AgentConfig`.
+        prompt: Task prompt for the agent (rules already prepended).
+        agent_name: ``oc`` agent profile (e.g. ``"operator"``).
+        oc_bin: Path to the ``oc`` binary.
+
+    Returns:
+        A single bash command string ready to run via ``/bin/bash -c`` through
+        ``core.subprocess.run``.
+    """
+    quoted_oc = shlex.quote(oc_bin)
+    return (
+        # Source nvm so the Node-based oc binary's runtime is available. An
+        # inherited NVM_DIR (custom install path) wins over the default.
+        'export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"; '
+        '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"; '
+        f"{quoted_oc} --log-level debug agent --local "
+        f"--agent {shlex.quote(agent_name)} {_oc_model_flag(config)}-m {shlex.quote(prompt)}"
+    )
+
+
+@AGENTS.register("openclaw")
+class OpenClawAgent(AgentHarness):
+    """OpenClaw CLI agent harness driving the local ``oc`` binary.
+
+    The binary path is resolved from ``config.target``, falling back to
+    ``~/bin/oc`` and then ``"oc"`` on ``$PATH``. Model /
+    provider flow from ``config.model`` / ``config.provider`` via the per-run
+    ``oc agent --model`` flag — never hardcoded, never the global
+    ``oc models set``.
+
+    Capabilities are delivered through openclaw's native channels: MCP servers
+    via an isolated ``OPENCLAW_CONFIG_PATH`` (``mcp.servers``), skills via
+    ``<OPENCLAW_STATE_DIR>/skills``, and rules prepended to the prompt.
+    ``__init__`` assigns ``self.rules``, ``self.mcp_servers`` and
+    ``self.skills``, so the agent structurally satisfies ``SupportsRules`` /
+    ``SupportsMcp`` / ``SupportsSkills``.
+
+    Args:
+        config: Typed :class:`AgentConfig`; defaults are used when omitted.
+        agent_name: ``oc`` agent profile (defaults to ``"main"``, openclaw's
+            built-in default agent, which exists in every config — including the
+            per-run isolated one written for MCP).
+    """
+
+    def __init__(self, config: AgentConfig | None = None, *, agent_name: str = "main") -> None:
+        AgentHarness.__init__(self, config)
+        self.agent_name = agent_name
+        caps = self.config.capabilities
+        self.rules = caps.rules
+        self.mcp_servers = caps.mcp_servers
+        self.skills = caps.skills
+
+    def _resolve_oc_bin(self) -> str:
+        """Pick the ``oc`` binary path from config or fall back."""
+        if self.config.target:
+            return os.path.expanduser(self.config.target)
+        candidate = os.path.expanduser("~/bin/oc")
+        return candidate if os.path.exists(candidate) else "oc"
+
+    def _execute(self, prompt: str, workspace_path: Path | None = None) -> AgentResult:
+        """Run ``oc agent --local`` with the granted capabilities and extract the trajectory.
+
+        The granted capabilities are laid down in ``workspace_path`` (the
+        harness-owned per-run workspace, when supplied, else a throwaway temp
+        dir this method owns) before invocation:
+
+        * ``<run>/state`` — ``OPENCLAW_STATE_DIR`` (sessions + skills root).
+        * ``<run>/state/skills/<name>/SKILL.md`` — one per discovered skill.
+        * ``<run>/openclaw.json`` — ``mcp.servers`` for each command-bearing MCP
+          binding, selected via ``OPENCLAW_CONFIG_PATH``.
+
+        ``rules.text`` is prepended to the prompt; the model API key is threaded
+        into the provider env var.
+        """
+        caps = self.config.capabilities
+        oc_bin = self._resolve_oc_bin()
+        final_prompt = _prepend_rules(caps.rules.text, prompt)
+
+        with agent_workdir(workspace_path, prefix="oc-run-") as workdir:
+            state_dir = workdir / _OPENCLAW_STATE_DIRNAME
+            state_dir.mkdir(parents=True, exist_ok=True)
+
+            materialize_skills(state_dir / _OPENCLAW_SKILLS_DIRNAME, caps.skills.paths)
+
+            env_overlay = _build_env(self.config)
+            env_overlay["OPENCLAW_STATE_DIR"] = str(state_dir)
+
+            config_payload = _build_openclaw_config(self.config, caps.mcp_servers)
+            if config_payload:
+                config_path = workdir / _OPENCLAW_CONFIG_FILE
+                config_path.write_text(json.dumps(config_payload, indent=2))
+                env_overlay["OPENCLAW_CONFIG_PATH"] = str(config_path)
+
+            command = _build_local_command(self.config, final_prompt, self.agent_name, oc_bin)
+
+            # TODO(follow-up): on timeout this SIGKILLs only the bash child,
+            # orphaning the oc/gcloud/kubectl/MCP process tree (which keeps
+            # consuming Vertex quota). Run in its own process group
+            # (start_new_session=True) and os.killpg(...) on timeout. Tracked as a
+            # separate, more intrusive change to generalize across all CLI agents.
+            try:
+                # bash -c (as argv, never shell=True) so nvm.sh can be sourced;
+                # every value interpolated into `command` is shlex.quoted.
+                completed = run(
+                    ["/bin/bash", "-c", command],
+                    cwd=str(workdir),
+                    extra_env=env_overlay,
+                    check=False,
+                    timeout=self.config.timeout_sec,
+                )
+            except SubprocessError:
+                # With check=False the only SubprocessError here is a timeout.
+                return AgentResult.errored(f"oc agent timed out after {self.config.timeout_sec}s")
+            except OSError as exc:
+                return AgentResult.errored(f"oc binary unavailable: {exc}")
+
+            stdout_text = _strip_ansi(completed.stdout or "")
+            errors: list[str] = []
+            metadata: dict = {}
+
+            if completed.returncode != 0:
+                stderr = (completed.stderr or "").strip()
+                errors.append(f"oc agent exited {completed.returncode}: {stderr or '<no stderr>'}")
+                metadata["returncode"] = completed.returncode
+
+            trajectory, tokens, bundle_output, export_errors = self._extract_trajectory(
+                oc_bin, env_overlay
+            )
+            errors.extend(export_errors)
+
+        # Bundle text is clean; bash stdout carries debug noise — fall back only if empty.
+        output = bundle_output if bundle_output else stdout_text
+
+        return AgentResult(
+            output=output,
+            trajectory=trajectory,
+            tokens=tokens,
+            errors=errors,
+            metadata=metadata,
+        )
+
+    def _extract_trajectory(
+        self, oc_bin: str, env_overlay: dict[str, str]
+    ) -> tuple[list[dict], dict, str, list[str]]:
+        """Run ``oc sessions`` + ``export-trajectory`` and parse the bundle.
+
+        ``env_overlay`` carries ``OPENCLAW_STATE_DIR`` (and ``OPENCLAW_CONFIG_PATH``
+        when MCP is configured) so the session commands read from the same
+        isolated state the agent turn wrote to.
+
+        Returns:
+            A ``(trajectory, tokens, output_text, errors)`` tuple. ``output_text``
+            is the agent's final answer parsed from the bundle's ``events.jsonl``
+            (``model.completed.assistantTexts``) when present, else ``""``; the
+            caller falls back to the ansi-stripped subprocess stdout when empty.
+        """
+        errors: list[str] = []
+        # The agent turn sources nvm inside a bash command, but these extraction
+        # calls run oc as a direct argv subprocess (no shell), so on nvm-managed
+        # hosts Node isn't on PATH -> `oc sessions` exits 127 and the trajectory
+        # is silently emptied. Make Node discoverable for the direct calls.
+        env_overlay = _ensure_node_on_path(env_overlay)
+        try:
+            sessions = run(
+                [oc_bin, "sessions", "--agent", self.agent_name, "--json"],
+                check=False,
+                timeout=self.config.timeout_sec,
+                extra_env=env_overlay,
+            )
+        except SubprocessError as exc:
+            errors.append(f"oc sessions failed: {exc}")
+            return [], {}, "", errors
+        except OSError as exc:
+            errors.append(f"oc sessions: binary unavailable: {exc}")
+            return [], {}, "", errors
+
+        if sessions.returncode != 0:
+            stderr = (sessions.stderr or "").strip()
+            errors.append(f"oc sessions exited {sessions.returncode}: {stderr or '<no stderr>'}")
+            return [], {}, "", errors
+
+        key = _pick_session_key(sessions.stdout or "")
+        if key is None:
+            errors.append("oc sessions returned no session key")
+            return [], {}, "", errors
+
+        with tempfile.TemporaryDirectory(prefix="oc-export-") as tmpdir:
+            workspace = Path(tmpdir)
+            try:
+                export = run(
+                    [
+                        oc_bin,
+                        "sessions",
+                        "export-trajectory",
+                        "--session-key",
+                        key,
+                        "--workspace",
+                        str(workspace),
+                        "--json",
+                    ],
+                    check=False,
+                    timeout=self.config.timeout_sec,
+                    extra_env=env_overlay,
+                )
+            except SubprocessError as exc:
+                errors.append(f"oc export-trajectory failed: {exc}")
+                return [], {}, "", errors
+            except OSError as exc:
+                errors.append(f"oc export-trajectory: binary unavailable: {exc}")
+                return [], {}, "", errors
+
+            if export.returncode != 0:
+                stderr = (export.stderr or "").strip()
+                errors.append(
+                    f"oc export-trajectory exited {export.returncode}: {stderr or '<no stderr>'}"
+                )
+                return [], {}, "", errors
+
+            events_text, read_errors = _read_export_bundle(workspace)
+            errors.extend(read_errors)
+            if not events_text:
+                return [], {}, "", errors
+
+            trajectory, tokens, output_text, parse_errors = parse_trajectory_export(events_text)
+            errors.extend(parse_errors)
+            return trajectory, tokens, output_text, errors

--- a/devops_bench/agents/cli/openclaw/parsing.py
+++ b/devops_bench/agents/cli/openclaw/parsing.py
@@ -1,0 +1,260 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parsers for OpenClaw ``oc sessions export-trajectory`` bundles.
+
+Folds the bundle's ``events.jsonl`` (dotted-``type`` events with a nested
+``data`` payload) into the canonical :class:`ToolCall` shape, locates the bundle
+on disk, and picks the session key from ``oc sessions --json`` output.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from devops_bench.agents.result import ToolCall
+from devops_bench.core import get_logger
+
+__all__ = ["parse_trajectory_export"]
+
+_log = get_logger("agents.cli.openclaw.parsing")
+
+# OpenClaw emits ANSI-colored debug logs to stdout. The escape codes add noise
+# to the text the judge grades, so strip them before returning the output.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def _join_text(content: object) -> str:
+    """Join the ``text`` parts of an OpenClaw message ``content`` value.
+
+    ``content`` is either a plain string or a list of typed parts
+    (``{"type": "text", "text": ...}`` / ``{"type": "toolCall", ...}``); only
+    text parts contribute, so tool-call blocks embedded in an assistant message
+    are ignored here (they ride on the dedicated ``tool.call`` events instead).
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            part["text"]
+            for part in content
+            if isinstance(part, dict) and isinstance(part.get("text"), str)
+        )
+    return ""
+
+
+def _accumulate_usage(acc: dict, usage: dict) -> None:
+    """Sum one turn's token usage into a running accumulator, in place.
+
+    OpenClaw emits a ``model.completed`` event per turn (per model call), each
+    carrying that turn's ``usage``, so the session total is the sum across turns
+    rather than the value of any single ``model.completed``. Numeric fields are
+    added; nested mappings (e.g. a ``cost`` breakdown) are summed recursively;
+    booleans and other non-numeric values are ignored.
+
+    Args:
+        acc: Accumulator mutated in place.
+        usage: A single turn's usage mapping.
+    """
+    for key, value in usage.items():
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)):
+            acc[key] = acc.get(key, 0) + value
+        elif isinstance(value, dict):
+            nested = acc.setdefault(key, {})
+            if isinstance(nested, dict):
+                _accumulate_usage(nested, value)
+
+
+def parse_trajectory_export(jsonl_text: str) -> tuple[list[dict], dict, str, list[str]]:
+    """Parse an ``oc sessions export-trajectory`` ``events.jsonl`` into the canonical shape.
+
+    The export bundle's ``events.jsonl`` is line-delimited JSON. Each line is an
+    event with a dotted ``type`` and an event-specific ``data`` payload:
+
+    - ``tool.call`` -> ``data.name`` / ``data.arguments`` / ``data.toolCallId``
+    - ``tool.result`` -> ``data.message`` with ``toolCallId`` + ``content[].text``
+      (+ ``isError`` / ``details.status``)
+    - ``model.completed`` -> ``data.usage`` (tokens) + ``data.assistantTexts``
+      (the agent's final answer)
+    - ``assistant.message`` -> ``data.message.content[].text`` (fallback output)
+
+    Matching ``tool.call`` / ``tool.result`` pairs (keyed on ``toolCallId``) fold
+    into one :class:`ToolCall` so the metrics layer sees the canonical trajectory
+    other agents emit. An unpaired ``tool.result`` (no matching call seen) is
+    **dropped** from the trajectory and reported on ``errors``, matching the API
+    agent's ``_fold_with_extraction_errors`` and the Gemini ``parse_stream_json``
+    policy.
+
+    Args:
+        jsonl_text: Raw contents of ``events.jsonl`` inside the export bundle.
+
+    Returns:
+        A ``(trajectory, tokens, output, errors)`` tuple. ``trajectory`` is a
+        list of ``ToolCall.to_dict()`` mappings; ``tokens`` is the usage summed
+        across every ``model.completed`` turn (not just the last); ``output`` is
+        the agent's final answer text (``""`` when none was found).
+    """
+    tokens: dict = {}
+    errors: list[str] = []
+    output = ""
+    fallback_output: list[str] = []
+    pending: dict[str, ToolCall] = {}
+    trajectory: list[ToolCall] = []
+
+    for lineno, raw in enumerate(jsonl_text.splitlines(), start=1):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as exc:
+            errors.append(f"events line {lineno} parse error: {exc}")
+            continue
+        if not isinstance(entry, dict):
+            continue
+
+        etype = entry.get("type") or entry.get("event")
+        data = entry.get("data")
+        if not isinstance(data, dict):
+            data = {}
+
+        if etype == "tool.call":
+            call_id = data.get("toolCallId") or data.get("id") or ""
+            args = data.get("arguments")
+            call = ToolCall(
+                name=data.get("name", ""),
+                args=args if isinstance(args, dict) else {},
+                status="called",
+            )
+            trajectory.append(call)
+            if call_id:
+                pending[str(call_id)] = call
+        elif etype == "tool.result":
+            msg = data.get("message") if isinstance(data.get("message"), dict) else data
+            call_id = msg.get("toolCallId") or msg.get("id") or ""
+            text = _join_text(msg.get("content"))
+            details = msg.get("details") if isinstance(msg.get("details"), dict) else {}
+            is_error = bool(msg.get("isError")) or (
+                str(details.get("status", "")).lower() in ("error", "failed", "failure")
+            )
+            target = pending.pop(str(call_id), None) if call_id else None
+            if target is None:
+                # Drop the orphan from the trajectory but surface it on errors.
+                # Synthesizing a free-floating result entry would break the
+                # "every trajectory item is a real ToolCall the model issued"
+                # invariant the metrics layer relies on; the API agent's
+                # ``_fold_with_extraction_errors`` and the Gemini stream-json
+                # parser both apply the same rule, so every agent feeds the
+                # metrics seam an identical canonical shape.
+                preview = text[:80].replace("\n", " ")
+                errors.append(
+                    f"events tool.result without matching call "
+                    f"(id={call_id!r}, content={preview!r})"
+                )
+                continue
+            target.result = text
+            target.status = "error" if is_error else "completed"
+        elif etype == "model.completed":
+            usage = data.get("usage")
+            if isinstance(usage, dict):
+                _accumulate_usage(tokens, usage)
+            texts = data.get("assistantTexts")
+            if isinstance(texts, list):
+                joined = "\n".join(t for t in texts if isinstance(t, str))
+                if joined:
+                    output = joined
+        elif etype == "assistant.message":
+            msg = data.get("message") if isinstance(data.get("message"), dict) else {}
+            txt = _join_text(msg.get("content"))
+            if txt:
+                fallback_output.append(txt)
+
+    if not output and fallback_output:
+        output = "\n".join(fallback_output)
+
+    return [call.to_dict() for call in trajectory], tokens, output, errors
+
+
+def _read_export_bundle(workspace: Path) -> tuple[str, list[str]]:
+    """Locate and read ``events.jsonl`` inside an ``export-trajectory`` bundle.
+
+    The bundle is written under
+    ``<workspace>/.openclaw/trajectory-exports/openclaw-trajectory-<id>-<ts>/``;
+    the trajectory itself is ``events.jsonl`` (siblings: ``manifest.json``,
+    ``tools.json``, ``metadata.json``, ...). There is exactly one export per run,
+    so a recursive glob suffices. The final answer + token usage are parsed out
+    of ``events.jsonl`` (``model.completed`` / ``assistant.message``), so no
+    separate output file is read.
+
+    Args:
+        workspace: Workspace dir handed to ``oc sessions export-trajectory --workspace``.
+
+    Returns:
+        A ``(events_jsonl, errors)`` tuple. ``events_jsonl`` is empty when the
+        bundle or file is missing; the miss is recorded on ``errors``.
+    """
+    errors: list[str] = []
+    export_root = workspace / ".openclaw" / "trajectory-exports"
+    if not export_root.exists():
+        errors.append(f"export-trajectory bundle missing: {export_root}")
+        return "", errors
+
+    event_files = sorted(export_root.rglob("events.jsonl"))
+    if not event_files:
+        errors.append(f"no events.jsonl under {export_root}")
+        return "", errors
+    try:
+        return event_files[0].read_text(encoding="utf-8"), errors
+    except OSError as exc:
+        errors.append(f"failed to read {event_files[0]}: {exc}")
+        return "", errors
+
+
+def _pick_session_key(sessions_json: str) -> str | None:
+    """Return the single session key from ``oc sessions --json`` output, or ``None``.
+
+    The output may be a list of rows or a wrapper dict with a ``sessions``
+    list (per ``docs/openclaw/sessions.md``). Because each run uses fresh
+    isolated state, exactly one row is expected; if more than one is present
+    the first is taken (with a debug log).
+
+    Args:
+        sessions_json: Raw stdout from ``oc sessions --agent <name> --json``.
+
+    Returns:
+        The ``key`` field of the chosen session, or ``None`` if parsing
+        failed or no sessions were returned.
+    """
+    try:
+        data = json.loads(sessions_json)
+    except json.JSONDecodeError:
+        return None
+    rows = data.get("sessions") if isinstance(data, dict) else data
+    if not isinstance(rows, list) or not rows:
+        return None
+    if len(rows) > 1:
+        _log.debug("oc sessions returned %d rows; using the first", len(rows))
+    first = rows[0]
+    if not isinstance(first, dict):
+        return None
+    key = first.get("key")
+    return key if isinstance(key, str) and key else None

--- a/devops_bench/agents/shared/__init__.py
+++ b/devops_bench/agents/shared/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers shared across agent implementations (API and CLI).
+
+Utilities here are agent-flavour-agnostic so neither the API agent nor a CLI
+agent has to reach into the other's package. Importing this package pulls no
+provider SDK, ``mcp``, or ``deepeval``.
+"""

--- a/devops_bench/agents/shared/cli_capabilities.py
+++ b/devops_bench/agents/shared/cli_capabilities.py
@@ -1,0 +1,164 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Capability materialization shared by the CLI agents (Gemini, openclaw).
+
+Both CLI agents render granted MCP bindings into a ``{name: {command, args}}``
+launch map and copy discovered ``SKILL.md`` files into the binary's workspace
+skills tree. Importing this module pulls no provider SDK.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from devops_bench.agents.shared.skills import parse_skill_md
+from devops_bench.core import get_logger
+
+if TYPE_CHECKING:
+    from devops_bench.agents.capabilities import McpBinding
+
+__all__ = ["agent_workdir", "build_mcp_servers", "materialize_skills"]
+
+_log = get_logger("agents.shared.cli_capabilities")
+
+_SKILL_FILE = "SKILL.md"
+
+
+@contextlib.contextmanager
+def agent_workdir(workspace_path: Path | None, *, prefix: str) -> Iterator[Path]:
+    """Yield the directory a CLI agent subprocess should run in.
+
+    When the harness supplies ``workspace_path`` (its own per-run workspace,
+    kept alive across the run so artifact collection can diff it afterward),
+    that directory is yielded as-is and is NOT cleaned up here — the harness
+    owns its lifecycle. Otherwise a throwaway ``TemporaryDirectory`` is
+    created and removed on exit, preserving each CLI agent's standalone
+    behavior (e.g. a direct unit-test invocation with no harness workspace).
+
+    Args:
+        workspace_path: The harness-owned workspace directory, or ``None``.
+        prefix: Prefix for the fallback temp directory's name.
+
+    Yields:
+        The directory the CLI agent subprocess should run in.
+    """
+    if workspace_path is not None:
+        yield workspace_path
+        return
+    with tempfile.TemporaryDirectory(prefix=prefix) as tmpdir:
+        yield Path(tmpdir)
+
+
+def build_mcp_servers(mcp_servers: tuple[McpBinding, ...]) -> dict[str, dict]:
+    """Map MCP bindings with a launch command to a CLI ``servers`` mapping.
+
+    Bindings with an empty ``command`` are skipped: a CLI needs a command to
+    spawn a stdio MCP server, and an empty-command binding denotes a server the
+    binary already hosts itself.
+
+    If the command is path-like (contains a path separator) and exists on disk,
+    it is resolved to its absolute path to prevent execution ambiguity in the
+    agent's workspace. If it does not exist, a warning is logged.
+
+    Args:
+        mcp_servers: Bindings granted for the run.
+
+    Returns:
+        A ``{name: {"command": ..., "args": [...]}}`` mapping suitable for the
+        agent's MCP-servers config section. Empty when no binding carries a
+        command.
+    """
+    servers: dict[str, dict] = {}
+    for index, binding in enumerate(mcp_servers):
+        if not binding.command:
+            continue
+        name = binding.name or f"mcp{index}"
+        cmd = binding.command[0]
+        if os.sep in cmd:
+            if os.path.exists(cmd):
+                cmd = os.path.abspath(cmd)
+            else:
+                _log.warning(
+                    "Path-like MCP command '%s' not found relative to harness; passing unchanged",
+                    cmd,
+                )
+        entry: dict = {"command": cmd}
+        if len(binding.command) > 1:
+            entry["args"] = list(binding.command[1:])
+        servers[name] = entry
+    return servers
+
+
+def materialize_skills(skills_root: Path, paths: tuple[str, ...]) -> list[str]:
+    """Copy discovered ``SKILL.md`` files into a CLI's workspace skills tree.
+
+    For each ``SKILL.md`` found beneath ``paths`` (the same discovery the API
+    agent performs), the file is written to ``skills_root/<name>/SKILL.md`` using
+    the ``name`` from its frontmatter.
+
+    The frontmatter ``name`` must be a bare directory name: anything carrying a
+    path separator, ``..``, or an absolute prefix would escape ``skills_root``,
+    so such skills are warned and skipped rather than written. When two skill
+    files share a name, the first discovered wins and later ones are warned
+    and skipped rather than silently overwriting it.
+
+    Args:
+        skills_root: The destination skills directory to populate.
+        paths: Skill source directories to walk recursively. Missing paths are
+            warned and skipped (matching the API agent's discovery semantic).
+
+    Returns:
+        The names of the skills materialized, in discovery order.
+    """
+    written: list[str] = []
+    for raw_path in paths:
+        if not raw_path:
+            continue
+        source = Path(os.path.expanduser(raw_path))
+        if not source.exists():
+            _log.warning("Skills directory not found: %s", source)
+            continue
+        for skill_file in sorted(source.rglob(_SKILL_FILE)):
+            name, _description, content = parse_skill_md(str(skill_file))
+            if not name or content is None:
+                continue
+            # Path("..").name is ".." itself, so ".." needs its own rejection.
+            if name == ".." or name != Path(name).name:
+                _log.warning(
+                    "Skipping skill %r from %s: name must not contain path separators, "
+                    "'..', or an absolute prefix",
+                    name,
+                    skill_file,
+                )
+                continue
+            if name in written:
+                _log.warning(
+                    "Skipping duplicate skill %r from %s: already materialized from an "
+                    "earlier source",
+                    name,
+                    skill_file,
+                )
+                continue
+            dest_dir = skills_root / name
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            (dest_dir / _SKILL_FILE).write_text(content, encoding="utf-8")
+            written.append(name)
+            _log.info("Linked skill %s -> %s", name, dest_dir)
+    return written

--- a/devops_bench/agents/shared/skills.py
+++ b/devops_bench/agents/shared/skills.py
@@ -1,0 +1,82 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Frontmatter parsing for ``SKILL.md`` files, shared by every agent.
+
+Both the API agent (advertising skills as synthetic tools) and the CLI agents
+(materializing skills into the launched CLI) need a skill file's ``name`` and
+``description``; keeping the parser here lets either import it without reaching
+into the other's package. Importing this module pulls no provider SDK.
+"""
+
+from __future__ import annotations
+
+import re
+
+from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
+
+from devops_bench.core import get_logger
+
+__all__ = ["parse_skill_md"]
+
+_log = get_logger("agents.shared.skills")
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL | re.MULTILINE)
+
+# YAML 1.2 semantics (matching tasks/loader.py): only ``true``/``false`` are
+# booleans, so a description like ``yes`` stays a plain string.
+_yaml = YAML(typ="safe")
+
+
+def parse_skill_md(file_path: str) -> tuple[str | None, str | None, str | None]:
+    """Parse a ``SKILL.md`` file's YAML frontmatter.
+
+    The frontmatter block is parsed as safe YAML, so multi-line block scalars
+    (e.g. a ``description: >-`` spanning several lines) are read in full
+    rather than truncated to the first line.
+
+    Args:
+        file_path: Path to a skill markdown file.
+
+    Returns:
+        A ``(name, description, content)`` tuple. ``name``/``description`` are
+        ``None`` when the field is absent; ``content`` is the full file text, or
+        ``None`` when the file is unreadable or carries no frontmatter block.
+    """
+    try:
+        with open(file_path, encoding="utf-8") as f:
+            content = f.read()
+    except OSError as exc:
+        _log.warning("Error parsing skill file %s: %s", file_path, exc)
+        return None, None, None
+
+    match = _FRONTMATTER_RE.search(content)
+    if not match:
+        return None, None, None
+
+    try:
+        frontmatter = _yaml.load(match.group(1))
+    except YAMLError as exc:
+        _log.warning("Invalid YAML frontmatter in skill file %s: %s", file_path, exc)
+        return None, None, content
+
+    if not isinstance(frontmatter, dict):
+        return None, None, content
+
+    name = frontmatter.get("name")
+    description = frontmatter.get("description")
+    name = str(name).strip() if name is not None else None
+    description = str(description).strip() if description is not None else None
+    return name, description, content

--- a/devops_bench/models/claude.py
+++ b/devops_bench/models/claude.py
@@ -1,0 +1,249 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Anthropic (Claude) adapter for the LLM client interface.
+
+Claude is reachable through three backends; this adapter selects one from the
+environment so the ``claude`` provider key (alias ``anthropic``) names the model
+family rather than a single transport:
+
+- ``api`` — the first-party Anthropic API (``AsyncAnthropic``), the canonical
+  default, selected when ``AGENT_API_KEY``/``ANTHROPIC_API_KEY`` is set.
+- ``vertex`` — Claude on Google Vertex AI (``AsyncAnthropicVertex``), selected
+  when ``GCP_PROJECT_ID`` is set, and the fallback when nothing else matches.
+- ``bedrock`` — Claude on Amazon Bedrock (``AsyncAnthropicBedrock``), selected
+  when ``AWS_REGION``/``AWS_DEFAULT_REGION`` is set.
+
+Set ``ANTHROPIC_BACKEND`` to force a backend regardless of the inference above.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from devops_bench.core.config import first_env, get_env, get_int
+from devops_bench.core.errors import ConfigError, MissingDependencyError
+from devops_bench.core.logging import get_logger
+from devops_bench.models.base import MODELS, LLMClient
+
+try:
+    from anthropic import AsyncAnthropic, AsyncAnthropicBedrock, AsyncAnthropicVertex
+except ImportError:  # pragma: no cover - exercised only without the SDK
+    AsyncAnthropic = None
+    AsyncAnthropicBedrock = None
+    AsyncAnthropicVertex = None
+
+__all__ = ["ClaudeClientAdapter"]
+
+_DEFAULT_MAX_TOKENS = 16000
+
+# Per-backend default models. The model-id format is backend-specific, so each
+# backend carries its own default; Bedrock ids are region/version-specific and
+# have no safe universal default, so it requires AGENT_MODEL.
+_DEFAULT_MODELS = {
+    "api": "claude-sonnet-4-5",
+    "vertex": "claude-sonnet-4-5@20250929",
+}
+_BACKENDS = frozenset({"api", "vertex", "bedrock"})
+
+_log = get_logger("models.claude")
+
+
+@MODELS.register("claude")
+class ClaudeClientAdapter(LLMClient):
+    """Adapter for the Anthropic SDK across its three backends.
+
+    The backend (first-party API, Vertex AI, or Bedrock) is chosen from the
+    environment; see the module docstring for the selection rules.
+
+    Args:
+        model_name: Model override; falls back to ``AGENT_MODEL`` and then a
+            backend-specific default when omitted.
+        max_tokens: Per-response output token cap; falls back to
+            ``AGENT_MAX_TOKENS`` and then a sane default when omitted.
+        backend: Backend hint from the provider contract (``"vertex"`` /
+            ``"bedrock"``); overrides env inference. ``None`` infers from the
+            environment (the bare ``anthropic`` provider).
+
+    Raises:
+        MissingDependencyError: If the ``anthropic`` SDK is not installed.
+        ConfigError: If ``ANTHROPIC_BACKEND`` is unrecognized, or the ``bedrock``
+            backend is selected without ``AGENT_MODEL`` set.
+    """
+
+    def __init__(
+        self,
+        model_name: str | None = None,
+        max_tokens: int | None = None,
+        *,
+        backend: str | None = None,
+    ) -> None:
+        if AsyncAnthropic is None:
+            raise MissingDependencyError("the Anthropic model adapter", "anthropic")
+
+        # An explicit backend hint from the provider contract
+        # (``anthropic-vertex`` -> ``vertex``, ``anthropic-bedrock`` -> ``bedrock``)
+        # wins, decoupling Vertex/Bedrock auth from API-key presence; the bare
+        # ``anthropic`` provider passes ``None`` and still infers from the env.
+        backend = backend or self._select_backend()
+
+        if not model_name:
+            model_name = get_env("AGENT_MODEL", _DEFAULT_MODELS.get(backend))
+        if not model_name:
+            raise ConfigError(
+                f"the Anthropic {backend!r} backend has no default model; set AGENT_MODEL"
+            )
+
+        self.client = self._build_client(backend)
+        self.model_name = model_name
+        self.max_tokens = max_tokens or get_int("AGENT_MAX_TOKENS", _DEFAULT_MAX_TOKENS)
+
+    @staticmethod
+    def _select_backend() -> str:
+        """Resolve which backend to use from the environment.
+
+        Returns:
+            One of ``"api"``, ``"vertex"``, or ``"bedrock"``.
+
+        Raises:
+            ConfigError: If ``ANTHROPIC_BACKEND`` is set to an unknown value.
+        """
+        override = get_env("ANTHROPIC_BACKEND")
+        if override:
+            backend = override.lower()
+            if backend not in _BACKENDS:
+                raise ConfigError(
+                    f"ANTHROPIC_BACKEND must be one of {sorted(_BACKENDS)}; got {override!r}"
+                )
+            return backend
+
+        if first_env("AGENT_API_KEY", "ANTHROPIC_API_KEY"):
+            return "api"
+        if get_env("GCP_PROJECT_ID"):
+            return "vertex"
+        if first_env("AWS_REGION", "AWS_DEFAULT_REGION"):
+            return "bedrock"
+
+        _log.warning(
+            "No Anthropic backend could be inferred from the environment; "
+            "defaulting to Vertex. Set ANTHROPIC_BACKEND, AGENT_API_KEY, "
+            "GCP_PROJECT_ID, or AWS_REGION to select one explicitly.",
+        )
+        return "vertex"
+
+    @staticmethod
+    def _build_client(backend: str) -> Any:
+        """Construct the SDK client for the selected backend."""
+        if backend == "api":
+            return AsyncAnthropic(api_key=first_env("AGENT_API_KEY", "ANTHROPIC_API_KEY"))
+        if backend == "bedrock":
+            return AsyncAnthropicBedrock(aws_region=first_env("AWS_REGION", "AWS_DEFAULT_REGION"))
+        # vertex
+        return AsyncAnthropicVertex(
+            region=get_env("GCP_VERTEX_LOCATION", "global"),
+            project_id=get_env("GCP_PROJECT_ID"),
+        )
+
+    async def generate_content(
+        self,
+        contents: list[dict[str, Any]],
+        tools: Any,
+        system_instruction: str | None,
+    ) -> Any:
+        messages = self._convert_to_anthropic_messages(contents)
+        kwargs: dict[str, Any] = {
+            "model": self.model_name,
+            "max_tokens": self.max_tokens,
+            "messages": messages,
+        }
+        if tools:
+            kwargs["tools"] = tools
+        if system_instruction:
+            kwargs["system"] = system_instruction
+        return await self.client.messages.create(**kwargs)
+
+    def format_tools(self, mcp_tools: Any) -> Any:
+        return [
+            {
+                "name": tool.name,
+                "description": tool.description,
+                "input_schema": tool.inputSchema if hasattr(tool, "inputSchema") else {},
+            }
+            for tool in mcp_tools
+        ]
+
+    def extract_function_calls(self, response: Any) -> list[dict[str, Any]]:
+        calls: list[dict[str, Any]] = []
+        if hasattr(response, "content"):
+            for content in response.content:
+                if hasattr(content, "type") and content.type == "tool_use":
+                    calls.append({"name": content.name, "args": content.input, "id": content.id})
+        return calls
+
+    def get_text_content(self, response: Any) -> str:
+        text = ""
+        if hasattr(response, "content"):
+            for content in response.content:
+                if hasattr(content, "type") and content.type == "text":
+                    text += content.text
+        return text
+
+    def _convert_to_anthropic_messages(
+        self, contents: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        anthropic_messages: list[dict[str, Any]] = []
+        for msg in contents:
+            role = msg["role"]
+            content = msg["content"]
+
+            if role == "user":
+                anthropic_messages.append({"role": "user", "content": content})
+            elif role == "assistant":
+                if "tool_calls" in msg:
+                    content_blocks: list[dict[str, Any]] = []
+                    if content:
+                        content_blocks.append({"type": "text", "text": content})
+                    for tc in msg["tool_calls"]:
+                        content_blocks.append(
+                            {
+                                "type": "tool_use",
+                                "id": tc.get("id"),
+                                "name": tc.get("name"),
+                                "input": tc.get("args"),
+                            }
+                        )
+                    anthropic_messages.append({"role": "assistant", "content": content_blocks})
+                else:
+                    anthropic_messages.append({"role": "assistant", "content": content})
+            elif role == "tool":
+                # Group consecutive tool results into one user message so that
+                # parallel tool calls do not produce back-to-back user turns,
+                # which the Anthropic API rejects.
+                tool_block = {
+                    "type": "tool_result",
+                    "tool_use_id": msg.get("tool_call_id"),
+                    "content": content,
+                }
+                if anthropic_messages and anthropic_messages[-1]["role"] == "user":
+                    last = anthropic_messages[-1]["content"]
+                    if isinstance(last, list):
+                        last.append(tool_block)
+                    else:
+                        anthropic_messages[-1]["content"] = [
+                            {"type": "text", "text": last},
+                            tool_block,
+                        ]
+                else:
+                    anthropic_messages.append({"role": "user", "content": [tool_block]})
+        return anthropic_messages

--- a/devops_bench/models/gemini.py
+++ b/devops_bench/models/gemini.py
@@ -1,0 +1,366 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gemini (google-genai) adapter for the LLM client interface."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import random
+from typing import Any
+
+from devops_bench.core.config import get_env
+from devops_bench.core.errors import MissingDependencyError
+from devops_bench.core.logging import get_logger
+from devops_bench.models.base import MODELS, LLMClient
+
+try:
+    from google import genai
+    from google.genai import types
+except ImportError:  # pragma: no cover - exercised only without the SDK
+    genai = None
+    types = None
+
+__all__ = ["GeminiClientAdapter", "filter_schema_for_gemini"]
+
+_log = get_logger("models.gemini")
+
+# Bounded exponential backoff for transient Vertex/Gemini failures. A single
+# unretried 429 (RESOURCE_EXHAUSTED) is the dominant flash failure mode and
+# otherwise hard-fails the whole run.
+_MAX_RETRIES = 5
+_BASE_DELAY_SEC = 1.0
+_MAX_DELAY_SEC = 30.0
+_RETRYABLE_STATUS = frozenset({429, 503})
+_RETRYABLE_TOKENS = ("RESOURCE_EXHAUSTED", "UNAVAILABLE", "429", "503")
+
+
+def _is_retryable(exc: Exception) -> bool:
+    """Whether a Gemini API error is a transient quota/availability failure.
+
+    Retries HTTP 429 (RESOURCE_EXHAUSTED) and 503 (UNAVAILABLE), matched on the
+    SDK error's ``code`` attribute when present and falling back to the message
+    text (the SDK surfaces the status in the string for wrapped errors).
+
+    Args:
+        exc: The exception raised by the SDK call.
+
+    Returns:
+        True if the call is worth retrying.
+    """
+    code = getattr(exc, "code", None)
+    if code in _RETRYABLE_STATUS:
+        return True
+    text = str(exc)
+    return any(token in text for token in _RETRYABLE_TOKENS)
+
+
+def _backoff_delay(attempt: int) -> float:
+    """Full-jitter exponential backoff delay for ``attempt`` (0-based)."""
+    ceiling = min(_MAX_DELAY_SEC, _BASE_DELAY_SEC * (2**attempt))
+    return random.uniform(0.0, ceiling)
+
+
+_SUPPORTED_SCHEMA_FIELDS = frozenset(
+    {
+        "type",
+        "format",
+        "description",
+        "nullable",
+        "enum",
+        "items",
+        "properties",
+        "required",
+        "minItems",
+        "maxItems",
+        "minimum",
+        "maximum",
+        "$ref",
+        "ref",
+    }
+)
+
+_SCHEMA_FIELD_NAMES = ("items",)
+_LIST_SCHEMA_FIELD_NAMES = ("anyOf", "any_of", "oneOf", "one_of")
+_DICT_SCHEMA_FIELD_NAMES = ("properties", "defs", "$defs")
+
+# Output keys are normalized to the spelling google-genai's Schema accepts:
+# the SDK rejects "$defs"/"$ref" (its fields are named "defs"/"ref") and has
+# no oneOf field at all, so oneOf collapses into anyOf — for a tool-call
+# schema the exclusivity distinction carries no weight, the model picks one
+# branch either way.
+_SCHEMA_KEY_ALIASES = {
+    "any_of": "anyOf",
+    "oneOf": "anyOf",
+    "one_of": "anyOf",
+    "$defs": "defs",
+    "$ref": "ref",
+}
+
+# The definitions container is renamed to "defs", so pointer values into it
+# must be rewritten to match ("ref: #/defs/Pet" per the Schema field docs).
+_DEFS_POINTER_PREFIX = "#/$defs/"
+_DEFS_POINTER_REPLACEMENT = "#/defs/"
+
+
+def _normalize_ref_value(value: Any) -> Any:
+    """Rewrite a ``$ref`` pointer aimed at ``$defs`` to aim at ``defs``."""
+    if isinstance(value, str) and value.startswith(_DEFS_POINTER_PREFIX):
+        return _DEFS_POINTER_REPLACEMENT + value[len(_DEFS_POINTER_PREFIX) :]
+    return value
+
+
+def filter_schema_for_gemini(schema: Any) -> Any:
+    """Filter a JSON schema down to the subset supported by the Gemini API.
+
+    Recursively drops unsupported fields, upper-cases ``type`` values, and maps
+    nullable union types (``["string", "null"]``) to ``nullable: True``. Key
+    aliases are normalized to the spellings ``google-genai``'s ``Schema``
+    validates (see ``_SCHEMA_KEY_ALIASES``); values landing on the same
+    normalized key (e.g. ``oneOf`` collapsing into an existing ``anyOf``) are
+    merged.
+
+    Args:
+        schema: A JSON schema fragment (dict, bool, or scalar).
+
+    Returns:
+        The filtered schema. Returns ``{}`` for ``True``, ``None`` for
+        ``False``, and non-dict inputs unchanged.
+    """
+    if isinstance(schema, bool):
+        return {} if schema else None
+    if not isinstance(schema, dict):
+        return schema
+
+    filtered_schema: dict[str, Any] = {}
+    for field_name, field_value in schema.items():
+        if field_name == "type":
+            if isinstance(field_value, list):
+                if "null" in field_value:
+                    filtered_schema["nullable"] = True
+                    non_null_types = [t for t in field_value if t != "null"]
+                    if non_null_types:
+                        filtered_schema["type"] = non_null_types[0].upper()
+                    else:
+                        filtered_schema["type"] = "NULL"
+                elif field_value:
+                    filtered_schema["type"] = field_value[0].upper()
+            elif isinstance(field_value, str):
+                filtered_schema["type"] = field_value.upper()
+        elif field_name in _SCHEMA_FIELD_NAMES:
+            filtered_value = filter_schema_for_gemini(field_value)
+            if filtered_value is not None:
+                filtered_schema[field_name] = filtered_value
+        elif field_name in _LIST_SCHEMA_FIELD_NAMES:
+            out_name = _SCHEMA_KEY_ALIASES.get(field_name, field_name)
+            if isinstance(field_value, list):
+                filtered_value = [
+                    v
+                    for v in (filter_schema_for_gemini(value) for value in field_value)
+                    if v is not None
+                ]
+            else:
+                filtered_value = field_value
+            existing = filtered_schema.get(out_name)
+            if isinstance(existing, list) and isinstance(filtered_value, list):
+                existing.extend(filtered_value)
+            else:
+                filtered_schema[out_name] = filtered_value
+        elif field_name in _DICT_SCHEMA_FIELD_NAMES:
+            out_name = _SCHEMA_KEY_ALIASES.get(field_name, field_name)
+            if isinstance(field_value, dict):
+                filtered_dict: dict[str, Any] = {}
+                for key, value in field_value.items():
+                    filtered_value = filter_schema_for_gemini(value)
+                    if filtered_value is not None:
+                        filtered_dict[key] = filtered_value
+                existing_dict = filtered_schema.get(out_name)
+                if isinstance(existing_dict, dict):
+                    existing_dict.update(filtered_dict)
+                else:
+                    filtered_schema[out_name] = filtered_dict
+            else:
+                filtered_schema[out_name] = field_value
+        elif field_name in _SUPPORTED_SCHEMA_FIELDS:
+            out_name = _SCHEMA_KEY_ALIASES.get(field_name, field_name)
+            if out_name == "ref":
+                field_value = _normalize_ref_value(field_value)
+            filtered_schema[out_name] = field_value
+
+    return filtered_schema
+
+
+@MODELS.register("gemini")
+class GeminiClientAdapter(LLMClient):
+    """Adapter for the Gemini SDK (google-genai).
+
+    The backend is chosen from the ``backend`` hint and the environment:
+    ``backend="vertex"`` (the ``google-vertex`` provider) forces Vertex AI;
+    otherwise an explicit ``AGENT_API_KEY`` takes precedence, then Vertex via
+    ``GCP_PROJECT_ID``, otherwise the SDK's default credential resolution.
+
+    Args:
+        model_name: Model override; falls back to ``AGENT_MODEL`` when omitted.
+        backend: Backend hint from the provider contract; ``"vertex"`` forces
+            Vertex AI, ``None`` infers from the environment.
+
+    Raises:
+        MissingDependencyError: If the ``google-genai`` SDK is not installed.
+    """
+
+    def __init__(self, model_name: str | None = None, *, backend: str | None = None) -> None:
+        if genai is None:
+            raise MissingDependencyError("the Gemini model adapter", "google-genai")
+
+        if not model_name:
+            model_name = get_env("AGENT_MODEL", "gemini-3.1-pro-preview")
+
+        project_id = get_env("GCP_PROJECT_ID")
+        location = get_env("GCP_VERTEX_LOCATION", "global")
+        api_key = get_env("AGENT_API_KEY")
+
+        # ``backend == "vertex"`` (the ``google-vertex`` provider) forces Vertex
+        # AI regardless of an API key, so the provider — not key presence —
+        # decides the backend. Otherwise infer as before.
+        if backend == "vertex":
+            self.client = genai.Client(vertexai=True, project=project_id, location=location)
+        elif api_key:
+            self.client = genai.Client(api_key=api_key)
+        elif project_id:
+            self.client = genai.Client(vertexai=True, project=project_id, location=location)
+        else:
+            self.client = genai.Client()
+
+        self.model_name = model_name
+
+    async def generate_content(
+        self,
+        contents: list[dict[str, Any]],
+        tools: Any,
+        system_instruction: str | None,
+    ) -> Any:
+        gemini_contents = self._convert_to_gemini_messages(contents)
+
+        config_args: dict[str, Any] = {}
+        if system_instruction is not None:
+            config_args["system_instruction"] = system_instruction
+        if tools and hasattr(tools, "function_declarations") and tools.function_declarations:
+            config_args["tools"] = [tools]
+
+        config = types.GenerateContentConfig(**config_args)
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                return await self.client.aio.models.generate_content(
+                    model=self.model_name,
+                    contents=gemini_contents,
+                    config=config,
+                )
+            except Exception as exc:  # noqa: BLE001 - retry transient, re-raise the rest
+                if attempt >= _MAX_RETRIES or not _is_retryable(exc):
+                    raise
+                delay = _backoff_delay(attempt)
+                _log.warning(
+                    "gemini generate_content transient failure (%s); retry %d/%d in %.1fs",
+                    exc,
+                    attempt + 1,
+                    _MAX_RETRIES,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+        # Unreachable: the final attempt either returns or re-raises above.
+        raise AssertionError("unreachable: generate_content retry loop exhausted")
+
+    def format_tools(self, mcp_tools: Any) -> Any:
+        return types.Tool(
+            function_declarations=[
+                {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": (
+                        filter_schema_for_gemini(tool.inputSchema)
+                        if hasattr(tool, "inputSchema") and isinstance(tool.inputSchema, dict)
+                        else None
+                    ),
+                }
+                for tool in mcp_tools
+            ]
+        )
+
+    def extract_function_calls(self, response: Any) -> list[dict[str, Any]]:
+        calls: list[dict[str, Any]] = []
+        candidates = response.candidates
+        if candidates and candidates[0].content and candidates[0].content.parts:
+            for part in candidates[0].content.parts:
+                if part.function_call:
+                    fc = part.function_call
+                    call_info: dict[str, Any] = {"name": fc.name, "args": fc.args, "id": None}
+                    sig = getattr(part, "thought_signature", None)
+                    if sig:
+                        call_info["thought_signature"] = base64.b64encode(sig).decode("utf-8")
+                    calls.append(call_info)
+        return calls
+
+    def get_text_content(self, response: Any) -> str:
+        try:
+            return response.text or ""
+        except (ValueError, AttributeError):
+            parts = []
+            cands = getattr(response, "candidates", None)
+            if cands and cands[0].content and cands[0].content.parts:
+                parts = [p.text for p in cands[0].content.parts if getattr(p, "text", None)]
+            return "".join(parts)
+
+    def _convert_to_gemini_messages(self, contents: list[dict[str, Any]]) -> list[Any]:
+        gemini_contents = []
+        for msg in contents:
+            role = msg["role"]
+            content = msg["content"]
+
+            if role == "user":
+                gemini_contents.append(
+                    types.Content(role="user", parts=[types.Part.from_text(text=content)])
+                )
+            elif role == "assistant":
+                parts = []
+                if content:
+                    parts.append(types.Part.from_text(text=content))
+                if "tool_calls" in msg:
+                    for tc in msg["tool_calls"]:
+                        if "thought_signature" in tc:
+                            parts.append(
+                                types.Part(
+                                    function_call=types.FunctionCall(
+                                        name=tc["name"], args=tc["args"]
+                                    ),
+                                    thought_signature=base64.b64decode(tc["thought_signature"]),
+                                )
+                            )
+                        else:
+                            parts.append(
+                                types.Part.from_function_call(name=tc["name"], args=tc["args"])
+                            )
+                gemini_contents.append(types.Content(role="model", parts=parts))
+            elif role == "tool":
+                # Group consecutive tool results into the previous user Content
+                # so parallel tool results do not produce back-to-back user
+                # turns, which the Gemini API rejects.
+                part = types.Part.from_function_response(
+                    name=msg["name"], response={"result": content}
+                )
+                if gemini_contents and gemini_contents[-1].role == "user":
+                    gemini_contents[-1].parts.append(part)
+                else:
+                    gemini_contents.append(types.Content(role="user", parts=[part]))
+        return gemini_contents

--- a/devops_bench/models/ollama.py
+++ b/devops_bench/models/ollama.py
@@ -1,0 +1,163 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ollama adapter (OpenAI-compatible API) for the LLM client interface."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from devops_bench.core.config import get_env
+from devops_bench.core.errors import MissingDependencyError
+from devops_bench.models.base import MODELS, LLMClient
+
+try:
+    from openai import AsyncOpenAI
+except ImportError:  # pragma: no cover - exercised only without the SDK
+    AsyncOpenAI = None
+
+__all__ = ["OllamaClientAdapter"]
+
+_DEFAULT_MODEL = "gemma4:2b"
+_DEFAULT_BASE_URL = "http://localhost:11434/v1"
+
+
+@MODELS.register("ollama")
+class OllamaClientAdapter(LLMClient):
+    """Adapter for an Ollama server via its OpenAI-compatible API.
+
+    Talks to a locally (or remotely) hosted Ollama instance through the
+    ``openai`` client. The endpoint is read from ``OLLAMA_BASE_URL`` and the
+    model from ``AGENT_MODEL``.
+
+    Args:
+        model_name: Model override; falls back to ``AGENT_MODEL`` when omitted.
+        base_url: Endpoint override; falls back to ``OLLAMA_BASE_URL`` and then
+            the local default when omitted.
+        backend: Accepted for a uniform adapter signature; ignored (Ollama has no
+            backend variants).
+
+    Raises:
+        MissingDependencyError: If the ``openai`` SDK is not installed.
+    """
+
+    def __init__(
+        self,
+        model_name: str | None = None,
+        base_url: str | None = None,
+        *,
+        backend: str | None = None,
+    ) -> None:
+        if AsyncOpenAI is None:
+            raise MissingDependencyError("the Ollama model adapter", "openai")
+
+        if not model_name:
+            model_name = get_env("AGENT_MODEL", _DEFAULT_MODEL)
+        if not base_url:
+            base_url = get_env("OLLAMA_BASE_URL", _DEFAULT_BASE_URL)
+
+        # Ollama supports optional key-based auth (e.g. a remote/hosted endpoint);
+        # use ``AGENT_API_KEY`` when set, else a dummy the local server ignores
+        # (the openai client requires a non-empty key).
+        api_key = get_env("AGENT_API_KEY") or "ollama"
+        self.client = AsyncOpenAI(base_url=base_url, api_key=api_key)
+        self.model_name = model_name
+
+    async def generate_content(
+        self,
+        contents: list[dict[str, Any]],
+        tools: Any,
+        system_instruction: str | None,
+    ) -> Any:
+        messages = self._convert_to_openai_messages(contents, system_instruction)
+        kwargs: dict[str, Any] = {"model": self.model_name, "messages": messages}
+        if tools:
+            kwargs["tools"] = tools
+        return await self.client.chat.completions.create(**kwargs)
+
+    def format_tools(self, mcp_tools: Any) -> Any:
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": tool.inputSchema if hasattr(tool, "inputSchema") else {},
+                },
+            }
+            for tool in mcp_tools
+        ]
+
+    def extract_function_calls(self, response: Any) -> list[dict[str, Any]]:
+        calls: list[dict[str, Any]] = []
+        message = response.choices[0].message
+        if message.tool_calls:
+            for tc in message.tool_calls:
+                args = tc.function.arguments
+                if isinstance(args, str):
+                    try:
+                        args = json.loads(args)
+                    except json.JSONDecodeError:
+                        args = {}
+                calls.append({"name": tc.function.name, "args": args, "id": tc.id})
+        return calls
+
+    def get_text_content(self, response: Any) -> str:
+        content = response.choices[0].message.content
+        return content if content else ""
+
+    def _convert_to_openai_messages(
+        self, contents: list[dict[str, Any]], system_instruction: str | None
+    ) -> list[dict[str, Any]]:
+        messages: list[dict[str, Any]] = []
+        if system_instruction:
+            messages.append({"role": "system", "content": system_instruction})
+        for msg in contents:
+            role = msg["role"]
+            content = msg["content"]
+
+            if role == "user":
+                messages.append({"role": "user", "content": content})
+            elif role == "assistant":
+                if "tool_calls" in msg:
+                    tool_calls = [
+                        {
+                            "id": tc.get("id") or f"call_{i}",
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": (
+                                    json.dumps(tc["args"])
+                                    if isinstance(tc["args"], dict)
+                                    else tc["args"]
+                                ),
+                            },
+                        }
+                        for i, tc in enumerate(msg["tool_calls"])
+                    ]
+                    messages.append(
+                        {"role": "assistant", "content": content or "", "tool_calls": tool_calls}
+                    )
+                else:
+                    messages.append({"role": "assistant", "content": content})
+            elif role == "tool":
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": msg.get("tool_call_id", ""),
+                        "content": content,
+                    }
+                )
+        return messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,11 @@ dependencies = [
     "ruamel.yaml>=0.18.0",
 ]
 
+# Provider SDKs are optional: install only the extras for the providers you use.
+[project.optional-dependencies]
+anthropic = ["anthropic>=0.104.1"]
+openai = ["openai>=1.0.0"]
+
 [tool.hatch.version]
 path = "devops_bench/__init__.py"
 
@@ -52,6 +57,8 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=1.0.0",
     "pytest-mock>=3.15.1",
+    # The provider extras keep the full adapter test suite runnable under `uv sync`.
+    "devops-bench[anthropic,openai]",
 ]
 
 [[tool.uv.index]]

--- a/tests/unit/agents/shared/__init__.py
+++ b/tests/unit/agents/shared/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/tests/unit/agents/shared/test_cli_capabilities.py
+++ b/tests/unit/agents/shared/test_cli_capabilities.py
@@ -1,0 +1,174 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the CLI capability helpers shared by the Gemini/openclaw agents."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from devops_bench.agents.capabilities import McpBinding
+from devops_bench.agents.shared.cli_capabilities import (
+    agent_workdir,
+    build_mcp_servers,
+    materialize_skills,
+)
+
+
+def test_build_mcp_servers_maps_command_to_command_and_args() -> None:
+    """``command[0]`` → ``command``; the remainder → ``args``."""
+    servers = build_mcp_servers(
+        (McpBinding(name="gke", command=("gke-mcp", "--flag", "v"), tools=("t",)),)
+    )
+    assert servers == {"gke": {"command": "gke-mcp", "args": ["--flag", "v"]}}
+
+
+def test_build_mcp_servers_omits_args_for_bare_command() -> None:
+    """A single-element command yields no ``args`` key."""
+    servers = build_mcp_servers((McpBinding(name="gke", command=("gke-mcp",)),))
+    assert servers == {"gke": {"command": "gke-mcp"}}
+
+
+def test_build_mcp_servers_skips_command_less_bindings() -> None:
+    """Empty-command bindings (in-process/built-in servers) are not launched."""
+    servers = build_mcp_servers((McpBinding(name="builtin", command=(), tools=("t",)),))
+    assert servers == {}
+
+
+def test_build_mcp_servers_names_unnamed_bindings_by_index() -> None:
+    """A binding with no name falls back to a positional ``mcp<index>`` key."""
+    servers = build_mcp_servers((McpBinding(name="", command=("srv",)),))
+    assert servers == {"mcp0": {"command": "srv"}}
+
+
+def test_materialize_skills_writes_named_skill_files(tmp_path: Path) -> None:
+    """Each discovered ``SKILL.md`` is copied under ``<root>/<name>/SKILL.md``."""
+    src = tmp_path / "src"
+    (src / "rotate").mkdir(parents=True)
+    (src / "rotate" / "SKILL.md").write_text(
+        "---\nname: rotate-secret\ndescription: rotate\n---\nbody\n",
+        encoding="utf-8",
+    )
+    dest = tmp_path / "dest"
+
+    written = materialize_skills(dest, (str(src),))
+
+    assert written == ["rotate-secret"]
+    copied = dest / "rotate-secret" / "SKILL.md"
+    assert "body" in copied.read_text(encoding="utf-8")
+
+
+def test_materialize_skills_rejects_malicious_names(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Frontmatter names that would escape ``skills_root`` are warned and skipped."""
+    src = tmp_path / "src"
+    abs_escape = tmp_path / "abs-escape"
+    bad_names = ("../rel-escape", str(abs_escape), "nested/name", "..")
+    for index, bad_name in enumerate(bad_names):
+        skill_dir = src / f"skill{index}"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {bad_name}\ndescription: d\n---\nbody\n", encoding="utf-8"
+        )
+    good = src / "zz-good"
+    good.mkdir(parents=True)
+    good_skill = "---\nname: good-skill\ndescription: d\n---\nbody\n"
+    (good / "SKILL.md").write_text(good_skill, encoding="utf-8")
+    dest = tmp_path / "skills" / "dest"
+
+    written = materialize_skills(dest, (str(src),))
+
+    assert written == ["good-skill"]
+    assert not (tmp_path / "skills" / "rel-escape").exists()
+    assert not abs_escape.exists()
+    assert sorted(p.name for p in dest.iterdir()) == ["good-skill"]
+    assert "Skipping skill '../rel-escape'" in caplog.text
+
+
+def test_materialize_skills_warns_and_keeps_first_on_duplicate_names(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A second SKILL.md with an already-seen name is skipped, not overwritten."""
+    first = tmp_path / "src1" / "dup"
+    second = tmp_path / "src2" / "dup"
+    for source_dir, body in ((first, "first body"), (second, "second body")):
+        source_dir.mkdir(parents=True)
+        (source_dir / "SKILL.md").write_text(
+            f"---\nname: dup-skill\ndescription: d\n---\n{body}\n", encoding="utf-8"
+        )
+    dest = tmp_path / "dest"
+
+    written = materialize_skills(dest, (str(tmp_path / "src1"), str(tmp_path / "src2")))
+
+    assert written == ["dup-skill"]
+    assert "first body" in (dest / "dup-skill" / "SKILL.md").read_text(encoding="utf-8")
+    assert "Skipping duplicate skill 'dup-skill'" in caplog.text
+
+
+def test_materialize_skills_skips_missing_paths(tmp_path: Path) -> None:
+    """A non-existent source path is warned and skipped, not fatal."""
+    assert materialize_skills(tmp_path / "dest", (str(tmp_path / "nope"),)) == []
+
+
+def test_build_mcp_servers_resolves_path_like_commands(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Path-like commands that exist on disk are absolutized; bare commands are not."""
+    monkeypatch.chdir(tmp_path)
+
+    # 1. Path-like command that exists -> resolved to absolute
+    local_cmd = tmp_path / "my-local-mcp"
+    local_cmd.touch()
+    servers = build_mcp_servers((McpBinding(name="gke", command=("./my-local-mcp",)),))
+    assert servers["gke"]["command"] == str(local_cmd.resolve())
+
+    # 2. Bare command exists as a file in cwd -> NOT resolved (stays bare)
+    dummy_node = tmp_path / "node"
+    dummy_node.touch()
+    servers = build_mcp_servers((McpBinding(name="node_srv", command=("node",)),))
+    assert servers["node_srv"]["command"] == "node"
+
+    # 3. Path-like command that does NOT exist -> NOT resolved
+    servers = build_mcp_servers((McpBinding(name="missing", command=("./missing-mcp",)),))
+    assert servers["missing"]["command"] == "./missing-mcp"
+    assert (
+        "Path-like MCP command './missing-mcp' not found relative to harness; passing unchanged"
+        in caplog.text
+    )
+
+
+def test_agent_workdir_yields_supplied_path_without_cleanup(tmp_path: Path) -> None:
+    """A supplied ``workspace_path`` is yielded as-is and left in place afterward."""
+    supplied = tmp_path / "workspace"
+    supplied.mkdir()
+
+    with agent_workdir(supplied, prefix="ignored-") as workdir:
+        assert workdir == supplied
+        (workdir / "marker.txt").write_text("artifact", encoding="utf-8")
+
+    assert supplied.exists()
+    assert (supplied / "marker.txt").read_text(encoding="utf-8") == "artifact"
+
+
+def test_agent_workdir_creates_and_cleans_up_temp_dir_when_no_path_supplied() -> None:
+    """``None`` falls back to a prefixed temp dir that is removed on exit."""
+    with agent_workdir(None, prefix="agent-workdir-test-") as workdir:
+        created = workdir
+        assert workdir.is_dir()
+        assert workdir.name.startswith("agent-workdir-test-")
+
+    assert not created.exists()

--- a/tests/unit/agents/test_agents_base.py
+++ b/tests/unit/agents/test_agents_base.py
@@ -33,7 +33,7 @@ def test_abstract_base_cannot_be_instantiated() -> None:
 
 def test_subclass_run_returns_typed_result_with_latency() -> None:
     class _Stub(AgentHarness):
-        def _execute(self, prompt: str) -> AgentResult:
+        def _execute(self, prompt: str, workspace_path=None) -> AgentResult:
             return AgentResult(output=f"echo:{prompt}", trajectory=[])
 
     result = _Stub().run("hi")
@@ -44,7 +44,7 @@ def test_subclass_run_returns_typed_result_with_latency() -> None:
 
 def test_subclass_can_self_stamp_latency() -> None:
     class _Stub(AgentHarness):
-        def _execute(self, prompt: str) -> AgentResult:
+        def _execute(self, prompt: str, workspace_path=None) -> AgentResult:
             # Subclasses with finer-grained timing may pre-fill latency; the
             # base must leave that value untouched.
             return AgentResult(output="x", trajectory=[], latency=99.0)
@@ -54,7 +54,7 @@ def test_subclass_can_self_stamp_latency() -> None:
 
 def test_safety_net_converts_unexpected_exception_to_errored_result() -> None:
     class _Boom(AgentHarness):
-        def _execute(self, prompt: str) -> AgentResult:
+        def _execute(self, prompt: str, workspace_path=None) -> AgentResult:
             raise RuntimeError("kaboom")
 
     result = _Boom().run("hi")
@@ -68,7 +68,7 @@ def test_safety_net_converts_unexpected_exception_to_errored_result() -> None:
 
 def test_safety_net_covers_a_none_result_from_execute() -> None:
     class _Forgetful(AgentHarness):
-        def _execute(self, prompt: str) -> AgentResult:
+        def _execute(self, prompt: str, workspace_path=None) -> AgentResult:
             return None  # type: ignore[return-value]  # subclass bug: forgot to return
 
     result = _Forgetful().run("hi")
@@ -79,7 +79,7 @@ def test_safety_net_covers_a_none_result_from_execute() -> None:
 
 def test_config_default_is_a_fresh_agent_config() -> None:
     class _Stub(AgentHarness):
-        def _execute(self, prompt: str) -> AgentResult:
+        def _execute(self, prompt: str, workspace_path=None) -> AgentResult:
             return AgentResult(output="", trajectory=[])
 
     a = _Stub()
@@ -92,7 +92,7 @@ def test_third_party_can_register_with_no_central_edit() -> None:
     """A dummy agent registers via @AGENTS.register and resolves via .get."""
 
     class _Dummy(AgentHarness):
-        def _execute(self, prompt: str) -> AgentResult:
+        def _execute(self, prompt: str, workspace_path=None) -> AgentResult:
             return AgentResult(output="", trajectory=[])
 
     AGENTS.register("dummy-extension")(_Dummy)

--- a/tests/unit/agents/test_agents_cli_gemini.py
+++ b/tests/unit/agents/test_agents_cli_gemini.py
@@ -1,0 +1,688 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.agents.cli.gemini_cli."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from devops_bench.agents import AGENTS, AgentConfig
+from devops_bench.agents.capabilities import (
+    AgentRules,
+    AllCapabilities,
+    McpBinding,
+    SkillBinding,
+    SupportsMcp,
+    SupportsRules,
+    SupportsSkills,
+)
+from devops_bench.agents.cli.gemini_cli import GeminiCliAgent, parse_stream_json
+from devops_bench.agents.cli.gemini_cli import agent as gemini_mod
+from devops_bench.agents.cli.gemini_cli.agent import (
+    _build_argv,
+    _build_env,
+    _build_settings,
+)
+from devops_bench.core.errors import ConfigError, SubprocessError
+
+
+def _stream(*events: dict) -> str:
+    """Render a list of events as a stream-json stdout blob."""
+    return "\n".join(json.dumps(event) for event in events) + "\n"
+
+
+SAMPLE_STREAM = _stream(
+    {"type": "init", "session_id": "abc-123", "model": "gemini-2.5-pro"},
+    {
+        "type": "tool_use",
+        "id": "call-1",
+        "name": "mcp_gke_list_clusters",
+        "input": {"project": "p1"},
+    },
+    {
+        "type": "tool_result",
+        "tool_use_id": "call-1",
+        "content": "cluster-a, cluster-b",
+    },
+    {
+        "type": "tool_use",
+        "id": "call-2",
+        "name": "mcp_gke_get_cluster",
+        "input": {"cluster": "cluster-a"},
+    },
+    {
+        "type": "tool_result",
+        "tool_use_id": "call-2",
+        "content": "v1.30",
+        "is_error": False,
+    },
+    {
+        "type": "result",
+        "output": "Done.",
+        "tokens": {"prompt_token_count": 10, "candidates_token_count": 20},
+    },
+)
+
+
+def test_parse_stream_json_emits_canonical_trajectory() -> None:
+    output, trajectory, tokens, errors = parse_stream_json(SAMPLE_STREAM)
+    assert output == "Done."
+    assert tokens == {"prompt_token_count": 10, "candidates_token_count": 20}
+    assert errors == []
+    assert trajectory == [
+        {
+            "name": "mcp_gke_list_clusters",
+            "args": {"project": "p1"},
+            "result": "cluster-a, cluster-b",
+            "status": "completed",
+        },
+        {
+            "name": "mcp_gke_get_cluster",
+            "args": {"cluster": "cluster-a"},
+            "result": "v1.30",
+            "status": "completed",
+        },
+    ]
+
+
+def test_parse_stream_json_records_json_decode_errors_on_errors_list() -> None:
+    blob = "{not json}\n" + json.dumps({"type": "result", "output": "ok"}) + "\n"
+    output, trajectory, _tokens, errors = parse_stream_json(blob)
+    assert output == "ok"
+    assert trajectory == []
+    assert len(errors) == 1
+    assert "parse error" in errors[0]
+
+
+def test_parse_stream_json_records_unmatched_tool_results() -> None:
+    blob = _stream({"type": "tool_result", "tool_use_id": "ghost", "content": "?"})
+    _output, trajectory, _tokens, errors = parse_stream_json(blob)
+    # Unpaired result must surface; canonical trajectory is empty.
+    assert trajectory == []
+    assert any("without matching tool_use" in msg for msg in errors)
+
+
+def test_parse_stream_json_records_error_events() -> None:
+    blob = _stream({"type": "error", "message": "rate limit"})
+    _output, _trajectory, _tokens, errors = parse_stream_json(blob)
+    assert errors == ["stream-json error event: rate limit"]
+
+
+def test_parse_stream_json_marks_failed_tool_results_as_error_status() -> None:
+    blob = _stream(
+        {"type": "tool_use", "id": "c", "name": "x", "input": {}},
+        {"type": "tool_result", "tool_use_id": "c", "content": "oops", "is_error": True},
+    )
+    _output, trajectory, _tokens, _errors = parse_stream_json(blob)
+    assert trajectory[0]["status"] == "error"
+
+
+def test_parse_stream_json_empty_input_returns_empty() -> None:
+    assert parse_stream_json("") == ("", [], {}, [])
+
+
+def test_build_argv_disables_extensions_when_no_allowed_tools() -> None:
+    argv = _build_argv("/bin/gemini", "hi", ())
+    assert "--output-format" in argv and "stream-json" in argv
+    assert "--extensions=" in argv
+    assert "--allowed-tools" not in argv
+    # Headless auto-approve so MCP/built-in tool calls never block on a prompt.
+    assert argv[argv.index("--approval-mode") + 1] == "yolo"
+    assert argv[-2:] == ["-p", "hi"]
+
+
+def test_build_argv_emits_one_allowed_tools_pair_per_tool() -> None:
+    argv = _build_argv("/bin/gemini", "hi", ("a", "b"))
+    pairs = [(argv[i], argv[i + 1]) for i in range(len(argv) - 1) if argv[i] == "--allowed-tools"]
+    assert pairs == [("--allowed-tools", "a"), ("--allowed-tools", "b")]
+    assert "--extensions=" not in argv
+    assert argv[argv.index("--approval-mode") + 1] == "yolo"
+
+
+def test_build_env_threads_api_key_and_model_into_gemini_vars() -> None:
+    cfg = AgentConfig(model="gemini-2.5-pro", api_key="abc", extra_env={"X": "y"})
+    env = _build_env(cfg)
+    assert env["GOOGLE_API_KEY"] == "abc"
+    assert env["GEMINI_API_KEY"] == "abc"
+    assert env["GEMINI_MODEL"] == "gemini-2.5-pro"
+    assert env["OTEL_SDK_DISABLED"] == "true"
+    assert env["X"] == "y"
+
+
+def test_build_env_vertex_key_routes_to_cloud_api_key() -> None:
+    # google-vertex routes a provided key to GOOGLE_CLOUD_API_KEY (the vertex
+    # transport var), not the google-genai vars.
+    env = _build_env(AgentConfig(model="gemini-2.5-pro", api_key="abc", provider="google-vertex"))
+    assert env["GOOGLE_CLOUD_API_KEY"] == "abc"
+    assert "GEMINI_API_KEY" not in env and "GOOGLE_API_KEY" not in env
+
+
+def test_build_env_keyless_writes_no_key_var() -> None:
+    # No api_key (Vertex/ADC): no key env var is written regardless of provider.
+    env = _build_env(AgentConfig(model="gemini-2.5-pro", provider="google-vertex"))
+    assert not {"GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_CLOUD_API_KEY"} & env.keys()
+
+
+def test_build_env_unknown_provider_raises_even_when_keyless() -> None:
+    # Validation is unconditional — a typoed provider fails loud on a keyless run.
+    with pytest.raises(ConfigError):
+        _build_env(AgentConfig(model="gemini-2.5-pro", provider="google-vertyx"))
+
+
+def test_gemini_agent_registered_under_canonical_key() -> None:
+    assert AGENTS.get("gemini") is GeminiCliAgent
+
+
+def test_execute_returns_typed_result_with_trajectory(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        captured["timeout"] = kwargs.get("timeout")
+        captured["extra_env"] = kwargs.get("extra_env")
+        return SimpleNamespace(stdout=SAMPLE_STREAM, stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    agent = GeminiCliAgent(AgentConfig(target="gemini-x", timeout_sec=30.0))
+    result = agent.run("ping")
+    assert result.output == "Done."
+    assert len(result.trajectory) == 2
+    assert result.errors == []
+    assert result.tokens == {"prompt_token_count": 10, "candidates_token_count": 20}
+    assert captured["timeout"] == 30.0
+    assert captured["argv"][0].endswith("gemini-x")
+    assert "--output-format" in captured["argv"]
+    assert "stream-json" in captured["argv"]
+    assert captured["argv"][-2:] == ["-p", "ping"]
+
+
+def test_execute_records_non_zero_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(argv, **kwargs):
+        return SimpleNamespace(stdout="", stderr="boom", returncode=2)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    result = GeminiCliAgent(AgentConfig(target="gemini")).run("p")
+    assert result.has_errors()
+    assert any("exited 2" in e for e in result.errors)
+    assert result.metadata.get("returncode") == 2
+
+
+def test_execute_handles_subprocess_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(argv, **kwargs):
+        raise SubprocessError(argv, returncode=-1, stdout="", stderr="timeout")
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    result = GeminiCliAgent(AgentConfig(target="gemini")).run("p")
+    assert result.has_errors()
+    assert "subprocess error" in result.errors[0]
+    assert result.trajectory == []
+
+
+def test_execute_handles_missing_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(argv, **kwargs):
+        raise OSError("not found")
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    result = GeminiCliAgent(AgentConfig(target="gemini")).run("p")
+    assert result.has_errors()
+    assert "binary unavailable" in result.errors[0]
+
+
+def test_execute_passes_timeout_to_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    GeminiCliAgent(AgentConfig(target="gemini", timeout_sec=15.5)).run("p")
+    assert captured["timeout"] == 15.5
+
+
+def test_execute_wires_extra_env_into_subprocess_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Call-site wiring: GEMINI_MODEL / GOOGLE_API_KEY actually reach `run(...)`."""
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        captured["extra_env"] = kwargs.get("extra_env")
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    cfg = AgentConfig(target="gemini", model="gemini-2.5-pro", api_key="abc")
+    GeminiCliAgent(cfg).run("p")
+    env = captured["extra_env"]
+    assert env is not None
+    assert env["GEMINI_MODEL"] == "gemini-2.5-pro"
+    assert env["GOOGLE_API_KEY"] == "abc"
+    assert env["GEMINI_API_KEY"] == "abc"
+    # OTLP exporters must be disabled to avoid the CLI hanging on a broken
+    # telemetry endpoint when no AGENT_API_KEY/AGENT_MODEL is configured.
+    assert env["OTEL_SDK_DISABLED"] == "true"
+
+
+def test_parse_stream_json_accepts_tool_use_id_field_for_call_id() -> None:
+    """Some CLI builds key the tool_use on `tool_use_id`, not `id`."""
+    blob = _stream(
+        {
+            "type": "tool_use",
+            "tool_use_id": "alt-1",
+            "name": "list",
+            "input": {},
+        },
+        {"type": "tool_result", "tool_use_id": "alt-1", "content": "ok"},
+    )
+    _output, trajectory, _tokens, errors = parse_stream_json(blob)
+    assert errors == []
+    assert trajectory == [
+        {"name": "list", "args": {}, "result": "ok", "status": "completed"},
+    ]
+
+
+def test_parse_stream_json_accepts_args_field_when_input_absent() -> None:
+    """Older CLI builds emit `args` instead of `input` on tool_use."""
+    blob = _stream(
+        {"type": "tool_use", "id": "c1", "name": "x", "args": {"k": "v"}},
+        {"type": "tool_result", "id": "c1", "output": "ok"},
+    )
+    _output, trajectory, _tokens, errors = parse_stream_json(blob)
+    assert errors == []
+    assert trajectory[0]["args"] == {"k": "v"}
+    assert trajectory[0]["result"] == "ok"
+
+
+def test_parse_stream_json_real_cli_schema() -> None:
+    """The live Gemini CLI schema: ``tool_name``/``tool_id``/``parameters`` on
+    tool_use, the answer streamed across ``message`` (role=assistant) events,
+    and token usage under ``result.stats`` — none of which the legacy field
+    names cover. Captured from gemini-cli 0.47 + gke-mcp 0.13.
+    """
+    blob = _stream(
+        {"type": "init", "session_id": "s1", "model": "gemini-3.1-pro-preview"},
+        {"type": "message", "role": "user", "content": "list files"},
+        {
+            "type": "tool_use",
+            "tool_name": "list_directory",
+            "tool_id": "list_directory__abc",
+            "parameters": {"dir_path": "/work"},
+        },
+        {"type": "tool_result", "tool_id": "list_directory__abc", "status": "success"},
+        {"type": "message", "role": "assistant", "content": "I found "},
+        {"type": "message", "role": "assistant", "content": "one file."},
+        {
+            "type": "result",
+            "status": "success",
+            "stats": {
+                "total_tokens": 31489,
+                "input_tokens": 31225,
+                "output_tokens": 35,
+                "cached": 12173,
+            },
+        },
+    )
+    output, trajectory, tokens, errors = parse_stream_json(blob)
+    assert output == "I found one file."
+    assert errors == []
+    # The live tool_result carries only a status (no payload), so result stays
+    # unset (None) — the stream simply doesn't include tool output text.
+    assert trajectory == [
+        {
+            "name": "list_directory",
+            "args": {"dir_path": "/work"},
+            "result": None,
+            "status": "completed",
+        },
+    ]
+    assert tokens == {"input": 31225, "output": 35, "total": 31489, "cached": 12173}
+
+
+def test_parse_stream_json_marks_failed_tool_result_status_field() -> None:
+    """A tool_result with ``status="error"`` (and no is_error flag) is failed."""
+    blob = _stream(
+        {"type": "tool_use", "tool_name": "x", "tool_id": "t1", "parameters": {}},
+        {"type": "tool_result", "tool_id": "t1", "status": "error"},
+    )
+    _output, trajectory, _tokens, errors = parse_stream_json(blob)
+    assert errors == []
+    assert trajectory[0]["status"] == "error"
+
+
+def test_run_does_not_invoke_subprocess_when_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sanity: parse_stream_json must not shell out (catches an import-time hazard)."""
+
+    def boom(*_a, **_kw):
+        raise AssertionError("parse_stream_json should not run subprocess")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    parse_stream_json(SAMPLE_STREAM)
+
+
+# Tests for the now-deleted legacy surface — these documents what is gone for
+# good and will fail-fast if the dead modules are ever reintroduced.
+
+
+def test_legacy_run_cli_agent_is_gone() -> None:
+    assert not hasattr(gemini_mod, "run_cli_agent")
+
+
+def test_legacy_session_glob_is_gone() -> None:
+    assert not hasattr(gemini_mod, "extract_trajectory_from_session")
+
+
+# ---------------------------------------------------------------------------
+# PR3 — capability negotiation and binding consumption
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_agent_satisfies_mcp_skills_and_rules_protocols() -> None:
+    """Gemini declares MCP, Skills and Rules: it writes ``mcpServers`` into a
+    workspace ``settings.json``, materializes workspace skills under
+    ``.gemini/skills``, and auto-loads ``GEMINI.md``."""
+    agent = GeminiCliAgent(AgentConfig())
+    assert isinstance(agent, SupportsMcp)
+    assert isinstance(agent, SupportsSkills)
+    assert isinstance(agent, SupportsRules)
+
+
+def test_execute_pulls_allowed_tools_from_capabilities(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--allowed-tools`` argv comes from ``capabilities.allowed_tools``."""
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="t", command=(), tools=("alpha", "beta")),),
+    )
+    GeminiCliAgent(AgentConfig(target="gemini", capabilities=caps)).run("p")
+    argv = captured["argv"]
+    pairs = [(argv[i], argv[i + 1]) for i in range(len(argv) - 1) if argv[i] == "--allowed-tools"]
+    assert pairs == [("--allowed-tools", "alpha"), ("--allowed-tools", "beta")]
+    assert "--extensions=" not in argv  # tools present → extensions enabled
+
+
+def test_execute_disables_extensions_when_capabilities_have_no_mcp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No MCP binding (no allowed tools) → ``--extensions=`` argv (extensions off)."""
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    GeminiCliAgent(AgentConfig(target="gemini")).run("p")
+    assert "--extensions=" in captured["argv"]
+    assert "--allowed-tools" not in captured["argv"]
+
+
+def test_gemini_agent_mirrors_capability_bindings_onto_mixin_attributes() -> None:
+    """The structural-Protocol attributes track the granted bindings."""
+    binding = McpBinding(name="x", command=(), tools=("t",))
+    skills = SkillBinding(paths=("/some/skills",))
+    caps = AllCapabilities(
+        mcp_servers=(binding,),
+        skills=skills,
+        rules=AgentRules(text="be a sre"),
+    )
+    agent = GeminiCliAgent(AgentConfig(capabilities=caps))
+    assert agent.mcp_servers == (binding,)
+    assert agent.skills == skills
+    assert agent.rules == AgentRules(text="be a sre")
+
+
+# ---------------------------------------------------------------------------
+# Rules delivery: GEMINI.md actually reaches the binary's working directory.
+# ---------------------------------------------------------------------------
+
+
+def test_execute_writes_gemini_md_with_rules_text_before_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When rules.text is bound, GEMINI.md exists with that text in the cwd
+    handed to the subprocess — at the *moment* `run` is called.
+
+    Snapshotting inside the fake `run` is load-bearing: the agent uses a
+    `TemporaryDirectory` context manager whose cleanup runs after `_execute`
+    returns, so a post-hoc filesystem check on the cwd would race with
+    cleanup. Reading the file from inside `run` proves the binary would see
+    it on startup, which is what the CLI's auto-load relies on.
+    """
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        from pathlib import Path
+
+        cwd = kwargs.get("cwd")
+        captured["cwd"] = cwd
+        gemini_md = Path(cwd) / "GEMINI.md" if cwd else None
+        captured["gemini_md_exists"] = bool(gemini_md and gemini_md.exists())
+        captured["gemini_md_text"] = (
+            gemini_md.read_text(encoding="utf-8") if captured["gemini_md_exists"] else None
+        )
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    caps = AllCapabilities(rules=AgentRules(text="you are a precise SRE"))
+    GeminiCliAgent(AgentConfig(target="gemini", capabilities=caps)).run("p")
+
+    assert captured["cwd"] is not None, "agent must set cwd so GEMINI.md is auto-loaded"
+    assert captured["gemini_md_exists"], "GEMINI.md must exist in cwd before subprocess"
+    assert captured["gemini_md_text"] == "you are a precise SRE"
+
+
+def test_execute_skips_writing_gemini_md_when_rules_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty rules.text → no GEMINI.md created (do not write a blank file)."""
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        cwd = kwargs.get("cwd")
+        captured["cwd"] = cwd
+        gemini_md = os.path.join(cwd, "GEMINI.md") if cwd else None
+        captured["gemini_md_exists"] = bool(gemini_md and os.path.exists(gemini_md))
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    GeminiCliAgent(AgentConfig(target="gemini")).run("p")  # default empty rules
+    assert captured["gemini_md_exists"] is False
+
+
+def test_execute_cleans_up_temp_working_dir_after_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The per-run temp working dir is cleaned up after `_execute` returns;
+    the bound GEMINI.md leaves no trail on the user's filesystem."""
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    caps = AllCapabilities(rules=AgentRules(text="any rules"))
+    GeminiCliAgent(AgentConfig(target="gemini", capabilities=caps)).run("p")
+    # cwd was a real path during the run; after _execute returns it is gone.
+    assert captured["cwd"] is not None
+    assert not os.path.exists(captured["cwd"])
+
+
+# ---------------------------------------------------------------------------
+# MCP server wiring: settings.json mcpServers reach the binary's cwd.
+# ---------------------------------------------------------------------------
+
+
+def test_build_settings_combines_mcp_servers_and_skills_flag() -> None:
+    """Both knobs render; skills flag is gated on ``skills_enabled``."""
+    binding = McpBinding(name="gke", command=("gke-mcp",))
+    assert _build_settings((binding,), skills_enabled=True) == {
+        "mcpServers": {"gke": {"command": "gke-mcp"}},
+        "skills": {"enabled": True},
+    }
+    assert _build_settings((), skills_enabled=False) == {}
+
+
+def test_execute_writes_mcp_servers_into_workspace_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A command-bearing MCP binding lands in ``<cwd>/.gemini/settings.json``."""
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        settings_path = os.path.join(kwargs["cwd"], ".gemini", "settings.json")
+        captured["exists"] = os.path.exists(settings_path)
+        if captured["exists"]:
+            with open(settings_path) as f:
+                captured["settings"] = json.load(f)
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="gke", command=("gke-mcp",), tools=("mcp_gke_x",)),),
+    )
+    GeminiCliAgent(AgentConfig(target="gemini", capabilities=caps)).run("p")
+
+    assert captured["exists"], "settings.json must exist in cwd before subprocess"
+    assert captured["settings"]["mcpServers"] == {"gke": {"command": "gke-mcp"}}
+
+
+def test_execute_writes_no_settings_when_no_command_and_no_skills(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No launchable MCP server and no skills → no settings.json is written."""
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        settings_path = os.path.join(kwargs["cwd"], ".gemini", "settings.json")
+        captured["exists"] = os.path.exists(settings_path)
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    # Binding carries tools (→ --allowed-tools) but no launch command.
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="builtin", command=(), tools=("alpha",)),),
+    )
+    GeminiCliAgent(AgentConfig(target="gemini", capabilities=caps)).run("p")
+    assert captured["exists"] is False
+
+
+def test_execute_materializes_skills_into_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Bound skill paths are copied to ``<cwd>/.gemini/skills/<name>/SKILL.md``
+    and ``skills.enabled`` is set in settings.json."""
+    src = tmp_path / "skills" / "my-skill"
+    src.mkdir(parents=True)
+    skill_text = "---\nname: my-skill\ndescription: do things\n---\nbody\n"
+    (src / "SKILL.md").write_text(skill_text)
+
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        skill_path = os.path.join(kwargs["cwd"], ".gemini", "skills", "my-skill", "SKILL.md")
+        captured["skill_exists"] = os.path.exists(skill_path)
+        if captured["skill_exists"]:
+            with open(skill_path) as f:
+                captured["skill_text"] = f.read()
+        else:
+            captured["skill_text"] = None
+        settings_path = os.path.join(kwargs["cwd"], ".gemini", "settings.json")
+        with open(settings_path) as f:
+            captured["settings"] = json.load(f)
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    caps = AllCapabilities(skills=SkillBinding(paths=(str(tmp_path / "skills"),)))
+    GeminiCliAgent(AgentConfig(target="gemini", capabilities=caps)).run("p")
+
+    assert captured["skill_exists"], "skill must be materialized before subprocess"
+    assert captured["skill_text"] == skill_text
+    assert captured["settings"]["skills"] == {"enabled": True}
+
+
+def test_execute_warns_and_skips_missing_skill_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-existent skill path is skipped (no settings.json, no crash)."""
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        settings_path = os.path.join(kwargs["cwd"], ".gemini", "settings.json")
+        captured["exists"] = os.path.exists(settings_path)
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    caps = AllCapabilities(skills=SkillBinding(paths=("/no/such/skills/dir",)))
+    GeminiCliAgent(AgentConfig(target="gemini", capabilities=caps)).run("p")
+    assert captured["exists"] is False
+
+
+# ---------------------------------------------------------------------------
+# Parallel isolation: each run gets its own throwaway cwd, never a shared one.
+# This is what makes concurrent gemini runs safe on a single host — the binary
+# reads/writes its workspace `.gemini` from cwd, so two runs sharing a cwd would
+# clobber each other's settings/skills. The refactored arm also parses the
+# trajectory from stdout (see parse_stream_json tests), so it never touches the
+# shared `~/.gemini/tmp/.../chats` dir the legacy arm relies on.
+# ---------------------------------------------------------------------------
+
+
+def test_execute_runs_in_isolated_temp_cwd_not_user_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The cwd is a fresh temp dir (prefix ``gemini-run-``), not the process cwd
+    and not under the user's ``~/.gemini``."""
+    import tempfile
+
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    GeminiCliAgent(AgentConfig(target="gemini")).run("p")
+
+    cwd = captured["cwd"]
+    assert cwd is not None
+    assert os.path.basename(cwd).startswith("gemini-run-")
+    # Sandboxed under the OS temp root, and distinct from the process cwd.
+    assert os.path.realpath(cwd).startswith(os.path.realpath(tempfile.gettempdir()))
+    assert os.path.realpath(cwd) != os.path.realpath(os.getcwd())
+    # The user-level gemini config dir must never be used as the workspace.
+    assert os.path.expanduser("~/.gemini") not in os.path.realpath(cwd)
+
+
+def test_execute_uses_distinct_cwd_per_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two runs never share a working directory — the core parallel-safety
+    invariant. Each ``_execute`` mints its own ``TemporaryDirectory``."""
+    cwds: list[str] = []
+
+    def fake_run(argv, **kwargs):
+        cwds.append(kwargs.get("cwd"))
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    # Two separate agents and a re-run of one — all must get unique cwds.
+    GeminiCliAgent(AgentConfig(target="gemini")).run("p")
+    agent = GeminiCliAgent(AgentConfig(target="gemini"))
+    agent.run("p")
+    agent.run("p")
+
+    assert len(cwds) == 3
+    assert all(c is not None for c in cwds)
+    assert len(set(cwds)) == 3, f"cwds must be unique per run, got {cwds}"

--- a/tests/unit/agents/test_agents_cli_openclaw.py
+++ b/tests/unit/agents/test_agents_cli_openclaw.py
@@ -1,0 +1,903 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.agents.cli.openclaw."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from devops_bench.agents import AGENTS, AgentConfig
+from devops_bench.agents.capabilities import (
+    AgentRules,
+    AllCapabilities,
+    McpBinding,
+    SkillBinding,
+    SupportsMcp,
+    SupportsRules,
+    SupportsSkills,
+)
+from devops_bench.agents.cli.openclaw import OpenClawAgent, parse_trajectory_export
+from devops_bench.agents.cli.openclaw import agent as oc_mod
+from devops_bench.agents.cli.openclaw.agent import (
+    _build_env,
+    _build_local_command,
+    _build_model_override,
+    _build_openclaw_config,
+    _oc_model_id,
+)
+from devops_bench.agents.cli.openclaw.parsing import _pick_session_key, _strip_ansi
+from devops_bench.core.errors import ConfigError, SubprocessError
+
+
+def _events(*entries: dict) -> str:
+    return "\n".join(json.dumps(e) for e in entries) + "\n"
+
+
+def _tool_call(call_id: str, name: str, arguments: dict) -> dict:
+    return {
+        "type": "tool.call",
+        "data": {"toolCallId": call_id, "name": name, "arguments": arguments},
+    }
+
+
+def _tool_result(
+    call_id: str, text: str, *, is_error: bool = False, status: str = "completed"
+) -> dict:
+    return {
+        "type": "tool.result",
+        "data": {
+            "message": {
+                "toolCallId": call_id,
+                "content": [{"type": "text", "text": text}],
+                "details": {"status": status},
+                "isError": is_error,
+            }
+        },
+    }
+
+
+# Mirrors the real ``oc sessions export-trajectory`` events.jsonl schema:
+# dotted ``type`` with a nested ``data`` payload (captured from oc 2026.6.9).
+SAMPLE_EVENTS = _events(
+    _tool_call("1", "kubectl_get_pods", {"namespace": "default"}),
+    _tool_result("1", "pod-a Running\n"),
+    _tool_call("2", "kubectl_describe", {"resource": "pod/pod-a"}),
+    _tool_result("2", "Phase: Running"),
+    {
+        "type": "model.completed",
+        "data": {
+            "usage": {"input": 5, "output": 10, "total": 15},
+            "assistantTexts": ["All pods healthy."],
+        },
+    },
+)
+
+
+def test_parse_trajectory_export_folds_call_result_pairs() -> None:
+    trajectory, tokens, output, errors = parse_trajectory_export(SAMPLE_EVENTS)
+    assert errors == []
+    assert tokens == {"input": 5, "output": 10, "total": 15}
+    assert output == "All pods healthy."
+    assert trajectory == [
+        {
+            "name": "kubectl_get_pods",
+            "args": {"namespace": "default"},
+            "result": "pod-a Running\n",
+            "status": "completed",
+        },
+        {
+            "name": "kubectl_describe",
+            "args": {"resource": "pod/pod-a"},
+            "result": "Phase: Running",
+            "status": "completed",
+        },
+    ]
+
+
+def test_parse_trajectory_export_sums_usage_across_turns() -> None:
+    """Token usage is summed across every model.completed, not just the last.
+
+    OpenClaw reports usage per turn (per model call); a multi-turn session that
+    kept only the final ``model.completed`` would undercount to a single call.
+    """
+    blob = _events(
+        {"type": "model.completed", "data": {"usage": {"input": 100, "output": 20, "total": 120}}},
+        _tool_call("1", "kubectl_get_pods", {}),
+        _tool_result("1", "pod-a Running"),
+        {"type": "model.completed", "data": {"usage": {"input": 250, "output": 30, "total": 280}}},
+        {
+            "type": "model.completed",
+            "data": {"usage": {"input": 75, "output": 15, "total": 90}, "assistantTexts": ["done"]},
+        },
+    )
+    _trajectory, tokens, output, errors = parse_trajectory_export(blob)
+    assert errors == []
+    assert output == "done"
+    assert tokens == {"input": 425, "output": 65, "total": 490}
+
+
+def test_parse_trajectory_export_sums_nested_cost_breakdown() -> None:
+    """Nested numeric mappings (e.g. a per-turn ``cost`` block) are summed too."""
+    blob = _events(
+        {"type": "model.completed", "data": {"usage": {"input": 10, "cost": {"total": 0.01}}}},
+        {"type": "model.completed", "data": {"usage": {"input": 5, "cost": {"total": 0.02}}}},
+    )
+    _trajectory, tokens, _output, errors = parse_trajectory_export(blob)
+    assert errors == []
+    assert tokens["input"] == 15
+    assert tokens["cost"]["total"] == pytest.approx(0.03)
+
+
+def test_parse_trajectory_export_marks_failed_tool_result_as_error() -> None:
+    """``isError`` (or ``details.status`` of error/failed) → status 'error'."""
+    blob = _events(
+        _tool_call("1", "exec", {"command": "false"}),
+        _tool_result("1", "boom", is_error=True, status="error"),
+    )
+    trajectory, _tokens, _output, errors = parse_trajectory_export(blob)
+    assert errors == []
+    assert trajectory[0]["status"] == "error"
+
+
+def test_parse_trajectory_export_output_falls_back_to_assistant_message() -> None:
+    """When no model.completed.assistantTexts, output comes from assistant.message text."""
+    blob = _events(
+        {
+            "type": "assistant.message",
+            "data": {
+                "message": {"role": "assistant", "content": [{"type": "text", "text": "done."}]}
+            },
+        },
+        {"type": "model.completed", "data": {"usage": {"input": 1, "output": 2}}},
+    )
+    _trajectory, tokens, output, _errors = parse_trajectory_export(blob)
+    assert tokens == {"input": 1, "output": 2}
+    assert output == "done."
+
+
+def test_parse_trajectory_export_surfaces_decode_errors() -> None:
+    blob = "{not json}\n" + json.dumps(_tool_call("1", "x", {})) + "\n"
+    trajectory, _tokens, _output, errors = parse_trajectory_export(blob)
+    assert any("parse error" in m for m in errors)
+    assert len(trajectory) == 1
+
+
+def test_parse_trajectory_export_drops_unpaired_result_and_surfaces_error() -> None:
+    """Orphan tool.result is dropped from trajectory, recorded on errors.
+
+    Mirrors the API agent's ``_fold_with_extraction_errors`` policy and the
+    Gemini ``parse_stream_json`` policy so every agent feeds the metrics seam
+    one shape — only real ToolCalls the model issued ride on
+    ``AgentResult.trajectory``; orphans are diagnostics, not trajectory entries.
+    """
+    blob = _events(_tool_result("ghost", "?"))
+    trajectory, _tokens, _output, errors = parse_trajectory_export(blob)
+    # Orphan must NOT appear in the canonical trajectory.
+    assert trajectory == []
+    # ...but MUST be surfaced on errors so the run is never silent-empty.
+    assert any("without matching call" in m for m in errors)
+    assert any("ghost" in m for m in errors)
+
+
+def test_strip_ansi_removes_color_codes() -> None:
+    assert _strip_ansi("\x1b[31mhello\x1b[0m") == "hello"
+
+
+def test_oc_model_id_normalizes_provider_alias() -> None:
+    assert _oc_model_id(AgentConfig(model="gemini-2.5-pro", provider="gemini")) == (
+        "google/gemini-2.5-pro"
+    )
+
+
+def test_oc_model_id_preserves_full_id() -> None:
+    assert _oc_model_id(AgentConfig(model="anthropic/claude-opus-4-7")) == (
+        "anthropic/claude-opus-4-7"
+    )
+
+
+def test_oc_model_id_normalizes_full_id_provider_segment() -> None:
+    # A full id whose wire is an alias is normalized through the contract.
+    assert _oc_model_id(AgentConfig(model="gemini/gemini-2.5-pro")) == ("google/gemini-2.5-pro")
+
+
+def test_oc_model_id_passes_through_unknown_full_id_wire() -> None:
+    # An unrecognized wire is left for oc to validate, not rejected here.
+    assert _oc_model_id(AgentConfig(model="mystery/some-model")) == "mystery/some-model"
+
+
+def test_oc_model_id_returns_empty_when_no_model() -> None:
+    assert _oc_model_id(AgentConfig()) == ""
+
+
+def test_oc_model_id_defaults_to_google() -> None:
+    assert _oc_model_id(AgentConfig(model="gemini-2.5-pro")) == "google/gemini-2.5-pro"
+
+
+def test_build_local_command_quotes_inputs_and_passes_model_flag() -> None:
+    cfg = AgentConfig(model="gemini-2.5-pro", provider="gemini")
+    cmd = _build_local_command(cfg, "hi 'world'", "main", "/usr/local/bin/oc")
+    # Prompt single-quote must be escaped, not break the shell line.
+    assert "hi '\\''world'\\''" in cmd or "hi 'world'" not in cmd
+    assert "NVM_DIR" in cmd  # nvm sourced for the node runtime
+    # Per-run model override, not the global `oc models set` (no shared config write).
+    assert "--model google/gemini-2.5-pro" in cmd
+    assert "models set" not in cmd
+    assert "agent --local" in cmd
+    assert "--agent main" in cmd
+
+
+def test_build_local_command_omits_model_flag_when_no_model_configured() -> None:
+    cmd = _build_local_command(AgentConfig(), "prompt", "main", "/usr/local/bin/oc")
+    assert "--model" not in cmd
+    assert "models set" not in cmd
+
+
+def test_pick_session_key_handles_top_level_list() -> None:
+    payload = json.dumps([{"key": "agent:operator:abc", "model": "x"}])
+    assert _pick_session_key(payload) == "agent:operator:abc"
+
+
+def test_pick_session_key_handles_wrapper_dict() -> None:
+    payload = json.dumps({"sessions": [{"key": "k1"}, {"key": "k2"}]})
+    assert _pick_session_key(payload) == "k1"
+
+
+def test_pick_session_key_returns_none_on_empty_or_invalid() -> None:
+    assert _pick_session_key("") is None
+    assert _pick_session_key("{}") is None
+    assert _pick_session_key(json.dumps({"sessions": []})) is None
+    assert _pick_session_key(json.dumps([{"no_key": "x"}])) is None
+
+
+def test_openclaw_agent_registered_under_canonical_key() -> None:
+    assert AGENTS.get("openclaw") is OpenClawAgent
+
+
+def test_ensure_node_on_path_picks_numerically_newest_node(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """v18 must beat v8 even though "v18" < "v8" as strings."""
+    for version in ("v8.9.0", "v18.17.0", "v9.11.2"):
+        (tmp_path / "versions" / "node" / version / "bin").mkdir(parents=True)
+    monkeypatch.setenv("NVM_DIR", str(tmp_path))
+    monkeypatch.setattr(oc_mod.shutil, "which", lambda _cmd: None)
+
+    merged = oc_mod._ensure_node_on_path({})
+
+    first_path_entry = merged["PATH"].split(os.pathsep)[0]
+    assert first_path_entry == str(tmp_path / "versions" / "node" / "v18.17.0" / "bin")
+
+
+def _make_subprocess_result(
+    stdout: str = "", stderr: str = "", returncode: int = 0
+) -> SimpleNamespace:
+    return SimpleNamespace(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
+def _install_oc_run(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_bash: Callable[..., Any],
+    fake_core_run: Callable[..., Any] | None = None,
+) -> None:
+    """Install a fake ``core.subprocess.run`` on the agent module.
+
+    The agent turn arrives as ``["/bin/bash", "-c", <command>]`` and is routed
+    to ``fake_bash(<command>, **kwargs)`` so fakes keep asserting on the bash
+    command string; any other argv is the direct ``oc`` extraction call and
+    goes to ``fake_core_run`` (defaulting to an empty ``oc sessions``).
+    """
+    core = fake_core_run or (lambda argv, **kwargs: _make_subprocess_result(json.dumps([]), "", 0))
+
+    def dispatch(argv, **kwargs):
+        if argv[0] == "/bin/bash":
+            return fake_bash(argv[2], **kwargs)
+        return core(argv, **kwargs)
+
+    monkeypatch.setattr(oc_mod, "run", dispatch)
+
+
+def _bundle_writer(events_jsonl: str) -> Callable[..., Any]:
+    """Build a fake core-subprocess.run that writes an export bundle's events.jsonl.
+
+    ``oc sessions`` returns one session row; ``oc sessions export-trajectory``
+    writes ``events.jsonl`` (the real trajectory filename) into the bundle dir
+    under the ``--workspace`` it was handed.
+    """
+    sessions_payload = json.dumps(
+        [{"key": "agent:operator:test", "model": "google/gemini-2.5-pro"}]
+    )
+
+    def fake_core_run(argv, **kwargs):
+        if argv[1] == "sessions" and "export-trajectory" not in argv:
+            return _make_subprocess_result(stdout=sessions_payload, returncode=0)
+        if "export-trajectory" in argv:
+            ws = Path(argv[argv.index("--workspace") + 1])
+            export_root = ws / ".openclaw" / "trajectory-exports" / "openclaw-trajectory-x"
+            export_root.mkdir(parents=True, exist_ok=True)
+            (export_root / "events.jsonl").write_text(events_jsonl, encoding="utf-8")
+            return _make_subprocess_result(stdout="exported", returncode=0)
+        raise AssertionError(f"unexpected argv {argv}")
+
+    return fake_core_run
+
+
+def test_execute_happy_path_emits_canonical_trajectory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """oc agent succeeds, oc sessions yields one row, export-trajectory parses cleanly.
+
+    The final answer comes from the bundle (``model.completed.assistantTexts``),
+    not the noisy bash stdout.
+    """
+
+    def fake_bash(cmd, **kwargs):
+        return _make_subprocess_result(stdout="OK\n", returncode=0)
+
+    _install_oc_run(monkeypatch, fake_bash, _bundle_writer(SAMPLE_EVENTS))
+
+    agent = OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"), timeout_sec=30.0))
+    result = agent.run("audit pods in default")
+    assert result.errors == []
+    assert len(result.trajectory) == 2
+    assert result.trajectory[0]["name"] == "kubectl_get_pods"
+    assert result.tokens == {"input": 5, "output": 10, "total": 15}
+    assert result.output == "All pods healthy."
+
+
+def test_execute_prefers_bundle_output_over_noisy_stdout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The agent's final answer (events.jsonl assistantTexts) must win over
+    `oc --log-level debug` noise — otherwise the judge grades debug spew.
+    """
+    noisy_stdout = "[DEBUG] starting oc...\n[INFO] sessionFile=/tmp/.openclaw/...\n[DEBUG] turn 1\n"
+
+    def fake_bash(cmd, **kwargs):
+        return _make_subprocess_result(stdout=noisy_stdout, returncode=0)
+
+    clean_answer = "All pods in `default` are Running."
+    events = _events(
+        _tool_call("1", "exec", {"command": "kubectl get pods"}),
+        _tool_result("1", "pod-a Running"),
+        {
+            "type": "model.completed",
+            "data": {"usage": {"input": 1, "output": 1}, "assistantTexts": [clean_answer]},
+        },
+    )
+    _install_oc_run(monkeypatch, fake_bash, _bundle_writer(events))
+
+    result = OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"))).run("audit pods")
+    assert result.output == clean_answer
+    assert "[DEBUG]" not in result.output
+
+
+def test_execute_falls_back_to_stdout_when_bundle_has_no_answer(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No assistantTexts and no assistant.message in events → use stripped stdout."""
+    events = _events(
+        _tool_call("1", "exec", {"command": "ls"}),
+        _tool_result("1", "file"),
+        {"type": "model.completed", "data": {"usage": {"input": 1, "output": 1}}},
+    )
+    _install_oc_run(
+        monkeypatch,
+        lambda *a, **k: _make_subprocess_result(stdout="bare stdout answer", returncode=0),
+        _bundle_writer(events),
+    )
+
+    result = OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"))).run("p")
+    assert result.output == "bare stdout answer"
+
+
+def test_execute_records_when_sessions_returns_no_rows(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fake_core_run(argv, **kwargs):
+        # oc sessions returns empty.
+        return _make_subprocess_result(stdout=json.dumps([]), returncode=0)
+
+    _install_oc_run(
+        monkeypatch, lambda *a, **k: _make_subprocess_result("ok", "", 0), fake_core_run
+    )
+
+    result = OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"))).run("p")
+    assert result.has_errors()
+    assert any("no session key" in e for e in result.errors)
+
+
+def test_execute_records_export_subprocess_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fake_core_run(argv, **kwargs):
+        if "export-trajectory" in argv:
+            raise SubprocessError(argv, returncode=1, stdout="", stderr="bad")
+        return _make_subprocess_result(stdout=json.dumps([{"key": "k1"}]), returncode=0)
+
+    _install_oc_run(
+        monkeypatch, lambda *a, **k: _make_subprocess_result("ok", "", 0), fake_core_run
+    )
+    result = OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"))).run("p")
+    assert result.has_errors()
+    assert any("export-trajectory failed" in e for e in result.errors)
+
+
+def test_execute_records_bash_timeout(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def fake_bash(cmd, **kwargs):
+        # core.subprocess.run wraps TimeoutExpired in SubprocessError.
+        raise SubprocessError(["/bin/bash", "-c", cmd], returncode=-1, stdout="", stderr="")
+
+    _install_oc_run(monkeypatch, fake_bash)
+    result = OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"), timeout_sec=5.0)).run("p")
+    assert result.has_errors()
+    assert "timed out" in result.errors[0]
+    assert result.trajectory == []
+
+
+def test_execute_passes_timeout_to_bash(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        captured.update(kwargs)
+        return _make_subprocess_result("ok", "", 0)
+
+    _install_oc_run(monkeypatch, fake_bash)
+    OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"), timeout_sec=12.5)).run("p")
+    assert captured["timeout"] == 12.5
+
+
+# Tests for the now-deleted legacy surface — fail-fast if SSH transport returns.
+
+
+def test_legacy_ssh_runner_is_gone() -> None:
+    assert not hasattr(oc_mod, "run_openclaw_agent")
+
+
+def test_legacy_local_runner_is_gone() -> None:
+    assert not hasattr(oc_mod, "run_openclaw_agent_local")
+
+
+# ---------------------------------------------------------------------------
+# Capability negotiation: OpenClaw wires MCP + skills via oc's native channels
+# ---------------------------------------------------------------------------
+
+
+def test_openclaw_satisfies_mcp_skills_and_rules_protocols() -> None:
+    """OpenClaw declares MCP, Skills and Rules: it writes ``mcp.servers`` into an
+    isolated ``OPENCLAW_CONFIG_PATH``, materializes managed skills under
+    ``<OPENCLAW_STATE_DIR>/skills``, and prepends the operator brief to the
+    prompt."""
+    agent = OpenClawAgent(AgentConfig())
+    assert isinstance(agent, SupportsRules)
+    assert isinstance(agent, SupportsMcp)
+    assert isinstance(agent, SupportsSkills)
+
+
+def test_openclaw_agent_mirrors_capability_bindings_onto_mixin_attributes() -> None:
+    """The structural-Protocol attributes track the granted bindings."""
+    binding = McpBinding(name="gke", command=("gke-mcp",), tools=("t",))
+    skills = SkillBinding(paths=("/some/skills",))
+    caps = AllCapabilities(
+        mcp_servers=(binding,),
+        skills=skills,
+        rules=AgentRules(text="be a sre"),
+    )
+    agent = OpenClawAgent(AgentConfig(capabilities=caps))
+    assert agent.mcp_servers == (binding,)
+    assert agent.skills == skills
+    assert agent.rules == AgentRules(text="be a sre")
+
+
+def test_openclaw_agent_mirrors_rules_binding_onto_mixin_attribute() -> None:
+    caps = AllCapabilities(rules=AgentRules(text="be precise"))
+    agent = OpenClawAgent(AgentConfig(capabilities=caps))
+    assert agent.rules == AgentRules(text="be precise")
+
+
+# ---------------------------------------------------------------------------
+# Rules delivery: the bound text actually reaches the spawned `oc` command.
+# ---------------------------------------------------------------------------
+
+
+def test_prepend_rules_passes_prompt_through_when_rules_empty() -> None:
+    from devops_bench.agents.cli.openclaw.agent import _prepend_rules
+
+    assert _prepend_rules("", "do the thing") == "do the thing"
+    assert _prepend_rules("   \n  ", "do the thing") == "do the thing"
+
+
+def test_prepend_rules_separates_brief_from_prompt_with_blank_line() -> None:
+    from devops_bench.agents.cli.openclaw.agent import _prepend_rules
+
+    assert _prepend_rules("be careful", "audit pods") == "be careful\n\naudit pods"
+
+
+def test_execute_prepends_bound_rules_to_oc_prompt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The rules text must land inside the bash command string the agent
+    spawns — specifically inside the ``-m '<prompt>'`` segment that ``oc
+    agent`` reads. We capture the command and assert both the original prompt
+    and the rules text are present, with the rules ahead of the prompt."""
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    _install_oc_run(monkeypatch, fake_bash)
+
+    caps = AllCapabilities(rules=AgentRules(text="you are a precise SRE"))
+    OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"), capabilities=caps)).run(
+        "audit pods in default"
+    )
+
+    cmd = captured["cmd"]
+    assert "you are a precise SRE" in cmd, "rules text must reach the spawned oc command"
+    assert "audit pods in default" in cmd, "task prompt must still reach oc"
+    # The rules brief must precede the task prompt — order matters because the
+    # model reads it as the leading context.
+    assert cmd.index("you are a precise SRE") < cmd.index("audit pods in default")
+
+
+def test_execute_does_not_prepend_rules_when_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """With default (empty) rules, the prompt reaches oc unchanged — no
+    accidental blank-line prefix that would shift the model's attention."""
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    _install_oc_run(monkeypatch, fake_bash)
+
+    OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"))).run("just the prompt")
+    cmd = captured["cmd"]
+    # The agent shlex-quotes the prompt; "just the prompt" appears verbatim
+    # inside single quotes in the `-m` segment — and no extra blank-line
+    # prefix surrounds it.
+    assert "-m 'just the prompt'" in cmd
+
+
+# ---------------------------------------------------------------------------
+# MCP server wiring: mcp.servers reach an isolated OPENCLAW_CONFIG_PATH.
+# ---------------------------------------------------------------------------
+
+
+def test_build_openclaw_config_wraps_servers_under_mcp() -> None:
+    """A launchable binding renders under the ``mcp.servers`` config path."""
+    cfg = _build_openclaw_config(AgentConfig(), (McpBinding(name="gke", command=("gke-mcp",)),))
+    assert cfg == {"mcp": {"servers": {"gke": {"command": "gke-mcp"}}}}
+
+
+def test_build_openclaw_config_empty_without_launchable_server_or_override() -> None:
+    """No MCP binding and a catalog-known model → empty config (caller skips)."""
+    assert _build_openclaw_config(AgentConfig(), ()) == {}
+    assert (
+        _build_openclaw_config(
+            AgentConfig(model="gemini-3.1-pro-preview"),
+            (McpBinding(name="b", command=(), tools=("t",)),),
+        )
+        == {}
+    )
+
+
+def test_build_openclaw_config_merges_mcp_and_model_override() -> None:
+    """MCP servers and a model-catalog entry coexist (disjoint key spaces)."""
+    cfg = _build_openclaw_config(
+        AgentConfig(model="gemini-3.5-flash", provider="google"),
+        (McpBinding(name="gke", command=("gke-mcp",)),),
+    )
+    assert cfg["mcp"] == {"servers": {"gke": {"command": "gke-mcp"}}}
+    assert cfg["models"]["providers"]["google"]["models"] == [
+        {"id": "gemini-3.5-flash", "name": "gemini-3.5-flash"}
+    ]
+    assert cfg["agents"]["defaults"]["models"] == {"google/gemini-3.5-flash": {}}
+
+
+# ---------------------------------------------------------------------------
+# Model catalog override: models oc doesn't ship by default get registered in
+# the per-run isolated config, for both google-genai and google-vertex.
+# ---------------------------------------------------------------------------
+
+
+def test_model_override_empty_for_catalog_known_model() -> None:
+    """A model already in oc's catalog needs no override."""
+    assert _build_model_override(AgentConfig(model="gemini-3.1-pro-preview")) == {}
+
+
+def test_model_override_empty_when_no_model() -> None:
+    assert _build_model_override(AgentConfig()) == {}
+
+
+def test_model_override_genai_pins_generative_ai_transport() -> None:
+    """google-genai: the entry pins ``api: google-generative-ai`` so oc routes it
+    through the google-genai transport (a per-run provider entry replaces oc's
+    built-in one, so the transport must be carried) and needs no ``baseUrl``.
+    Allowlists ``google/<model>``."""
+    override = _build_model_override(AgentConfig(model="gemini-3.5-flash", provider="google"))
+    google = override["models"]["providers"]["google"]
+    assert google["api"] == "google-generative-ai"
+    assert "baseUrl" not in google
+    assert google["models"] == [{"id": "gemini-3.5-flash", "name": "gemini-3.5-flash"}]
+    assert override["agents"]["defaults"]["models"] == {"google/gemini-3.5-flash": {}}
+
+
+def test_model_override_gemini_alias_normalizes_to_google() -> None:
+    """``provider=gemini`` resolves to the ``google`` provider (id alias)."""
+    override = _build_model_override(AgentConfig(model="gemini-3.5-flash", provider="gemini"))
+    assert "google" in override["models"]["providers"]
+    assert override["agents"]["defaults"]["models"] == {"google/gemini-3.5-flash": {}}
+
+
+def test_model_override_vertex_pins_transport_and_allowlists() -> None:
+    """google-vertex: the entry pins ``api``/``baseUrl`` so oc uses the vertex
+    transport (not the OpenAI fallback), and allowlists ``google-vertex/<model>``."""
+    override = _build_model_override(
+        AgentConfig(model="gemini-3.5-flash", provider="google-vertex")
+    )
+    vertex = override["models"]["providers"]["google-vertex"]
+    assert vertex["api"] == "google-vertex"
+    assert vertex["baseUrl"] == "https://{location}-aiplatform.googleapis.com"
+    assert vertex["models"] == [{"id": "gemini-3.5-flash", "name": "gemini-3.5-flash"}]
+    assert override["agents"]["defaults"]["models"] == {"google-vertex/gemini-3.5-flash": {}}
+
+
+def test_model_override_vertex_needs_no_api_key() -> None:
+    """The override is independent of ``api_key`` — a keyless ADC vertex run still
+    gets its catalog entry (auth is the metadata-server ADC, set outside)."""
+    override = _build_model_override(
+        AgentConfig(model="gemini-3.5-flash", provider="google-vertex", api_key=None)
+    )
+    assert override["agents"]["defaults"]["models"] == {"google-vertex/gemini-3.5-flash": {}}
+    assert _build_env(AgentConfig(model="gemini-3.5-flash", provider="google-vertex")) == {}
+
+
+def test_build_env_threads_api_key_by_provider() -> None:
+    """``config.api_key`` lands on the provider-specific env var(s)."""
+    google = _build_env(AgentConfig(api_key="k", provider="google"))
+    assert google["GEMINI_API_KEY"] == "k" and google["GOOGLE_API_KEY"] == "k"
+    anthropic = _build_env(AgentConfig(api_key="k", provider="anthropic"))
+    assert anthropic == {"ANTHROPIC_API_KEY": "k"}
+    assert _build_env(AgentConfig()) == {}
+
+
+def test_build_env_routes_vertex_key_to_cloud_api_key() -> None:
+    """A ``google-vertex`` key reaches ``GOOGLE_CLOUD_API_KEY`` (the vertex
+    transport's var), not ``GEMINI_API_KEY`` (the google-genai one)."""
+    vertex = _build_env(AgentConfig(api_key="marker", provider="google-vertex"))
+    assert vertex == {"GOOGLE_CLOUD_API_KEY": "marker"}
+
+
+def test_build_env_unknown_provider_raises() -> None:
+    """An unknown provider fails loud instead of silently writing a Gemini key."""
+    with pytest.raises(ConfigError):
+        _build_env(AgentConfig(api_key="k", provider="mystery"))
+
+
+def test_build_env_unknown_provider_raises_even_when_keyless() -> None:
+    """Validation is unconditional — a typoed provider fails loud on a keyless
+    (Vertex/ADC) run too, not only when a key is set."""
+    with pytest.raises(ConfigError):
+        _build_env(AgentConfig(provider="google-vertyx"))
+
+
+def test_model_override_raises_for_unpinned_transport() -> None:
+    """A catalog-override model whose provider has no pinned transport fails loud
+    rather than shipping a transport-less entry (which would 401 via the OpenAI
+    fallback). A full-id with an unknown wire reaches this path."""
+    with pytest.raises(ConfigError):
+        _build_model_override(AgentConfig(model="mystery/gemini-3.5-flash"))
+
+
+def _empty_sessions_run(argv: list[str], **kwargs: Any) -> SimpleNamespace:
+    """Core-subprocess.run stub: ``oc sessions`` returns no rows."""
+    return _make_subprocess_result(stdout=json.dumps([]), returncode=0)
+
+
+def test_execute_writes_mcp_servers_into_isolated_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A command-bearing MCP binding lands in ``<cwd>/openclaw.json`` and
+    ``OPENCLAW_CONFIG_PATH`` is pointed at it (read inside the fake to beat
+    temp-dir cleanup)."""
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        env = kwargs.get("extra_env") or {}
+        cfg_path = env.get("OPENCLAW_CONFIG_PATH")
+        captured["cfg_path"] = cfg_path
+        captured["config"] = (
+            json.loads(Path(cfg_path).read_text()) if cfg_path and Path(cfg_path).exists() else None
+        )
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    _install_oc_run(monkeypatch, fake_bash, _empty_sessions_run)
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="gke", command=("gke-mcp",), tools=("mcp_gke_x",)),),
+    )
+    OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"), capabilities=caps)).run("p")
+    assert captured["cfg_path"], "OPENCLAW_CONFIG_PATH must be set when MCP is bound"
+    assert captured["config"] == {"mcp": {"servers": {"gke": {"command": "gke-mcp"}}}}
+
+
+def test_execute_writes_no_config_when_no_launchable_server(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No command-bearing MCP binding and a catalog-known model → no isolated
+    config, env var unset."""
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        env = kwargs.get("extra_env") or {}
+        captured["has_cfg"] = "OPENCLAW_CONFIG_PATH" in env
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    _install_oc_run(monkeypatch, fake_bash, _empty_sessions_run)
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="builtin", command=(), tools=("alpha",)),),
+    )
+    OpenClawAgent(
+        AgentConfig(
+            target=str(tmp_path / "oc"),
+            model="gemini-3.1-pro-preview",
+            capabilities=caps,
+        )
+    ).run("p")
+    assert captured["has_cfg"] is False
+
+
+def test_execute_writes_model_override_config_without_mcp(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A model absent from oc's catalog gets an isolated config + OPENCLAW_CONFIG_PATH
+    even with no MCP server — and works keyless (vertex/ADC)."""
+    for k in ("GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_CLOUD_API_KEY"):
+        monkeypatch.delenv(k, raising=False)
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        env = kwargs.get("extra_env") or {}
+        cfg_path = env.get("OPENCLAW_CONFIG_PATH")
+        captured["cfg_path"] = cfg_path
+        captured["config"] = (
+            json.loads(Path(cfg_path).read_text()) if cfg_path and Path(cfg_path).exists() else None
+        )
+        # ADC path: no API key threaded into the subprocess env.
+        captured["has_key"] = any(
+            k in env for k in ("GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_CLOUD_API_KEY")
+        )
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    _install_oc_run(monkeypatch, fake_bash, _empty_sessions_run)
+    OpenClawAgent(
+        AgentConfig(
+            target=str(tmp_path / "oc"),
+            model="gemini-3.5-flash",
+            provider="google-vertex",
+        )
+    ).run("p")
+    assert captured["cfg_path"], "OPENCLAW_CONFIG_PATH must be set for a catalog override"
+    vertex = captured["config"]["models"]["providers"]["google-vertex"]
+    assert vertex["api"] == "google-vertex"
+    assert captured["config"]["agents"]["defaults"]["models"] == {
+        "google-vertex/gemini-3.5-flash": {}
+    }
+    assert captured["has_key"] is False
+
+
+def test_execute_isolates_state_dir_and_drops_global_session_wipe(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``OPENCLAW_STATE_DIR`` points under the per-run cwd and the old global
+    ``rm -rf ~/.openclaw/.../sessions`` wipe is gone (state is fresh per run)."""
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        env = kwargs.get("extra_env") or {}
+        captured["state_dir"] = env.get("OPENCLAW_STATE_DIR")
+        captured["cwd"] = kwargs.get("cwd")
+        captured["cmd"] = cmd
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    _install_oc_run(monkeypatch, fake_bash, _empty_sessions_run)
+    OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"))).run("p")
+    assert captured["state_dir"] == os.path.join(captured["cwd"], "state")
+    assert "rm -rf" not in captured["cmd"]
+
+
+def test_execute_threads_api_key_into_subprocess_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The model API key reaches the spawned ``oc`` process env."""
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        captured["env"] = kwargs.get("extra_env") or {}
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    _install_oc_run(monkeypatch, fake_bash, _empty_sessions_run)
+    cfg = AgentConfig(target=str(tmp_path / "oc"), api_key="secret", provider="google")
+    OpenClawAgent(cfg).run("p")
+    assert captured["env"]["GEMINI_API_KEY"] == "secret"
+    assert captured["env"]["GOOGLE_API_KEY"] == "secret"
+
+
+def test_execute_materializes_skills_into_state_skills_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Bound skill paths are copied to ``<cwd>/state/skills/<name>/SKILL.md``."""
+    src = tmp_path / "skills" / "my-skill"
+    src.mkdir(parents=True)
+    skill_text = "---\nname: my-skill\ndescription: do things\n---\nbody\n"
+    (src / "SKILL.md").write_text(skill_text)
+
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        cwd = kwargs.get("cwd")
+        skill_path = os.path.join(cwd, "state", "skills", "my-skill", "SKILL.md")
+        captured["exists"] = os.path.exists(skill_path)
+        captured["text"] = Path(skill_path).read_text() if captured["exists"] else None
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    _install_oc_run(monkeypatch, fake_bash, _empty_sessions_run)
+    caps = AllCapabilities(skills=SkillBinding(paths=(str(tmp_path / "skills"),)))
+    OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"), capabilities=caps)).run("p")
+    assert captured["exists"], "skill must be materialized before subprocess"
+    assert captured["text"] == skill_text
+
+
+def test_execute_warns_and_skips_missing_skill_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A non-existent skill path is skipped (no crash, empty skills root)."""
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        cwd = kwargs.get("cwd")
+        skills_root = os.path.join(cwd, "state", "skills")
+        captured["entries"] = sorted(os.listdir(skills_root)) if os.path.isdir(skills_root) else []
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    _install_oc_run(monkeypatch, fake_bash, _empty_sessions_run)
+    caps = AllCapabilities(skills=SkillBinding(paths=("/no/such/skills/dir",)))
+    OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"), capabilities=caps)).run("p")
+    assert captured["entries"] == []
+
+
+def test_execute_cleans_up_temp_working_dir_after_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The per-run temp dir (state, config, skills) is removed after _execute."""
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    _install_oc_run(monkeypatch, fake_bash, _empty_sessions_run)
+    OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"))).run("p")
+    assert captured["cwd"] is not None
+    assert not os.path.exists(captured["cwd"])

--- a/tests/unit/models/test_models_claude.py
+++ b/tests/unit/models/test_models_claude.py
@@ -1,0 +1,382 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Claude adapter and its backend selection."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from devops_bench.core.errors import ConfigError, MissingDependencyError
+from devops_bench.models import claude
+from devops_bench.models.base import MODELS, get_model
+from devops_bench.models.claude import ClaudeClientAdapter
+
+
+def _make_tool(name: str, description: str, input_schema: dict) -> SimpleNamespace:
+    return SimpleNamespace(name=name, description=description, inputSchema=input_schema)
+
+
+# --- backend selection / construction ----------------------------------------
+
+
+def test_init_selects_vertex_from_project(mocker: MockerFixture) -> None:
+    client_cls = mocker.patch.object(claude, "AsyncAnthropicVertex")
+    mocker.patch.dict(
+        os.environ, {"GCP_PROJECT_ID": "proj", "GCP_VERTEX_LOCATION": "us-east5"}, clear=True
+    )
+
+    adapter = ClaudeClientAdapter()
+
+    client_cls.assert_called_once_with(region="us-east5", project_id="proj")
+    assert adapter.model_name == "claude-sonnet-4-5@20250929"
+
+
+def test_init_defaults_to_vertex_and_warns(mocker: MockerFixture) -> None:
+    mocker.patch.object(claude, "AsyncAnthropicVertex")
+    warn = mocker.patch.object(claude._log, "warning")
+    mocker.patch.dict(os.environ, {}, clear=True)
+
+    adapter = ClaudeClientAdapter()
+
+    warn.assert_called_once()
+    assert adapter.model_name == "claude-sonnet-4-5@20250929"
+
+
+def test_init_selects_api_from_key(mocker: MockerFixture) -> None:
+    client_cls = mocker.patch.object(claude, "AsyncAnthropic")
+    mocker.patch.dict(os.environ, {"AGENT_API_KEY": "sk-test"}, clear=True)
+
+    adapter = ClaudeClientAdapter()
+
+    client_cls.assert_called_once_with(api_key="sk-test")
+    assert adapter.model_name == "claude-sonnet-4-5"
+
+
+def test_init_api_key_takes_precedence_over_project(mocker: MockerFixture) -> None:
+    api_cls = mocker.patch.object(claude, "AsyncAnthropic")
+    vertex_cls = mocker.patch.object(claude, "AsyncAnthropicVertex")
+    mocker.patch.dict(
+        os.environ, {"AGENT_API_KEY": "sk-test", "GCP_PROJECT_ID": "proj"}, clear=True
+    )
+
+    ClaudeClientAdapter()
+
+    api_cls.assert_called_once()
+    vertex_cls.assert_not_called()
+
+
+def test_init_selects_bedrock_from_aws_region(mocker: MockerFixture) -> None:
+    client_cls = mocker.patch.object(claude, "AsyncAnthropicBedrock")
+    mocker.patch.dict(
+        os.environ, {"AWS_REGION": "us-west-2", "AGENT_MODEL": "anthropic.claude-x"}, clear=True
+    )
+
+    adapter = ClaudeClientAdapter()
+
+    client_cls.assert_called_once_with(aws_region="us-west-2")
+    assert adapter.model_name == "anthropic.claude-x"
+
+
+def test_init_bedrock_requires_model(mocker: MockerFixture) -> None:
+    mocker.patch.object(claude, "AsyncAnthropicBedrock")
+    mocker.patch.dict(os.environ, {"AWS_REGION": "us-west-2"}, clear=True)
+
+    with pytest.raises(ConfigError):
+        ClaudeClientAdapter()
+
+
+def test_init_backend_override_forces_vertex(mocker: MockerFixture) -> None:
+    mocker.patch.object(claude, "AsyncAnthropic")
+    vertex_cls = mocker.patch.object(claude, "AsyncAnthropicVertex")
+    mocker.patch.dict(
+        os.environ, {"AGENT_API_KEY": "sk-test", "ANTHROPIC_BACKEND": "vertex"}, clear=True
+    )
+
+    ClaudeClientAdapter()
+
+    vertex_cls.assert_called_once()
+
+
+def test_init_backend_override_invalid_raises(mocker: MockerFixture) -> None:
+    mocker.patch.dict(os.environ, {"ANTHROPIC_BACKEND": "nope"}, clear=True)
+
+    with pytest.raises(ConfigError):
+        ClaudeClientAdapter()
+
+
+def test_init_backend_arg_forces_vertex_over_api_key(mocker: MockerFixture) -> None:
+    api_cls = mocker.patch.object(claude, "AsyncAnthropic")
+    vertex_cls = mocker.patch.object(claude, "AsyncAnthropicVertex")
+    # anthropic-vertex provider passes backend="vertex"; a stray API key must not
+    # flip it to the api backend (decoupling Vertex auth from the key).
+    mocker.patch.dict(
+        os.environ, {"AGENT_API_KEY": "sk-test", "AGENT_MODEL": "claude-x"}, clear=True
+    )
+
+    ClaudeClientAdapter(backend="vertex")
+
+    vertex_cls.assert_called_once()
+    api_cls.assert_not_called()
+
+
+def test_init_backend_arg_forces_bedrock(mocker: MockerFixture) -> None:
+    bedrock_cls = mocker.patch.object(claude, "AsyncAnthropicBedrock")
+    mocker.patch.dict(
+        os.environ, {"AWS_REGION": "us-west-2", "AGENT_MODEL": "anthropic.claude-x"}, clear=True
+    )
+
+    ClaudeClientAdapter(backend="bedrock")
+
+    bedrock_cls.assert_called_once_with(aws_region="us-west-2")
+
+
+def test_init_backend_none_still_infers(mocker: MockerFixture) -> None:
+    api_cls = mocker.patch.object(claude, "AsyncAnthropic")
+    mocker.patch.dict(os.environ, {"AGENT_API_KEY": "sk-test"}, clear=True)
+
+    ClaudeClientAdapter(backend=None)
+
+    api_cls.assert_called_once_with(api_key="sk-test")
+
+
+def test_init_without_sdk_raises(mocker: MockerFixture) -> None:
+    mocker.patch.object(claude, "AsyncAnthropic", None)
+
+    with pytest.raises(MissingDependencyError):
+        ClaudeClientAdapter()
+
+
+# --- format_tools -------------------------------------------------------------
+
+
+def test_format_tools_shape(mocker: MockerFixture) -> None:
+    mocker.patch.object(claude, "AsyncAnthropicVertex")
+    adapter = ClaudeClientAdapter()
+    schema = {"type": "object", "properties": {}}
+
+    result = adapter.format_tools([_make_tool("t", "d", schema)])
+
+    assert result == [{"name": "t", "description": "d", "input_schema": schema}]
+
+
+# --- extract_function_calls ---------------------------------------------------
+
+
+def test_extract_function_calls(mocker: MockerFixture) -> None:
+    mocker.patch.object(claude, "AsyncAnthropicVertex")
+    adapter = ClaudeClientAdapter()
+
+    response = SimpleNamespace(
+        content=[
+            SimpleNamespace(type="text", text="ignored"),
+            SimpleNamespace(type="tool_use", name="fc", input={"a": 1}, id="tool-1"),
+        ]
+    )
+
+    assert adapter.extract_function_calls(response) == [
+        {"name": "fc", "args": {"a": 1}, "id": "tool-1"}
+    ]
+
+
+# --- get_text_content ---------------------------------------------------------
+
+
+def test_get_text_content_concatenates(mocker: MockerFixture) -> None:
+    mocker.patch.object(claude, "AsyncAnthropicVertex")
+    adapter = ClaudeClientAdapter()
+
+    response = SimpleNamespace(
+        content=[
+            SimpleNamespace(type="text", text="hello "),
+            SimpleNamespace(type="tool_use", name="x", input={}, id="i"),
+            SimpleNamespace(type="text", text="world"),
+        ]
+    )
+
+    assert adapter.get_text_content(response) == "hello world"
+
+
+# --- generate_content ---------------------------------------------------------
+
+
+def test_generate_content_passes_max_tokens_and_system(mocker: MockerFixture) -> None:
+    client = mocker.patch.object(claude, "AsyncAnthropicVertex").return_value
+    create = AsyncMock(return_value="resp")
+    client.messages.create = create
+    mocker.patch.dict(os.environ, {}, clear=True)
+
+    adapter = ClaudeClientAdapter()
+    tools = adapter.format_tools([_make_tool("t", "d", {"type": "object"})])
+
+    result = asyncio.run(
+        adapter.generate_content([{"role": "user", "content": "hello"}], tools, "be helpful")
+    )
+
+    assert result == "resp"
+    create.assert_awaited_once()
+    kwargs = create.await_args.kwargs
+    assert kwargs["max_tokens"] == 16000
+    assert kwargs["model"] == adapter.model_name
+    assert kwargs["system"] == "be helpful"
+    assert kwargs["messages"] == [{"role": "user", "content": "hello"}]
+    assert kwargs["tools"] == tools
+
+
+def test_generate_content_default_max_tokens(mocker: MockerFixture) -> None:
+    client = mocker.patch.object(claude, "AsyncAnthropicVertex").return_value
+    create = AsyncMock(return_value="resp")
+    client.messages.create = create
+    mocker.patch.dict(os.environ, {}, clear=True)
+
+    adapter = ClaudeClientAdapter()
+    asyncio.run(adapter.generate_content([{"role": "user", "content": "hi"}], [], None))
+
+    assert create.await_args.kwargs["max_tokens"] == 16000
+
+
+def test_generate_content_env_overrides_max_tokens(mocker: MockerFixture) -> None:
+    client = mocker.patch.object(claude, "AsyncAnthropicVertex").return_value
+    create = AsyncMock(return_value="resp")
+    client.messages.create = create
+    mocker.patch.dict(os.environ, {"AGENT_MAX_TOKENS": "12345"}, clear=True)
+
+    adapter = ClaudeClientAdapter()
+    asyncio.run(adapter.generate_content([{"role": "user", "content": "hi"}], [], None))
+
+    assert adapter.max_tokens == 12345
+    assert create.await_args.kwargs["max_tokens"] == 12345
+
+
+def test_generate_content_arg_overrides_env_max_tokens(mocker: MockerFixture) -> None:
+    client = mocker.patch.object(claude, "AsyncAnthropicVertex").return_value
+    create = AsyncMock(return_value="resp")
+    client.messages.create = create
+    mocker.patch.dict(os.environ, {"AGENT_MAX_TOKENS": "12345"}, clear=True)
+
+    adapter = ClaudeClientAdapter(max_tokens=999)
+    asyncio.run(adapter.generate_content([{"role": "user", "content": "hi"}], [], None))
+
+    assert adapter.max_tokens == 999
+    assert create.await_args.kwargs["max_tokens"] == 999
+
+
+def test_generate_content_omits_system_when_empty(mocker: MockerFixture) -> None:
+    client = mocker.patch.object(claude, "AsyncAnthropicVertex").return_value
+    create = AsyncMock(return_value="resp")
+    client.messages.create = create
+    mocker.patch.dict(os.environ, {}, clear=True)
+
+    adapter = ClaudeClientAdapter()
+    asyncio.run(adapter.generate_content([{"role": "user", "content": "hi"}], [], None))
+
+    assert "system" not in create.await_args.kwargs
+
+
+def test_generate_content_omits_tools_when_empty(mocker: MockerFixture) -> None:
+    client = mocker.patch.object(claude, "AsyncAnthropicVertex").return_value
+    create = AsyncMock(return_value="resp")
+    client.messages.create = create
+    mocker.patch.dict(os.environ, {}, clear=True)
+
+    adapter = ClaudeClientAdapter()
+    asyncio.run(adapter.generate_content([{"role": "user", "content": "hi"}], [], "sys"))
+
+    assert "tools" not in create.await_args.kwargs
+
+
+def test_convert_messages_tool_calls_and_results(mocker: MockerFixture) -> None:
+    mocker.patch.object(claude, "AsyncAnthropicVertex")
+    adapter = ClaudeClientAdapter()
+
+    contents = [
+        {"role": "user", "content": "do it"},
+        {
+            "role": "assistant",
+            "content": "thinking",
+            "tool_calls": [{"id": "c1", "name": "fc", "args": {"k": "v"}}],
+        },
+        {"role": "tool", "content": "result", "tool_call_id": "c1"},
+    ]
+
+    messages = adapter._convert_to_anthropic_messages(contents)
+
+    assert messages[0] == {"role": "user", "content": "do it"}
+    assert messages[1]["content"][0] == {"type": "text", "text": "thinking"}
+    assert messages[1]["content"][1] == {
+        "type": "tool_use",
+        "id": "c1",
+        "name": "fc",
+        "input": {"k": "v"},
+    }
+    assert messages[2]["content"][0] == {
+        "type": "tool_result",
+        "tool_use_id": "c1",
+        "content": "result",
+    }
+
+
+def test_convert_messages_groups_parallel_tool_results(mocker: MockerFixture) -> None:
+    mocker.patch.object(claude, "AsyncAnthropicVertex")
+    adapter = ClaudeClientAdapter()
+
+    contents = [
+        {"role": "user", "content": "do it"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "c1", "name": "fc1", "args": {}},
+                {"id": "c2", "name": "fc2", "args": {}},
+            ],
+        },
+        {"role": "tool", "content": "r1", "tool_call_id": "c1"},
+        {"role": "tool", "content": "r2", "tool_call_id": "c2"},
+    ]
+
+    messages = adapter._convert_to_anthropic_messages(contents)
+
+    # The two tool results must collapse into a single trailing user message
+    # with two tool_result blocks (no back-to-back user turns).
+    assert len(messages) == 3
+    assert messages[2]["role"] == "user"
+    assert messages[2]["content"] == [
+        {"type": "tool_result", "tool_use_id": "c1", "content": "r1"},
+        {"type": "tool_result", "tool_use_id": "c2", "content": "r2"},
+    ]
+
+
+# --- registry / provider resolution -------------------------------------------
+
+
+def test_registered_in_models_registry() -> None:
+    assert MODELS.get("claude") is ClaudeClientAdapter
+
+
+@pytest.mark.parametrize(
+    "provider", ["claude", "anthropic", "anthropic-vertex", "anthropic_vertex"]
+)
+def test_get_model_resolves_claude_aliases(mocker: MockerFixture, provider: str) -> None:
+    mocker.patch.object(claude, "AsyncAnthropicVertex")
+    mocker.patch.dict(os.environ, {"GCP_PROJECT_ID": "proj"}, clear=True)
+
+    client = get_model(provider=provider)
+
+    assert isinstance(client, ClaudeClientAdapter)

--- a/tests/unit/models/test_models_gemini.py
+++ b/tests/unit/models/test_models_gemini.py
@@ -1,0 +1,393 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Gemini (google-genai) adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from devops_bench.models import gemini
+from devops_bench.models.base import MODELS, get_model
+from devops_bench.models.gemini import GeminiClientAdapter, filter_schema_for_gemini
+
+
+def _make_tool(name: str, description: str, input_schema: dict) -> SimpleNamespace:
+    return SimpleNamespace(name=name, description=description, inputSchema=input_schema)
+
+
+# --- filter_schema_for_gemini -------------------------------------------------
+
+
+def test_filter_schema_upper_cases_type_and_drops_unsupported() -> None:
+    schema = {
+        "type": "object",
+        "title": "ignored",
+        "properties": {
+            "count": {"type": "integer", "description": "a count"},
+            "name": {"type": ["string", "null"]},
+        },
+        "required": ["count"],
+    }
+
+    result = filter_schema_for_gemini(schema)
+
+    assert result["type"] == "OBJECT"
+    assert "title" not in result
+    assert result["properties"]["count"] == {"type": "INTEGER", "description": "a count"}
+    # Nullable union collapses to nullable + the non-null type.
+    assert result["properties"]["name"] == {"type": "STRING", "nullable": True}
+    assert result["required"] == ["count"]
+
+
+def test_filter_schema_bool_inputs() -> None:
+    assert filter_schema_for_gemini(True) == {}
+    assert filter_schema_for_gemini(False) is None
+
+
+def test_filter_schema_normalizes_ref_and_defs_aliases() -> None:
+    """``$defs``/``$ref`` are rewritten to ``defs``/``ref`` — google-genai's
+    Schema rejects the ``$``-prefixed spellings with a validation error — and
+    pointer values into the renamed container are rewritten to match
+    (``ref`` resolves against the root ``defs`` per the Schema field docs)."""
+    schema = {
+        "type": "object",
+        "properties": {"x": {"$ref": "#/$defs/item"}},
+        "$defs": {"item": {"type": "string"}},
+    }
+
+    result = filter_schema_for_gemini(schema)
+
+    assert result["defs"] == {"item": {"type": "STRING"}}
+    assert result["properties"]["x"] == {"ref": "#/defs/item"}
+    assert "$defs" not in result
+    assert "$ref" not in result["properties"]["x"]
+
+
+def test_filter_schema_collapses_oneof_into_anyof() -> None:
+    """google-genai's Schema has no oneOf field at all; both spellings map to
+    anyOf, and a oneOf merges into an anyOf already present."""
+    schema = {
+        "anyOf": [{"type": "string"}],
+        "oneOf": [{"type": "integer"}],
+        "one_of": [{"type": "boolean"}],
+    }
+
+    result = filter_schema_for_gemini(schema)
+
+    assert "oneOf" not in result
+    assert "one_of" not in result
+    assert result["anyOf"] == [{"type": "STRING"}, {"type": "INTEGER"}, {"type": "BOOLEAN"}]
+
+
+def test_filtered_schema_is_accepted_by_the_sdk() -> None:
+    """Ground truth: the filtered output of an alias-heavy schema must construct
+    a FunctionDeclaration without a pydantic validation error."""
+    from google.genai import types
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "target": {"oneOf": [{"type": "string"}, {"type": "integer"}]},
+            "item": {"$ref": "#/$defs/item"},
+        },
+        "$defs": {"item": {"type": "string"}},
+    }
+
+    types.FunctionDeclaration(name="t", parameters=filter_schema_for_gemini(schema))
+
+
+# --- client selection by env --------------------------------------------------
+
+
+def test_client_selection_api_key(mocker: MockerFixture) -> None:
+    client_cls = mocker.patch.object(gemini.genai, "Client")
+    mocker.patch.dict(os.environ, {"AGENT_API_KEY": "k", "GCP_PROJECT_ID": "p"}, clear=True)
+
+    GeminiClientAdapter()
+
+    client_cls.assert_called_once_with(api_key="k")
+
+
+def test_client_selection_vertex(mocker: MockerFixture) -> None:
+    client_cls = mocker.patch.object(gemini.genai, "Client")
+    mocker.patch.dict(
+        os.environ, {"GCP_PROJECT_ID": "proj", "GCP_VERTEX_LOCATION": "europe-west1"}, clear=True
+    )
+
+    GeminiClientAdapter()
+
+    client_cls.assert_called_once_with(vertexai=True, project="proj", location="europe-west1")
+
+
+def test_client_selection_default(mocker: MockerFixture) -> None:
+    client_cls = mocker.patch.object(gemini.genai, "Client")
+    mocker.patch.dict(os.environ, {}, clear=True)
+
+    adapter = GeminiClientAdapter()
+
+    client_cls.assert_called_once_with()
+    assert adapter.model_name == "gemini-3.1-pro-preview"
+
+
+def test_backend_vertex_forces_vertex_even_with_api_key(mocker: MockerFixture) -> None:
+    client_cls = mocker.patch.object(gemini.genai, "Client")
+    # An API key is present, but backend="vertex" (the google-vertex provider)
+    # must still build the Vertex client — provider decides, not key presence.
+    mocker.patch.dict(os.environ, {"AGENT_API_KEY": "k", "GCP_PROJECT_ID": "proj"}, clear=True)
+
+    GeminiClientAdapter(backend="vertex")
+
+    client_cls.assert_called_once_with(vertexai=True, project="proj", location="global")
+
+
+def test_backend_none_keeps_inference(mocker: MockerFixture) -> None:
+    client_cls = mocker.patch.object(gemini.genai, "Client")
+    mocker.patch.dict(os.environ, {"AGENT_API_KEY": "k"}, clear=True)
+
+    GeminiClientAdapter(backend=None)
+
+    client_cls.assert_called_once_with(api_key="k")
+
+
+# --- format_tools -------------------------------------------------------------
+
+
+def test_format_tools_applies_filter(mocker: MockerFixture) -> None:
+    mocker.patch.object(gemini.genai, "Client")
+    adapter = GeminiClientAdapter()
+    tool = _make_tool("do_thing", "does a thing", {"type": "object", "title": "drop"})
+
+    result = adapter.format_tools([tool])
+
+    decl = result.function_declarations[0]
+    assert decl.name == "do_thing"
+    assert decl.description == "does a thing"
+    # filter_schema_for_gemini upper-cased the type and dropped unsupported keys.
+    assert decl.parameters.type == "OBJECT"
+
+
+# --- extract_function_calls ---------------------------------------------------
+
+
+def test_extract_function_calls(mocker: MockerFixture) -> None:
+    mocker.patch.object(gemini.genai, "Client")
+    adapter = GeminiClientAdapter()
+
+    part = SimpleNamespace(
+        function_call=SimpleNamespace(name="fc", args={"x": 1}),
+        thought_signature=b"sig",
+    )
+    response = SimpleNamespace(candidates=[SimpleNamespace(content=SimpleNamespace(parts=[part]))])
+
+    calls = adapter.extract_function_calls(response)
+
+    assert calls == [
+        {
+            "name": "fc",
+            "args": {"x": 1},
+            "id": None,
+            "thought_signature": base64.b64encode(b"sig").decode("utf-8"),
+        }
+    ]
+
+
+def test_extract_function_calls_no_candidates(mocker: MockerFixture) -> None:
+    mocker.patch.object(gemini.genai, "Client")
+    adapter = GeminiClientAdapter()
+
+    assert adapter.extract_function_calls(SimpleNamespace(candidates=None)) == []
+
+
+# --- get_text_content ---------------------------------------------------------
+
+
+def test_get_text_content(mocker: MockerFixture) -> None:
+    mocker.patch.object(gemini.genai, "Client")
+    adapter = GeminiClientAdapter()
+
+    assert adapter.get_text_content(SimpleNamespace(text="hi")) == "hi"
+    assert adapter.get_text_content(SimpleNamespace(text=None)) == ""
+
+
+# --- generate_content ---------------------------------------------------------
+
+
+def test_generate_content_invokes_sdk(mocker: MockerFixture) -> None:
+    client = mocker.patch.object(gemini.genai, "Client").return_value
+    generate = AsyncMock(return_value="resp")
+    client.aio.models.generate_content = generate
+
+    adapter = GeminiClientAdapter()
+    tools = adapter.format_tools([_make_tool("t", "d", {"type": "object", "properties": {}})])
+
+    result = asyncio.run(
+        adapter.generate_content([{"role": "user", "content": "hello"}], tools, "be helpful")
+    )
+
+    assert result == "resp"
+    generate.assert_awaited_once()
+    kwargs = generate.await_args.kwargs
+    assert kwargs["model"] == adapter.model_name
+    assert kwargs["contents"]  # converted gemini messages
+
+
+class _FakeAPIError(Exception):
+    """SDK-like error carrying an HTTP status ``code``."""
+
+    def __init__(self, code: int, message: str = "") -> None:
+        super().__init__(message or str(code))
+        self.code = code
+
+
+def test_generate_content_retries_on_429_then_succeeds(mocker: MockerFixture) -> None:
+    client = mocker.patch.object(gemini.genai, "Client").return_value
+    sleep = mocker.patch.object(gemini.asyncio, "sleep", new=AsyncMock())
+    generate = AsyncMock(side_effect=[_FakeAPIError(429, "RESOURCE_EXHAUSTED"), "resp"])
+    client.aio.models.generate_content = generate
+
+    adapter = GeminiClientAdapter()
+    result = asyncio.run(adapter.generate_content([{"role": "user", "content": "hi"}], None, None))
+
+    assert result == "resp"
+    assert generate.await_count == 2
+    sleep.assert_awaited_once()
+
+
+def test_generate_content_does_not_retry_non_retryable(mocker: MockerFixture) -> None:
+    client = mocker.patch.object(gemini.genai, "Client").return_value
+    sleep = mocker.patch.object(gemini.asyncio, "sleep", new=AsyncMock())
+    generate = AsyncMock(side_effect=_FakeAPIError(400, "INVALID_ARGUMENT"))
+    client.aio.models.generate_content = generate
+
+    adapter = GeminiClientAdapter()
+    try:
+        asyncio.run(adapter.generate_content([{"role": "user", "content": "hi"}], None, None))
+    except _FakeAPIError as exc:
+        assert exc.code == 400
+    else:  # pragma: no cover - the call must propagate
+        raise AssertionError("expected the non-retryable error to propagate")
+
+    assert generate.await_count == 1
+    sleep.assert_not_awaited()
+
+
+def test_generate_content_gives_up_after_max_retries(mocker: MockerFixture) -> None:
+    client = mocker.patch.object(gemini.genai, "Client").return_value
+    mocker.patch.object(gemini.asyncio, "sleep", new=AsyncMock())
+    generate = AsyncMock(side_effect=_FakeAPIError(503, "UNAVAILABLE"))
+    client.aio.models.generate_content = generate
+
+    adapter = GeminiClientAdapter()
+    try:
+        asyncio.run(adapter.generate_content([{"role": "user", "content": "hi"}], None, None))
+    except _FakeAPIError as exc:
+        assert exc.code == 503
+    else:  # pragma: no cover
+        raise AssertionError("expected the error to propagate after retries")
+
+    assert generate.await_count == gemini._MAX_RETRIES + 1
+
+
+def test_generate_content_includes_system_instruction(mocker: MockerFixture) -> None:
+    client = mocker.patch.object(gemini.genai, "Client").return_value
+    captured: dict = {}
+
+    def fake_config(**config_args):
+        captured.update(config_args)
+        return SimpleNamespace(**config_args)
+
+    mocker.patch.object(gemini.types, "GenerateContentConfig", side_effect=fake_config)
+    client.aio.models.generate_content = AsyncMock(return_value="resp")
+
+    adapter = GeminiClientAdapter()
+    asyncio.run(
+        adapter.generate_content([{"role": "user", "content": "hello"}], None, "be helpful")
+    )
+
+    assert captured["system_instruction"] == "be helpful"
+
+
+def test_generate_content_omits_system_instruction_when_none(mocker: MockerFixture) -> None:
+    client = mocker.patch.object(gemini.genai, "Client").return_value
+    captured: dict = {}
+
+    def fake_config(**config_args):
+        captured.update(config_args)
+        return SimpleNamespace(**config_args)
+
+    mocker.patch.object(gemini.types, "GenerateContentConfig", side_effect=fake_config)
+    client.aio.models.generate_content = AsyncMock(return_value="resp")
+
+    adapter = GeminiClientAdapter()
+    asyncio.run(adapter.generate_content([{"role": "user", "content": "hello"}], None, None))
+
+    assert "system_instruction" not in captured
+
+
+# --- _convert_to_gemini_messages ----------------------------------------------
+
+
+def test_convert_messages_groups_parallel_tool_results(mocker: MockerFixture) -> None:
+    mocker.patch.object(gemini.genai, "Client")
+    adapter = GeminiClientAdapter()
+
+    contents = [
+        {"role": "user", "content": "do it"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"name": "fc1", "args": {}},
+                {"name": "fc2", "args": {}},
+            ],
+        },
+        {"role": "tool", "name": "fc1", "content": "r1"},
+        {"role": "tool", "name": "fc2", "content": "r2"},
+    ]
+
+    gemini_contents = adapter._convert_to_gemini_messages(contents)
+
+    # The two tool results must collapse into a single trailing user Content
+    # with two parts (no back-to-back user Contents).
+    assert len(gemini_contents) == 3
+    last = gemini_contents[-1]
+    assert last.role == "user"
+    assert len(last.parts) == 2
+    assert last.parts[0].function_response.name == "fc1"
+    assert last.parts[1].function_response.name == "fc2"
+
+
+# --- registry / provider resolution -------------------------------------------
+
+
+def test_registered_in_models_registry() -> None:
+    assert MODELS.get("gemini") is GeminiClientAdapter
+
+
+@pytest.mark.parametrize("provider", ["gemini", "google", "google-vertex", "google_vertex"])
+def test_get_model_resolves_gemini_aliases(mocker: MockerFixture, provider: str) -> None:
+    mocker.patch.object(gemini.genai, "Client")
+    mocker.patch.dict(os.environ, {}, clear=True)
+
+    client = get_model(provider=provider)
+
+    assert isinstance(client, GeminiClientAdapter)

--- a/tests/unit/models/test_models_ollama.py
+++ b/tests/unit/models/test_models_ollama.py
@@ -1,0 +1,272 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Ollama (OpenAI-compatible) adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from devops_bench.core.errors import MissingDependencyError
+from devops_bench.models import ollama
+from devops_bench.models.base import MODELS, get_model
+from devops_bench.models.ollama import OllamaClientAdapter
+
+
+def _make_tool(name: str, description: str, input_schema: dict) -> SimpleNamespace:
+    return SimpleNamespace(name=name, description=description, inputSchema=input_schema)
+
+
+# --- construction / client selection -----------------------------------------
+
+
+def test_init_uses_defaults(mocker: MockerFixture) -> None:
+    client_cls = mocker.patch.object(ollama, "AsyncOpenAI")
+    mocker.patch.dict(os.environ, {}, clear=True)
+
+    adapter = OllamaClientAdapter()
+
+    client_cls.assert_called_once_with(base_url="http://localhost:11434/v1", api_key="ollama")
+    assert adapter.model_name == "gemma4:2b"
+
+
+def test_init_reads_env(mocker: MockerFixture) -> None:
+    client_cls = mocker.patch.object(ollama, "AsyncOpenAI")
+    mocker.patch.dict(
+        os.environ,
+        {"AGENT_MODEL": "llama3:8b", "OLLAMA_BASE_URL": "http://remote:11434/v1"},
+        clear=True,
+    )
+
+    adapter = OllamaClientAdapter()
+
+    client_cls.assert_called_once_with(base_url="http://remote:11434/v1", api_key="ollama")
+    assert adapter.model_name == "llama3:8b"
+
+
+def test_init_args_override_env(mocker: MockerFixture) -> None:
+    client_cls = mocker.patch.object(ollama, "AsyncOpenAI")
+    mocker.patch.dict(
+        os.environ,
+        {"AGENT_MODEL": "llama3:8b", "OLLAMA_BASE_URL": "http://remote:11434/v1"},
+        clear=True,
+    )
+
+    adapter = OllamaClientAdapter(model_name="mistral", base_url="http://override/v1")
+
+    client_cls.assert_called_once_with(base_url="http://override/v1", api_key="ollama")
+    assert adapter.model_name == "mistral"
+
+
+def test_init_uses_agent_api_key_when_set(mocker: MockerFixture) -> None:
+    client_cls = mocker.patch.object(ollama, "AsyncOpenAI")
+    mocker.patch.dict(os.environ, {"AGENT_API_KEY": "sk-remote"}, clear=True)
+
+    OllamaClientAdapter()
+
+    # Ollama supports optional key-based auth (remote/hosted endpoints).
+    client_cls.assert_called_once_with(base_url="http://localhost:11434/v1", api_key="sk-remote")
+
+
+def test_init_without_sdk_raises(mocker: MockerFixture) -> None:
+    mocker.patch.object(ollama, "AsyncOpenAI", None)
+
+    with pytest.raises(MissingDependencyError):
+        OllamaClientAdapter()
+
+
+# --- format_tools -------------------------------------------------------------
+
+
+def test_format_tools_shape(mocker: MockerFixture) -> None:
+    mocker.patch.object(ollama, "AsyncOpenAI")
+    adapter = OllamaClientAdapter()
+    schema = {"type": "object", "properties": {}}
+
+    result = adapter.format_tools([_make_tool("t", "d", schema)])
+
+    assert result == [
+        {"type": "function", "function": {"name": "t", "description": "d", "parameters": schema}}
+    ]
+
+
+# --- extract_function_calls ---------------------------------------------------
+
+
+def test_extract_function_calls_parses_json_args(mocker: MockerFixture) -> None:
+    mocker.patch.object(ollama, "AsyncOpenAI")
+    adapter = OllamaClientAdapter()
+
+    tool_call = SimpleNamespace(
+        id="call-1", function=SimpleNamespace(name="fc", arguments='{"a": 1}')
+    )
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(tool_calls=[tool_call]))]
+    )
+
+    assert adapter.extract_function_calls(response) == [
+        {"name": "fc", "args": {"a": 1}, "id": "call-1"}
+    ]
+
+
+def test_extract_function_calls_invalid_json_falls_back_to_empty(mocker: MockerFixture) -> None:
+    mocker.patch.object(ollama, "AsyncOpenAI")
+    adapter = OllamaClientAdapter()
+
+    tool_call = SimpleNamespace(id="c", function=SimpleNamespace(name="fc", arguments="not-json"))
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(tool_calls=[tool_call]))]
+    )
+
+    assert adapter.extract_function_calls(response) == [{"name": "fc", "args": {}, "id": "c"}]
+
+
+def test_extract_function_calls_none(mocker: MockerFixture) -> None:
+    mocker.patch.object(ollama, "AsyncOpenAI")
+    adapter = OllamaClientAdapter()
+
+    response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(tool_calls=None))])
+
+    assert adapter.extract_function_calls(response) == []
+
+
+# --- get_text_content ---------------------------------------------------------
+
+
+def test_get_text_content(mocker: MockerFixture) -> None:
+    mocker.patch.object(ollama, "AsyncOpenAI")
+    adapter = OllamaClientAdapter()
+
+    response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="hello"))])
+    assert adapter.get_text_content(response) == "hello"
+
+
+def test_get_text_content_empty(mocker: MockerFixture) -> None:
+    mocker.patch.object(ollama, "AsyncOpenAI")
+    adapter = OllamaClientAdapter()
+
+    response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=None))])
+    assert adapter.get_text_content(response) == ""
+
+
+# --- generate_content ---------------------------------------------------------
+
+
+def test_generate_content_passes_model_and_tools(mocker: MockerFixture) -> None:
+    client = mocker.patch.object(ollama, "AsyncOpenAI").return_value
+    create = AsyncMock(return_value="resp")
+    client.chat.completions.create = create
+
+    adapter = OllamaClientAdapter()
+    tools = adapter.format_tools([_make_tool("t", "d", {"type": "object"})])
+
+    result = asyncio.run(
+        adapter.generate_content([{"role": "user", "content": "hi"}], tools, "be helpful")
+    )
+
+    assert result == "resp"
+    kwargs = create.await_args.kwargs
+    assert kwargs["model"] == adapter.model_name
+    assert kwargs["tools"] == tools
+    assert kwargs["messages"][0] == {"role": "system", "content": "be helpful"}
+    assert kwargs["messages"][1] == {"role": "user", "content": "hi"}
+
+
+def test_generate_content_omits_tools_when_empty(mocker: MockerFixture) -> None:
+    client = mocker.patch.object(ollama, "AsyncOpenAI").return_value
+    create = AsyncMock(return_value="resp")
+    client.chat.completions.create = create
+
+    adapter = OllamaClientAdapter()
+    asyncio.run(adapter.generate_content([{"role": "user", "content": "hi"}], [], None))
+
+    assert "tools" not in create.await_args.kwargs
+
+
+# --- message conversion -------------------------------------------------------
+
+
+def test_convert_messages_tool_calls_and_results(mocker: MockerFixture) -> None:
+    mocker.patch.object(ollama, "AsyncOpenAI")
+    adapter = OllamaClientAdapter()
+
+    contents = [
+        {"role": "user", "content": "do it"},
+        {
+            "role": "assistant",
+            "content": "thinking",
+            "tool_calls": [{"id": "c1", "name": "fc", "args": {"k": "v"}}],
+        },
+        {"role": "tool", "content": "result", "tool_call_id": "c1"},
+    ]
+
+    messages = adapter._convert_to_openai_messages(contents, "sys")
+
+    assert messages[0] == {"role": "system", "content": "sys"}
+    assert messages[1] == {"role": "user", "content": "do it"}
+    assert messages[2]["role"] == "assistant"
+    assert messages[2]["content"] == "thinking"
+    assert messages[2]["tool_calls"][0]["id"] == "c1"
+    assert messages[2]["tool_calls"][0]["function"]["name"] == "fc"
+    assert json.loads(messages[2]["tool_calls"][0]["function"]["arguments"]) == {"k": "v"}
+    assert messages[3] == {"role": "tool", "tool_call_id": "c1", "content": "result"}
+
+
+def test_convert_messages_synthesizes_tool_call_id(mocker: MockerFixture) -> None:
+    mocker.patch.object(ollama, "AsyncOpenAI")
+    adapter = OllamaClientAdapter()
+
+    contents = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"name": "fc", "args": {}}],
+        },
+    ]
+
+    messages = adapter._convert_to_openai_messages(contents, None)
+
+    assert messages[0]["tool_calls"][0]["id"] == "call_0"
+
+
+def test_convert_messages_no_system_when_absent(mocker: MockerFixture) -> None:
+    mocker.patch.object(ollama, "AsyncOpenAI")
+    adapter = OllamaClientAdapter()
+
+    messages = adapter._convert_to_openai_messages([{"role": "user", "content": "hi"}], None)
+
+    assert messages == [{"role": "user", "content": "hi"}]
+
+
+# --- registry / provider resolution -------------------------------------------
+
+
+def test_registered_in_models_registry() -> None:
+    assert MODELS.get("ollama") is OllamaClientAdapter
+
+
+def test_get_model_builds_ollama_adapter(mocker: MockerFixture) -> None:
+    mocker.patch.object(ollama, "AsyncOpenAI")
+    mocker.patch.dict(os.environ, {}, clear=True)
+
+    client = get_model(provider="ollama")
+
+    assert isinstance(client, OllamaClientAdapter)

--- a/uv.lock
+++ b/uv.lock
@@ -143,6 +143,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.117.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/0d/8f71d535edb0d438f023bd825fb65f67c14fa88a2bd6b75f292a58a63de4/anthropic-0.117.0.tar.gz", hash = "sha256:98107f2b76439641e0ae2a1754087534b8f178dbab99d6eb1bc4b7bc8c744496", size = 989933, upload-time = "2026-07-16T19:36:13.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/4c/917d21d6619a4475cdafc6d13a69fdb3b901ddac57e76caca5a25c117b6d/anthropic-0.117.0-py3-none-any.whl", hash = "sha256:451a0a6905f11dff7663d13e4ee5dbf909eb8942b1d049803c7b937a13ac47ec", size = 998327, upload-time = "2026-07-16T19:36:11.225Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -442,8 +461,17 @@ dependencies = [
     { name = "ruamel-yaml" },
 ]
 
+[package.optional-dependencies]
+anthropic = [
+    { name = "anthropic" },
+]
+openai = [
+    { name = "openai" },
+]
+
 [package.dev-dependencies]
 dev = [
+    { name = "devops-bench", extra = ["anthropic", "openai"] },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -453,14 +481,18 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.104.1" },
     { name = "deepeval", specifier = ">=4.0.3" },
     { name = "google-genai", specifier = ">=2.8.0" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "ruamel-yaml", specifier = ">=0.18.0" },
 ]
+provides-extras = ["anthropic", "openai"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "devops-bench", extras = ["anthropic", "openai"] },
     { name = "pre-commit", specifier = ">=3.5.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
@@ -484,6 +516,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds the three concrete LLM provider adapters and the first two CLI agent harnesses, plus the shared helpers the CLI harnesses use for capability wiring.

  ## Model provider clients (`devops_bench/models/`)

  - **`gemini.py`** — `GeminiClientAdapter` over `google-genai`: API-key or Vertex AI backends (provider-forced or inferred from the environment), schema filtering for Gemini's tool-declaration subset, and retry with backoff on transient errors.
  - **`claude.py`** — `ClaudeClientAdapter` over `anthropic`: API, Vertex, and Bedrock backends, backend inference from the environment with explicit override, and max-token config via env or argument.
  - **`ollama.py`** — `OllamaClientAdapter` over the OpenAI-compatible client for local Ollama runtimes.

  Each adapter registers itself in the `MODELS` registry and resolves through `get_model()` / `core.model_providers` aliases (covered by tests). Provider SDKs are imported lazily: a missing SDK surfaces as `MissingDependencyError` at construction, not import.

  ## CLI agent harnesses (`devops_bench/agents/cli/`)

  - **`gemini_cli/`** — drives the Gemini CLI binary in a per-run workspace, delivering capabilities through the CLI's native workspace channels (settings, MCP config, skills);
  `parsing.py` converts the stream-JSON output into a typed `AgentResult`.
  - **`openclaw/`** — drives the OpenClaw CLI analogously, including session export parsing with per-turn token accounting.
  - **`shared/`** — the capability-wiring helpers (`cli_capabilities.py`, `skills.py`) both harnesses consume.

  One commit extends `AgentHarness.run()` to accept a harness-owned `workspace_path`; it is identical to #28 — if #28 merges first this branch rebases and the duplicate drops out, otherwise #28 can be closed.

  ## Dependencies

  `anthropic` and `openai` are added as optional extras (install only the providers you use) and to the dev group so the full test suite resolves. `google-genai` is already a core dependency. `uv.lock` refreshed.

  ## Testing

  `uv sync --frozen && uv run ruff check && uv run pytest tests/unit -q` — 482 passed. All new files carry the Apache 2.0 header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Gemini CLI and OpenClaw agent integrations with streamed/bundled trajectory parsing, token usage capture, and per-run error reporting.
  * Added shared CLI utilities for MCP capability materialization and safe skills extraction.
  * Introduced Claude, Gemini, and Ollama model adapters.
  * Agent execution now supports an optional workspace directory.
* **Bug Fixes**
  * Improved resiliency of streamed/bundled trajectory parsing and subprocess error handling.
* **Tests**
  * Added extensive unit test coverage for agents, parsers, adapters, and workspace isolation (including capability/workspace behavior).
* **Chores**
  * Added provider-specific optional dependency extras for local adapter testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->