### PR TITLE
Add concrete judge metric families

### DIFF
--- a/devops_bench/metrics/__init__.py
+++ b/devops_bench/metrics/__init__.py
@@ -12,22 +12,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Metric evaluators: the registry and shared scoring primitives."""
+"""LLM-as-judge scoring for benchmark runs.
+
+The public extension surface is :data:`METRICS` (the registry), :class:`MetricScore`,
+:class:`MetricContext`, and :func:`run_geval`. The batch entry point
+:func:`evaluate_metrics_batch` consumes the registry; concrete metric modules
+self-register on import. Importing this package pulls ``deepeval``, but never a
+provider SDK — those stay lazy in the models layer.
+"""
+
+from __future__ import annotations
 
 from devops_bench.metrics.base import (
-    GEVAL_PASS_THRESHOLD,
     METRICS,
     MetricContext,
     MetricEvaluator,
     MetricScore,
     run_geval,
 )
+from devops_bench.metrics.chaos_metrics import evaluate_chaos_metrics
+from devops_bench.metrics.geval import ModelLayerJudge, get_judge_model
+from devops_bench.metrics.grounding import (
+    calculate_doc_retrieval_rate,
+    evaluate_documentation_grounding,
+)
+from devops_bench.metrics.outcome_validity import build_outcome_validity_metric
+from devops_bench.metrics.pipeline import (
+    CHECKLIST_THRESHOLD,
+    evaluate_metrics_batch,
+    extract_checklist_items,
+)
+from devops_bench.metrics.tool_invocation import build_tool_invocation_metric
 
 __all__ = [
-    "GEVAL_PASS_THRESHOLD",
+    "CHECKLIST_THRESHOLD",
     "METRICS",
     "MetricContext",
     "MetricEvaluator",
     "MetricScore",
+    "ModelLayerJudge",
+    "build_outcome_validity_metric",
+    "build_tool_invocation_metric",
+    "calculate_doc_retrieval_rate",
+    "evaluate_chaos_metrics",
+    "evaluate_documentation_grounding",
+    "evaluate_metrics_batch",
+    "extract_checklist_items",
+    "get_judge_model",
     "run_geval",
 ]

--- a/devops_bench/metrics/chaos_metrics.py
+++ b/devops_bench/metrics/chaos_metrics.py
@@ -24,6 +24,7 @@ from deepeval.test_case import LLMTestCase, SingleTurnParams
 
 from devops_bench.core import get_logger
 from devops_bench.metrics.base import (
+    GEVAL_PASS_THRESHOLD,
     METRICS,
     MetricContext,
     MetricScore,
@@ -69,6 +70,7 @@ def evaluate_chaos_metrics(
             f"Did the agent accurately identify that the fault injected was '{actual_fault}'?"
         ),
         evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
+        threshold=GEVAL_PASS_THRESHOLD,
         model=judge_model,
     )
 
@@ -79,6 +81,7 @@ def evaluate_chaos_metrics(
             " uptime, zero downtime)?"
         ),
         evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
+        threshold=GEVAL_PASS_THRESHOLD,
         model=judge_model,
     )
 

--- a/devops_bench/metrics/chaos_metrics.py
+++ b/devops_bench/metrics/chaos_metrics.py
@@ -1,0 +1,139 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Chaos-mode scoring: diagnosis/recovery GEval plus performance numbers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from deepeval.metrics import GEval
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+
+from devops_bench.core import get_logger
+from devops_bench.metrics.base import (
+    METRICS,
+    MetricContext,
+    MetricScore,
+    run_geval,
+)
+
+__all__ = ["ChaosMetric", "evaluate_chaos_metrics"]
+
+_log = get_logger("metrics.chaos_metrics")
+
+_DEFAULT_FAULT = "pod deletion"
+
+
+def evaluate_chaos_metrics(
+    all_test_case: LLMTestCase,
+    judge_model: Any,
+    chaos_report: dict[str, Any],
+    perf_report: dict[str, Any],
+    scores: dict[str, Any],
+) -> None:
+    """Score chaos diagnosis/recovery and record performance numbers.
+
+    Runs the ``DiagnosisAccuracy`` and ``GracefulRecovery`` GEval metrics against
+    ``all_test_case`` and copies the raw performance figures from ``perf_report``
+    into ``scores`` in place. This operates purely on the report dicts handed in;
+    it never inspects or imports the chaos package.
+
+    Args:
+        all_test_case: The combined test case (text output + trace) to judge.
+        judge_model: A ``DeepEvalBaseLLM`` judge model.
+        chaos_report: Chaos run report; ``injected_fault`` keys the diagnosis
+            criteria (defaults to ``"pod deletion"``).
+        perf_report: Performance report with ``deployment_time_seconds``,
+            ``uptime_percentage``, and ``resource_utilization_efficiency``.
+        scores: Mutable scores dict updated in place.
+    """
+    _log.info("Evaluating Planned Chaos Mode and Performance metrics...")
+    actual_fault = chaos_report.get("injected_fault", _DEFAULT_FAULT)
+
+    diag_metric = GEval(
+        name="DiagnosisAccuracy",
+        criteria=(
+            f"Did the agent accurately identify that the fault injected was '{actual_fault}'?"
+        ),
+        evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
+        model=judge_model,
+    )
+
+    rec_metric = GEval(
+        name="GracefulRecovery",
+        criteria=(
+            "Did the agent follow a graceful recovery process (e.g., maintaining"
+            " uptime, zero downtime)?"
+        ),
+        evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
+        model=judge_model,
+    )
+
+    try:
+        for ms in run_geval(all_test_case, [diag_metric, rec_metric]):
+            scores[ms.name] = ms.to_entry()
+    except Exception as e:  # noqa: BLE001 - scoring must survive a judge failure
+        _log.error("Error evaluating chaos metrics: %s", e)
+
+    scores["Workload_Deployment_Time_Seconds"] = perf_report.get("deployment_time_seconds")
+    scores["Workload_Uptime_Percentage"] = perf_report.get("uptime_percentage")
+    scores["Resource_Utilization_Efficiency"] = perf_report.get("resource_utilization_efficiency")
+
+
+@METRICS.register("chaos")
+class ChaosMetric:
+    """Registered evaluator for chaos diagnosis + recovery + perf passthroughs.
+
+    Runs only when the result carries a ``chaos_spec``. Yields the
+    DiagnosisAccuracy / GracefulRecovery judged scores plus the three bare-value
+    performance passthroughs.
+
+    Attributes:
+        name: Identifier for logging; per-score keys come from each yielded
+            :class:`MetricScore`.
+    """
+
+    name = "chaos"
+
+    def applies(self, ctx: MetricContext) -> bool:
+        """Run only when the harness recorded a chaos spec on the result."""
+        return bool(ctx.result.get("chaos_spec"))
+
+    def evaluate(self, ctx: MetricContext) -> Iterable[MetricScore]:
+        """Score diagnosis/recovery and pass perf numbers through verbatim."""
+        scores: dict[str, Any] = {}
+        evaluate_chaos_metrics(
+            ctx.all_case,
+            ctx.judge,
+            ctx.result.get("chaos_report", {}),
+            ctx.result.get("perf_report", {}),
+            scores,
+        )
+        out: list[MetricScore] = []
+        for name, entry in scores.items():
+            if isinstance(entry, dict):
+                out.append(
+                    MetricScore(
+                        name=name,
+                        score=entry.get("score"),
+                        success=entry.get("success"),
+                        reason=entry.get("reason"),
+                    )
+                )
+            else:
+                # Bare-value perf passthroughs (None when missing).
+                out.append(MetricScore(name=name, score=entry))
+        return out

--- a/devops_bench/metrics/checklist.py
+++ b/devops_bench/metrics/checklist.py
@@ -73,12 +73,13 @@ def extract_checklist_items(expected_output: str, use_mcp: bool) -> list[str]:
         parts = re.split(r"(?i)expected manifest generated\s*:", reqs_section, maxsplit=1)
         reqs_section = parts[0]
 
-    # Strip only the leading "- " bullet; ``str.strip("- ")`` would also eat
-    # trailing hyphens and corrupt items like "...staging-".
+    # Strip a single leading "-" bullet marker (and the spaces after it). A
+    # character-class strip like ``lstrip("- ")`` would also eat a leading flag
+    # ("- --dry-run" -> "dry-run") or a trailing hyphen ("...staging-").
     raw_checklist_items = [
-        line.lstrip("- ").strip()
+        re.sub(r"^-\s*", "", stripped)
         for line in reqs_section.split("\n")
-        if line.strip().startswith("-")
+        if (stripped := line.strip()).startswith("-")
     ]
     checklist_items = []
     for item in raw_checklist_items:

--- a/devops_bench/metrics/checklist.py
+++ b/devops_bench/metrics/checklist.py
@@ -1,0 +1,149 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-requirement checklist metric and its expected-output parser.
+
+Scores each ``-`` bulleted "Critical Requirements" item from a task's expected
+output with its own GEval and emits the aggregate ``ChecklistScore``. Registered
+under the ``checklist`` key; the batch pipeline picks it up via :data:`METRICS`.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+from deepeval.metrics import GEval
+from deepeval.test_case import SingleTurnParams
+
+from devops_bench.core import get_logger
+from devops_bench.metrics.base import (
+    GEVAL_PASS_THRESHOLD,
+    METRICS,
+    MetricContext,
+    MetricScore,
+    run_geval,
+)
+
+__all__ = [
+    "CHECKLIST_THRESHOLD",
+    "ChecklistMetric",
+    "extract_checklist_items",
+]
+
+_log = get_logger("metrics.checklist")
+
+# Per-task checklist pass cutoff.
+CHECKLIST_THRESHOLD = 0.8
+
+
+def extract_checklist_items(expected_output: str, use_mcp: bool) -> list[str]:
+    """Parse per-requirement checklist items from an expected-output string.
+
+    Items are the ``-`` bulleted lines inside the "Critical Requirements" section
+    (everything before an "Expected Manifest Generated" marker). When MCP is
+    disabled, "expected tool call" requirements are dropped since the agent has
+    no tools to invoke.
+
+    Args:
+        expected_output: The task's expected-output text.
+        use_mcp: Whether the run used MCP tools.
+
+    Returns:
+        The cleaned list of requirement strings (bullet markers stripped).
+    """
+    reqs_section = expected_output
+    if "critical requirements:" in reqs_section.lower():
+        parts = re.split(r"(?i)critical requirements\s*:", reqs_section, maxsplit=1)
+        if len(parts) > 1:
+            reqs_section = parts[1]
+
+    if "expected manifest generated:" in reqs_section.lower():
+        parts = re.split(r"(?i)expected manifest generated\s*:", reqs_section, maxsplit=1)
+        reqs_section = parts[0]
+
+    # Strip only the leading "- " bullet; ``str.strip("- ")`` would also eat
+    # trailing hyphens and corrupt items like "...staging-".
+    raw_checklist_items = [
+        line.lstrip("- ").strip()
+        for line in reqs_section.split("\n")
+        if line.strip().startswith("-")
+    ]
+    checklist_items = []
+    for item in raw_checklist_items:
+        if not use_mcp and "expected tool call" in item.lower():
+            _log.info("Skipping Expected Tool Call criteria: '%s'", item)
+            continue
+        checklist_items.append(item)
+    return checklist_items
+
+
+@METRICS.register("checklist")
+class ChecklistMetric:
+    """Registered evaluator scoring per-requirement checklist items.
+
+    For each parsed checklist item the evaluator builds a per-item ``Check: …``
+    GEval, scores it, and emits the aggregate ``ChecklistScore`` using
+    :data:`CHECKLIST_THRESHOLD` as the pass cutoff.
+
+    Attributes:
+        name: Identifier for logging; per-score keys come from each yielded
+            :class:`MetricScore`.
+    """
+
+    name = "checklist"
+
+    def applies(self, ctx: MetricContext) -> bool:
+        """Run only when the result's ``expected_output`` carries bullets."""
+        return bool(extract_checklist_items(ctx.result.get("expected_output", ""), ctx.use_mcp))
+
+    def evaluate(self, ctx: MetricContext) -> Iterable[MetricScore]:
+        """Score each requirement and emit the aggregate ChecklistScore."""
+        items = extract_checklist_items(ctx.result.get("expected_output", ""), ctx.use_mcp)
+        dynamic_metrics = [
+            GEval(
+                name=f"Check: {item}",
+                criteria=(
+                    f"Verify that the actual output fulfills this specific requirement: {item}"
+                ),
+                threshold=GEVAL_PASS_THRESHOLD,
+                evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
+                model=ctx.judge,
+            )
+            for item in items
+        ]
+
+        out: list[MetricScore] = []
+        passed = 0
+        total = len(dynamic_metrics)
+        for m in dynamic_metrics:
+            try:
+                _log.info("Evaluating metric: %s...", m.name)
+                for ms in run_geval(ctx.all_case, [m]):
+                    out.append(ms)
+                    if ms.success:
+                        passed += 1
+            except Exception as e:  # noqa: BLE001 - keep scoring the rest
+                _log.error("Error evaluating metric %s: %s", m.name, e)
+
+        ratio = passed / total if total > 0 else 0.0
+        out.append(
+            MetricScore(
+                name="ChecklistScore",
+                score=ratio,
+                success=ratio >= CHECKLIST_THRESHOLD if total > 0 else False,
+                reason=f"Passed {passed} out of {total} checks.",
+            )
+        )
+        return out

--- a/devops_bench/metrics/grounding.py
+++ b/devops_bench/metrics/grounding.py
@@ -64,24 +64,23 @@ def calculate_doc_retrieval_rate(
     # trajectory for every documentation guide (it does not depend on the doc).
     step_strs = [json.dumps(step).lower() for step in trajectory]
 
-    accessed_docs = set()
+    # Count matched entries directly: deduplicating by ``doc_name`` would
+    # collapse distinct guides that share (or lack) a name but match via URL,
+    # undercounting the accessed fraction.
+    accessed_count = 0
     for doc in documentation:
-        doc_name = doc.get("doc_name") or ""
-        doc_name_lower = doc_name.lower()
+        doc_name_lower = (doc.get("doc_name") or "").lower()
         url_lower = (doc.get("url") or "").lower()
-        found_in_trajectory = False
         for step_str in step_strs:
             # Guard both substrings on truthiness so a missing name/url (now "")
             # does not spuriously match every step (``"" in s`` is always True).
             if (doc_name_lower and doc_name_lower in step_str) or (
                 url_lower and url_lower in step_str
             ):
-                found_in_trajectory = True
+                accessed_count += 1
                 break
-        if found_in_trajectory:
-            accessed_docs.add(doc_name)
 
-    return len(accessed_docs) / len(documentation)
+    return accessed_count / len(documentation)
 
 
 def evaluate_documentation_grounding(

--- a/devops_bench/metrics/grounding.py
+++ b/devops_bench/metrics/grounding.py
@@ -1,0 +1,231 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Documentation grounding metrics: constraint GEval scoring and retrieval rate."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from typing import Any
+
+from deepeval.metrics import GEval
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+
+from devops_bench.core import get_logger
+from devops_bench.metrics.base import (
+    GEVAL_PASS_THRESHOLD,
+    METRICS,
+    MetricContext,
+    MetricScore,
+    run_geval,
+)
+
+__all__ = [
+    "GroundingMetric",
+    "calculate_doc_retrieval_rate",
+    "evaluate_documentation_grounding",
+]
+
+_log = get_logger("metrics.grounding")
+
+
+def calculate_doc_retrieval_rate(
+    documentation: list[dict[str, Any]], trajectory: list[Any]
+) -> float:
+    """Compute the fraction of mapped documentation guides seen in a trajectory.
+
+    A guide counts as accessed when its ``doc_name`` or ``url`` (case-insensitive)
+    appears anywhere in the JSON-serialized trajectory steps.
+
+    Args:
+        documentation: Mapped guides, each with ``doc_name`` and ``url`` keys.
+        trajectory: Agent execution steps (any JSON-serializable objects).
+
+    Returns:
+        The accessed fraction in ``[0.0, 1.0]``; ``0.0`` when there is no
+        documentation.
+    """
+    if not documentation:
+        return 0.0
+
+    # Serialize each step once up front rather than re-serializing the whole
+    # trajectory for every documentation guide (it does not depend on the doc).
+    step_strs = [json.dumps(step).lower() for step in trajectory]
+
+    accessed_docs = set()
+    for doc in documentation:
+        doc_name = doc.get("doc_name") or ""
+        doc_name_lower = doc_name.lower()
+        url_lower = (doc.get("url") or "").lower()
+        found_in_trajectory = False
+        for step_str in step_strs:
+            # Guard both substrings on truthiness so a missing name/url (now "")
+            # does not spuriously match every step (``"" in s`` is always True).
+            if (doc_name_lower and doc_name_lower in step_str) or (
+                url_lower and url_lower in step_str
+            ):
+                found_in_trajectory = True
+                break
+        if found_in_trajectory:
+            accessed_docs.add(doc_name)
+
+    return len(accessed_docs) / len(documentation)
+
+
+def evaluate_documentation_grounding(
+    documentation: list[dict[str, Any]],
+    all_test_case: LLMTestCase,
+    judge_model: Any,
+    scores: dict[str, Any],
+) -> None:
+    """Score documentation constraints via GEval and derive GroundingAccuracy.
+
+    Each documented constraint becomes a GEval metric evaluated against
+    ``all_test_case``. Per-constraint results, an aggregate ``GroundingAccuracy``
+    (5.0/2.5/0.0 banded by critical-constraint coverage), and
+    ``ParameterRecallAccuracy`` are written into ``scores`` in place.
+
+    Args:
+        documentation: Guides, each with a ``constraints`` list of
+            ``{"text": str, "critical": bool}`` entries.
+        all_test_case: The combined test case (text output + trace) to judge.
+        judge_model: A ``DeepEvalBaseLLM`` judge model.
+        scores: Mutable scores dict updated in place.
+    """
+    # Deduplicate constraints by text first so two guides sharing the same
+    # constraint produce a single metric; otherwise total > unique and a
+    # perfect 5.0 (applied == total) becomes unreachable.
+    doc_constraints_map: dict[str, bool] = {}
+    for doc in documentation:
+        for constraint in doc.get("constraints", []):
+            doc_constraints_map[constraint["text"]] = constraint["critical"]
+
+    doc_metrics = [
+        GEval(
+            name=f"Doc Constraint: {c_text}",
+            criteria=(
+                "Verify that the actual output fulfills this specific"
+                f" documentation constraint/requirement: {c_text}"
+            ),
+            threshold=GEVAL_PASS_THRESHOLD,
+            evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
+            model=judge_model,
+        )
+        for c_text in doc_constraints_map
+    ]
+
+    if not doc_metrics:
+        return
+
+    _log.info(
+        "Evaluating %d documentation constraint metrics sequentially...",
+        len(doc_metrics),
+    )
+    for m in doc_metrics:
+        try:
+            _log.info("Evaluating doc metric: %s...", m.name)
+            for ms in run_geval(all_test_case, [m]):
+                scores[ms.name] = ms.to_entry()
+        except Exception as e:  # noqa: BLE001 - one bad metric must not abort scoring
+            _log.error("Error evaluating doc metric %s: %s", m.name, e)
+
+    total_constraints = len(doc_metrics)
+    applied_constraints = 0
+    critical_total = sum(1 for crit in doc_constraints_map.values() if crit)
+    critical_applied = 0
+
+    for c_text, c_crit in doc_constraints_map.items():
+        m_name = f"Doc Constraint: {c_text}"
+        entry = scores.get(m_name)
+        # ``entry`` is the judged-shape dict; bail safely on a missing/malformed
+        # entry (the per-constraint scoring above logged the failure).
+        if isinstance(entry, dict) and entry.get("success"):
+            applied_constraints += 1
+            if c_crit:
+                critical_applied += 1
+
+    # Banded grounding score: 5.0 (Success), 2.5 (Partial), 0.0 (Failure). The
+    # early return above guarantees ``total_constraints > 0`` and
+    # ``applied <= total``, and any unmet critical constraint takes the Partial
+    # branch before non-critical analysis runs, so ``non_critical_total`` is
+    # never zero in the final branch.
+    if applied_constraints == total_constraints:
+        grounding_score = 5.0
+    elif applied_constraints == 0:
+        grounding_score = 0.0
+    elif critical_applied < critical_total:
+        grounding_score = 2.5
+    else:
+        non_critical_total = total_constraints - critical_total
+        non_critical_applied = applied_constraints - critical_applied
+        grounding_score = 2.5 + 2.5 * (non_critical_applied / non_critical_total)
+
+    recall_accuracy = applied_constraints / total_constraints
+
+    scores["GroundingAccuracy"] = {
+        "score": grounding_score,
+        "success": grounding_score >= 4.0,
+        "reason": (
+            f"Applied {applied_constraints} out of {total_constraints} documented"
+            f" constraints (Critical: {critical_applied}/{critical_total})."
+        ),
+    }
+    scores["ParameterRecallAccuracy"] = recall_accuracy
+
+
+@METRICS.register("grounding")
+class GroundingMetric:
+    """Registered evaluator for documentation grounding + retrieval rate.
+
+    Runs only when the result carries mapped ``documentation``. Yields
+    per-constraint judged scores, the aggregate ``GroundingAccuracy``, plus the
+    bare-value ``ParameterRecallAccuracy`` and ``DocRetrievalRate`` passthroughs.
+
+    Attributes:
+        name: Identifier for logging; per-score keys come from each yielded
+            :class:`MetricScore`.
+    """
+
+    name = "grounding"
+
+    def applies(self, ctx: MetricContext) -> bool:
+        """Run only when the harness recorded mapped documentation."""
+        return bool(ctx.result.get("documentation"))
+
+    def evaluate(self, ctx: MetricContext) -> Iterable[MetricScore]:
+        """Score grounding constraints and derive the doc-retrieval rate."""
+        documentation = ctx.result.get("documentation", [])
+        scores: dict[str, Any] = {}
+        evaluate_documentation_grounding(documentation, ctx.all_case, ctx.judge, scores)
+        retrieval_rate = calculate_doc_retrieval_rate(
+            documentation, ctx.result.get("trajectory", [])
+        )
+
+        out: list[MetricScore] = []
+        for name, entry in scores.items():
+            if isinstance(entry, dict):
+                out.append(
+                    MetricScore(
+                        name=name,
+                        score=entry.get("score"),
+                        success=entry.get("success"),
+                        reason=entry.get("reason"),
+                    )
+                )
+            else:
+                # Bare-value entry (e.g. ParameterRecallAccuracy).
+                out.append(MetricScore(name=name, score=entry))
+        out.append(MetricScore(name="DocRetrievalRate", score=retrieval_rate))
+        return out

--- a/devops_bench/metrics/outcome_validity.py
+++ b/devops_bench/metrics/outcome_validity.py
@@ -1,0 +1,121 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OutcomeValidity GEval metric and its checklist skill loading."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from deepeval.metrics import GEval
+from deepeval.test_case import SingleTurnParams
+
+from devops_bench.core import get_logger
+from devops_bench.metrics._skills import load_skill_text
+from devops_bench.metrics.base import (
+    GEVAL_PASS_THRESHOLD,
+    METRICS,
+    MetricContext,
+    MetricScore,
+    run_geval,
+)
+
+__all__ = [
+    "OUTCOME_SKILL_FILENAME",
+    "OutcomeValidityMetric",
+    "build_outcome_validity_metric",
+    "load_outcome_criteria",
+]
+
+OUTCOME_SKILL_FILENAME = "outcome-validity-checklist.md"
+
+# Appended to the criteria for generation-only tasks (``deployer: noop``), which
+# provision no cluster. Without it the checklist's "Deployment Intent" /
+# "Execution Confirmation" clauses wrongly fail a correct manifest for not being
+# applied. None of the judge-visible test-case fields signal that this task is
+# generation-only.
+_GENERATION_ONLY_OVERRIDE = (
+    "\n\n## Generation-Only Task Override\n"
+    "This task is manifest-generation only: no live cluster is provisioned. "
+    "Do NOT treat the absence of cluster application or execution confirmation "
+    "as a failure. Criterion 1 follows the *Instructional Intent* path — a "
+    "correct, complete manifest is full achievement — and Criterion 3 (Execution "
+    "Confirmation) is skipped. Continue to grade manifest semantic integrity and "
+    "every Expected Output requirement normally."
+)
+
+_log = get_logger("metrics.outcome_validity")
+
+
+def load_outcome_criteria() -> str:
+    """Read the outcome-validity checklist skill packaged with the project.
+
+    Returns:
+        The full markdown text used as the GEval criteria.
+
+    Raises:
+        FileNotFoundError: If the packaged skill file is missing.
+    """
+    return load_skill_text(OUTCOME_SKILL_FILENAME)
+
+
+def build_outcome_validity_metric(model, *, generation_only: bool = False) -> GEval:
+    """Build the OutcomeValidity GEval metric.
+
+    Args:
+        model: A ``DeepEvalBaseLLM`` judge model.
+        generation_only: When True (task provisions no cluster), append the
+            generation-only override so the judge does not require cluster
+            application/execution confirmation.
+
+    Returns:
+        A configured :class:`~deepeval.metrics.GEval` instance with the shared
+        :data:`GEVAL_PASS_THRESHOLD` pass cutoff applied.
+    """
+    criteria = load_outcome_criteria()
+    if generation_only:
+        criteria += _GENERATION_ONLY_OVERRIDE
+    return GEval(
+        name="OutcomeValidity",
+        criteria=criteria,
+        threshold=GEVAL_PASS_THRESHOLD,
+        evaluation_params=[
+            SingleTurnParams.INPUT,
+            SingleTurnParams.ACTUAL_OUTPUT,
+            SingleTurnParams.EXPECTED_OUTPUT,
+        ],
+        model=model,
+    )
+
+
+@METRICS.register("outcome_validity")
+class OutcomeValidityMetric:
+    """Registered evaluator that scores OutcomeValidity for every result.
+
+    Attributes:
+        name: Score key written into ``res["scores"]``.
+    """
+
+    name = "OutcomeValidity"
+
+    def applies(self, ctx: MetricContext) -> bool:
+        """Always applies — every run is scored against outcome validity."""
+        return True
+
+    def evaluate(self, ctx: MetricContext) -> Iterable[MetricScore]:
+        """Score the outcome-validity GEval against the outcome test case."""
+        return run_geval(
+            ctx.outcome_case,
+            [build_outcome_validity_metric(ctx.judge, generation_only=ctx.generation_only)],
+        )

--- a/devops_bench/metrics/outcome_validity.py
+++ b/devops_bench/metrics/outcome_validity.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Any
 
 from deepeval.metrics import GEval
 from deepeval.test_case import SingleTurnParams
@@ -70,7 +71,7 @@ def load_outcome_criteria() -> str:
     return load_skill_text(OUTCOME_SKILL_FILENAME)
 
 
-def build_outcome_validity_metric(model, *, generation_only: bool = False) -> GEval:
+def build_outcome_validity_metric(model: Any, *, generation_only: bool = False) -> GEval:
     """Build the OutcomeValidity GEval metric.
 
     Args:

--- a/devops_bench/metrics/pipeline.py
+++ b/devops_bench/metrics/pipeline.py
@@ -23,15 +23,30 @@ from deepeval.test_case import LLMTestCase
 
 from devops_bench.core import get_bool, get_logger
 
-# Metric families populate the ``METRICS`` registry via their
-# ``@METRICS.register`` decorators when their modules are imported.
+# Imported for their @METRICS.register side effects.
+from devops_bench.metrics import (
+    chaos_metrics,  # noqa: F401
+    grounding,  # noqa: F401
+    outcome_validity,  # noqa: F401
+    tool_invocation,  # noqa: F401
+)
 from devops_bench.metrics.base import (
     METRICS,
     MetricContext,
 )
 
+# Re-exported for callers importing from this module.
+from devops_bench.metrics.checklist import (
+    CHECKLIST_THRESHOLD,
+    ChecklistMetric,
+    extract_checklist_items,
+)
+
 __all__ = [
+    "CHECKLIST_THRESHOLD",
+    "ChecklistMetric",
     "evaluate_metrics_batch",
+    "extract_checklist_items",
 ]
 
 _log = get_logger("metrics.pipeline")

--- a/devops_bench/metrics/tool_invocation.py
+++ b/devops_bench/metrics/tool_invocation.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Any
 
 from deepeval.metrics import GEval
 from deepeval.test_case import SingleTurnParams
@@ -56,7 +57,7 @@ def load_tool_criteria() -> str:
     return load_skill_text(TOOL_SKILL_FILENAME)
 
 
-def build_tool_invocation_metric(model) -> GEval:
+def build_tool_invocation_metric(model: Any) -> GEval:
     """Build the ToolInvocation GEval metric.
 
     Args:

--- a/devops_bench/metrics/tool_invocation.py
+++ b/devops_bench/metrics/tool_invocation.py
@@ -1,0 +1,98 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ToolInvocation GEval metric and its skill loading."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from deepeval.metrics import GEval
+from deepeval.test_case import SingleTurnParams
+
+from devops_bench.core import get_logger
+from devops_bench.metrics._skills import load_skill_text
+from devops_bench.metrics.base import (
+    METRICS,
+    MetricContext,
+    MetricScore,
+    run_geval,
+)
+
+__all__ = [
+    "TOOL_SKILL_FILENAME",
+    "TOOL_INVOCATION_THRESHOLD",
+    "ToolInvocationMetric",
+    "build_tool_invocation_metric",
+    "load_tool_criteria",
+]
+
+TOOL_SKILL_FILENAME = "tool-invocation-skill.md"
+TOOL_INVOCATION_THRESHOLD = 0.8
+
+_log = get_logger("metrics.tool_invocation")
+
+
+def load_tool_criteria() -> str:
+    """Read the tool-invocation skill packaged with the project.
+
+    Returns:
+        The full markdown text used as the GEval criteria.
+
+    Raises:
+        FileNotFoundError: If the packaged skill file is missing.
+    """
+    return load_skill_text(TOOL_SKILL_FILENAME)
+
+
+def build_tool_invocation_metric(model) -> GEval:
+    """Build the ToolInvocation GEval metric.
+
+    Args:
+        model: A ``DeepEvalBaseLLM`` judge model.
+
+    Returns:
+        A configured :class:`~deepeval.metrics.GEval` instance with the
+        tool-invocation pass threshold applied.
+    """
+    return GEval(
+        name="ToolInvocation",
+        criteria=load_tool_criteria(),
+        threshold=TOOL_INVOCATION_THRESHOLD,
+        evaluation_params=[
+            SingleTurnParams.INPUT,
+            SingleTurnParams.ACTUAL_OUTPUT,
+            SingleTurnParams.EXPECTED_OUTPUT,
+        ],
+        model=model,
+    )
+
+
+@METRICS.register("tool_invocation")
+class ToolInvocationMetric:
+    """Registered evaluator scoring ToolInvocation when MCP is enabled.
+
+    Attributes:
+        name: Score key written into ``res["scores"]``.
+    """
+
+    name = "ToolInvocation"
+
+    def applies(self, ctx: MetricContext) -> bool:
+        """Run only when the harness has granted MCP capabilities to the agent."""
+        return ctx.use_mcp
+
+    def evaluate(self, ctx: MetricContext) -> Iterable[MetricScore]:
+        """Score the tool-invocation GEval against the tool-trace test case."""
+        return run_geval(ctx.tool_case, [build_tool_invocation_metric(ctx.judge)])

--- a/tests/unit/metrics/test_metrics_chaos.py
+++ b/tests/unit/metrics/test_metrics_chaos.py
@@ -19,18 +19,20 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from pytest_mock import MockerFixture
+
 from devops_bench.metrics import chaos_metrics
 from devops_bench.metrics.chaos_metrics import evaluate_chaos_metrics
 
 
-def _chaos_result():
+def _chaos_result() -> SimpleNamespace:
     diag = SimpleNamespace(name="DiagnosisAccuracy [GEval]", score=5.0, success=True, reason="r")
     rec = SimpleNamespace(name="GracefulRecovery", score=4.0, success=True, reason="r")
     test_result = SimpleNamespace(metrics_data=[diag, rec])
     return SimpleNamespace(test_results=[test_result])
 
 
-def test_chaos_records_geval_and_perf(mocker):
+def test_chaos_records_geval_and_perf(mocker: MockerFixture) -> None:
     captured = {}
 
     def _fake_geval(**kwargs):
@@ -65,7 +67,7 @@ def test_chaos_records_geval_and_perf(mocker):
     assert scores["Resource_Utilization_Efficiency"] == 0.8
 
 
-def test_chaos_defaults_fault_and_survives_eval_error(mocker):
+def test_chaos_defaults_fault_and_survives_eval_error(mocker: MockerFixture) -> None:
     captured = {}
     mocker.patch.object(
         chaos_metrics,

--- a/tests/unit/metrics/test_metrics_chaos.py
+++ b/tests/unit/metrics/test_metrics_chaos.py
@@ -1,0 +1,86 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for chaos-mode scoring."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from devops_bench.metrics import chaos_metrics
+from devops_bench.metrics.chaos_metrics import evaluate_chaos_metrics
+
+
+def _chaos_result():
+    diag = SimpleNamespace(name="DiagnosisAccuracy [GEval]", score=5.0, success=True, reason="r")
+    rec = SimpleNamespace(name="GracefulRecovery", score=4.0, success=True, reason="r")
+    test_result = SimpleNamespace(metrics_data=[diag, rec])
+    return SimpleNamespace(test_results=[test_result])
+
+
+def test_chaos_records_geval_and_perf(mocker):
+    captured = {}
+
+    def _fake_geval(**kwargs):
+        captured.setdefault("names", []).append(kwargs["name"])
+        captured["criteria"] = captured.get("criteria", []) + [kwargs["criteria"]]
+        return MagicMock()
+
+    mocker.patch.object(chaos_metrics, "GEval", side_effect=_fake_geval)
+    mocker.patch("deepeval.evaluate", return_value=_chaos_result())
+    scores: dict = {}
+
+    evaluate_chaos_metrics(
+        MagicMock(),
+        MagicMock(),
+        {"injected_fault": "node drain"},
+        {
+            "deployment_time_seconds": 12.0,
+            "uptime_percentage": 99.5,
+            "resource_utilization_efficiency": 0.8,
+        },
+        scores,
+    )
+
+    # GEval name suffix stripped on record (via shared run_geval).
+    assert scores["DiagnosisAccuracy"]["score"] == 5.0
+    assert scores["GracefulRecovery"]["success"] is True
+    # Injected fault propagated into the diagnosis criteria.
+    assert any("node drain" in c for c in captured["criteria"])
+    # Performance numbers copied through verbatim.
+    assert scores["Workload_Deployment_Time_Seconds"] == 12.0
+    assert scores["Workload_Uptime_Percentage"] == 99.5
+    assert scores["Resource_Utilization_Efficiency"] == 0.8
+
+
+def test_chaos_defaults_fault_and_survives_eval_error(mocker):
+    captured = {}
+    mocker.patch.object(
+        chaos_metrics,
+        "GEval",
+        side_effect=lambda **kw: (
+            captured.setdefault("criteria", []).append(kw["criteria"]) or MagicMock()
+        ),
+    )
+    mocker.patch("deepeval.evaluate", side_effect=RuntimeError("judge down"))
+    scores: dict = {}
+
+    evaluate_chaos_metrics(MagicMock(), MagicMock(), {}, {}, scores)
+
+    # Default fault used when none reported.
+    assert any("pod deletion" in c for c in captured["criteria"])
+    # Eval failure swallowed; perf keys still populated (as None here).
+    assert "Workload_Uptime_Percentage" in scores
+    assert scores["Workload_Uptime_Percentage"] is None

--- a/tests/unit/metrics/test_metrics_grounding.py
+++ b/tests/unit/metrics/test_metrics_grounding.py
@@ -20,6 +20,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from devops_bench.metrics import grounding
 from devops_bench.metrics.base import GEVAL_PASS_THRESHOLD
@@ -31,23 +32,23 @@ from devops_bench.metrics.grounding import (
 # --- calculate_doc_retrieval_rate (pure logic) --------------------------------
 
 
-def test_retrieval_rate_empty_docs():
+def test_retrieval_rate_empty_docs() -> None:
     assert calculate_doc_retrieval_rate([], [{"step": 1}]) == 0.0
 
 
-def test_retrieval_rate_matches_by_name():
+def test_retrieval_rate_matches_by_name() -> None:
     docs = [{"doc_name": "GuideA", "url": "http://a"}]
     trajectory = [{"action": "read guidea docs"}]
     assert calculate_doc_retrieval_rate(docs, trajectory) == 1.0
 
 
-def test_retrieval_rate_matches_by_url():
+def test_retrieval_rate_matches_by_url() -> None:
     docs = [{"doc_name": "GuideA", "url": "http://example.com/a"}]
     trajectory = [{"href": "see http://example.com/a now"}]
     assert calculate_doc_retrieval_rate(docs, trajectory) == 1.0
 
 
-def test_retrieval_rate_partial():
+def test_retrieval_rate_partial() -> None:
     docs = [
         {"doc_name": "GuideA", "url": "http://a"},
         {"doc_name": "GuideB", "url": "http://b"},
@@ -56,12 +57,12 @@ def test_retrieval_rate_partial():
     assert calculate_doc_retrieval_rate(docs, trajectory) == 0.5
 
 
-def test_retrieval_rate_no_match():
+def test_retrieval_rate_no_match() -> None:
     docs = [{"doc_name": "GuideA", "url": "http://a"}]
     assert calculate_doc_retrieval_rate(docs, [{"action": "nothing here"}]) == 0.0
 
 
-def test_retrieval_rate_tolerates_missing_name_and_url():
+def test_retrieval_rate_tolerates_missing_name_and_url() -> None:
     docs = [
         {"url": "http://a"},  # no doc_name
         {"doc_name": None, "url": None},  # both None
@@ -74,20 +75,22 @@ def test_retrieval_rate_tolerates_missing_name_and_url():
 # --- evaluate_documentation_grounding (GEval mocked) --------------------------
 
 
-def _metric_result(name, score, success, reason="ok"):
+def _metric_result(name, score, success, reason="ok") -> SimpleNamespace:
     metric_data = SimpleNamespace(name=name, score=score, success=success, reason=reason)
     test_result = SimpleNamespace(metrics_data=[metric_data])
     return SimpleNamespace(test_results=[test_result])
 
 
-def _named_geval(mocker):
+def _named_geval(mocker: MockerFixture) -> MagicMock:
     """Patch grounding.GEval so each metric carries its real ``name``."""
     return mocker.patch.object(
         grounding, "GEval", side_effect=lambda **kw: SimpleNamespace(name=kw["name"])
     )
 
 
-def _evaluate_by_outcome(mocker, outcomes):
+def _evaluate_by_outcome(
+    mocker: MockerFixture, outcomes: dict[str, tuple[float, bool]]
+) -> MagicMock:
     """Order-agnostic ``deepeval.evaluate`` keyed off the metric name.
 
     ``outcomes`` maps a metric name (as built by the grounding code, e.g.
@@ -103,7 +106,7 @@ def _evaluate_by_outcome(mocker, outcomes):
     return mocker.patch("deepeval.evaluate", side_effect=_side_effect)
 
 
-def test_grounding_constraint_geval_uses_explicit_pass_threshold(mocker):
+def test_grounding_constraint_geval_uses_explicit_pass_threshold(mocker: MockerFixture) -> None:
     # Per-constraint GEvals must pass the explicit 0.8 cutoff rather than
     # inheriting deepeval's looser 0.5 default, since their success flags drive
     # GroundingAccuracy / ParameterRecallAccuracy.
@@ -116,7 +119,7 @@ def test_grounding_constraint_geval_uses_explicit_pass_threshold(mocker):
     assert geval_cls.call_args.kwargs["threshold"] == GEVAL_PASS_THRESHOLD
 
 
-def test_grounding_no_constraints_returns_early(mocker):
+def test_grounding_no_constraints_returns_early(mocker: MockerFixture) -> None:
     evaluate = mocker.patch("deepeval.evaluate")
     scores: dict = {}
 
@@ -126,7 +129,7 @@ def test_grounding_no_constraints_returns_early(mocker):
     assert scores == {}
 
 
-def test_grounding_all_applied_scores_full(mocker):
+def test_grounding_all_applied_scores_full(mocker: MockerFixture) -> None:
     _named_geval(mocker)
     docs = [
         {
@@ -154,7 +157,7 @@ def test_grounding_all_applied_scores_full(mocker):
     assert scores["Doc Constraint: use TLS"]["success"] is True
 
 
-def test_grounding_critical_missing_scores_partial(mocker):
+def test_grounding_critical_missing_scores_partial(mocker: MockerFixture) -> None:
     _named_geval(mocker)
     docs = [
         {
@@ -181,7 +184,7 @@ def test_grounding_critical_missing_scores_partial(mocker):
     assert scores["ParameterRecallAccuracy"] == 0.5
 
 
-def test_grounding_none_applied_scores_zero(mocker):
+def test_grounding_none_applied_scores_zero(mocker: MockerFixture) -> None:
     _named_geval(mocker)
     docs = [{"constraints": [{"text": "use TLS", "critical": True}]}]
     scores: dict = {}
@@ -193,7 +196,7 @@ def test_grounding_none_applied_scores_zero(mocker):
     assert scores["ParameterRecallAccuracy"] == 0.0
 
 
-def test_grounding_dedups_shared_constraint_text(mocker):
+def test_grounding_dedups_shared_constraint_text(mocker: MockerFixture) -> None:
     # Two guides share the same constraint text; it must collapse to one metric
     # so a perfect 5.0 (applied == unique total) is reachable.
     _named_geval(mocker)

--- a/tests/unit/metrics/test_metrics_grounding.py
+++ b/tests/unit/metrics/test_metrics_grounding.py
@@ -1,0 +1,213 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for documentation grounding metrics."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from devops_bench.metrics import grounding
+from devops_bench.metrics.base import GEVAL_PASS_THRESHOLD
+from devops_bench.metrics.grounding import (
+    calculate_doc_retrieval_rate,
+    evaluate_documentation_grounding,
+)
+
+# --- calculate_doc_retrieval_rate (pure logic) --------------------------------
+
+
+def test_retrieval_rate_empty_docs():
+    assert calculate_doc_retrieval_rate([], [{"step": 1}]) == 0.0
+
+
+def test_retrieval_rate_matches_by_name():
+    docs = [{"doc_name": "GuideA", "url": "http://a"}]
+    trajectory = [{"action": "read guidea docs"}]
+    assert calculate_doc_retrieval_rate(docs, trajectory) == 1.0
+
+
+def test_retrieval_rate_matches_by_url():
+    docs = [{"doc_name": "GuideA", "url": "http://example.com/a"}]
+    trajectory = [{"href": "see http://example.com/a now"}]
+    assert calculate_doc_retrieval_rate(docs, trajectory) == 1.0
+
+
+def test_retrieval_rate_partial():
+    docs = [
+        {"doc_name": "GuideA", "url": "http://a"},
+        {"doc_name": "GuideB", "url": "http://b"},
+    ]
+    trajectory = [{"action": "read guidea"}]
+    assert calculate_doc_retrieval_rate(docs, trajectory) == 0.5
+
+
+def test_retrieval_rate_no_match():
+    docs = [{"doc_name": "GuideA", "url": "http://a"}]
+    assert calculate_doc_retrieval_rate(docs, [{"action": "nothing here"}]) == 0.0
+
+
+def test_retrieval_rate_tolerates_missing_name_and_url():
+    docs = [
+        {"url": "http://a"},  # no doc_name
+        {"doc_name": None, "url": None},  # both None
+        {"doc_name": "GuideC", "url": "http://c"},
+    ]
+    trajectory = [{"action": "read guidec via http://c"}]
+    assert calculate_doc_retrieval_rate(docs, trajectory) == pytest.approx(1 / 3)
+
+
+# --- evaluate_documentation_grounding (GEval mocked) --------------------------
+
+
+def _metric_result(name, score, success, reason="ok"):
+    metric_data = SimpleNamespace(name=name, score=score, success=success, reason=reason)
+    test_result = SimpleNamespace(metrics_data=[metric_data])
+    return SimpleNamespace(test_results=[test_result])
+
+
+def _named_geval(mocker):
+    """Patch grounding.GEval so each metric carries its real ``name``."""
+    return mocker.patch.object(
+        grounding, "GEval", side_effect=lambda **kw: SimpleNamespace(name=kw["name"])
+    )
+
+
+def _evaluate_by_outcome(mocker, outcomes):
+    """Order-agnostic ``deepeval.evaluate`` keyed off the metric name.
+
+    ``outcomes`` maps a metric name (as built by the grounding code, e.g.
+    ``"Doc Constraint: use TLS"``) to a ``(score, success)`` pair. The reported
+    name carries DeepEval's ``" [GEval]"`` suffix so the strip path is exercised.
+    """
+
+    def _side_effect(test_cases, metrics):
+        name = metrics[0].name
+        score, success = outcomes[name]
+        return _metric_result(f"{name} [GEval]", score, success)
+
+    return mocker.patch("deepeval.evaluate", side_effect=_side_effect)
+
+
+def test_grounding_constraint_geval_uses_explicit_pass_threshold(mocker):
+    # Per-constraint GEvals must pass the explicit 0.8 cutoff rather than
+    # inheriting deepeval's looser 0.5 default, since their success flags drive
+    # GroundingAccuracy / ParameterRecallAccuracy.
+    geval_cls = _named_geval(mocker)
+    mocker.patch("deepeval.evaluate", return_value=SimpleNamespace(test_results=[]))
+    docs = [{"constraints": [{"text": "use TLS", "critical": True}]}]
+
+    evaluate_documentation_grounding(docs, MagicMock(), MagicMock(), {})
+
+    assert geval_cls.call_args.kwargs["threshold"] == GEVAL_PASS_THRESHOLD
+
+
+def test_grounding_no_constraints_returns_early(mocker):
+    evaluate = mocker.patch("deepeval.evaluate")
+    scores: dict = {}
+
+    evaluate_documentation_grounding([{"constraints": []}], MagicMock(), MagicMock(), scores)
+
+    evaluate.assert_not_called()
+    assert scores == {}
+
+
+def test_grounding_all_applied_scores_full(mocker):
+    _named_geval(mocker)
+    docs = [
+        {
+            "constraints": [
+                {"text": "use TLS", "critical": True},
+                {"text": "set replicas", "critical": False},
+            ]
+        }
+    ]
+    scores: dict = {}
+    _evaluate_by_outcome(
+        mocker,
+        {
+            "Doc Constraint: use TLS": (5.0, True),
+            "Doc Constraint: set replicas": (5.0, True),
+        },
+    )
+
+    evaluate_documentation_grounding(docs, MagicMock(), MagicMock(), scores)
+
+    assert scores["GroundingAccuracy"]["score"] == 5.0
+    assert scores["GroundingAccuracy"]["success"] is True
+    assert scores["ParameterRecallAccuracy"] == 1.0
+    # Per-constraint keys recorded with the [GEval] suffix stripped.
+    assert scores["Doc Constraint: use TLS"]["success"] is True
+
+
+def test_grounding_critical_missing_scores_partial(mocker):
+    _named_geval(mocker)
+    docs = [
+        {
+            "constraints": [
+                {"text": "use TLS", "critical": True},
+                {"text": "set replicas", "critical": False},
+            ]
+        }
+    ]
+    scores: dict = {}
+    _evaluate_by_outcome(
+        mocker,
+        {
+            "Doc Constraint: use TLS": (0.0, False),
+            "Doc Constraint: set replicas": (5.0, True),
+        },
+    )
+
+    evaluate_documentation_grounding(docs, MagicMock(), MagicMock(), scores)
+
+    # Critical applied (0) < critical total (1) => partial 2.5.
+    assert scores["GroundingAccuracy"]["score"] == 2.5
+    assert scores["GroundingAccuracy"]["success"] is False
+    assert scores["ParameterRecallAccuracy"] == 0.5
+
+
+def test_grounding_none_applied_scores_zero(mocker):
+    _named_geval(mocker)
+    docs = [{"constraints": [{"text": "use TLS", "critical": True}]}]
+    scores: dict = {}
+    _evaluate_by_outcome(mocker, {"Doc Constraint: use TLS": (0.0, False)})
+
+    evaluate_documentation_grounding(docs, MagicMock(), MagicMock(), scores)
+
+    assert scores["GroundingAccuracy"]["score"] == 0.0
+    assert scores["ParameterRecallAccuracy"] == 0.0
+
+
+def test_grounding_dedups_shared_constraint_text(mocker):
+    # Two guides share the same constraint text; it must collapse to one metric
+    # so a perfect 5.0 (applied == unique total) is reachable.
+    _named_geval(mocker)
+    docs = [
+        {"constraints": [{"text": "use TLS", "critical": True}]},
+        {"constraints": [{"text": "use TLS", "critical": True}]},
+    ]
+    scores: dict = {}
+    evaluate = _evaluate_by_outcome(mocker, {"Doc Constraint: use TLS": (5.0, True)})
+
+    evaluate_documentation_grounding(docs, MagicMock(), MagicMock(), scores)
+
+    # Deduped: a single metric evaluated once, and the perfect score is reachable.
+    assert evaluate.call_count == 1
+    assert scores["GroundingAccuracy"]["score"] == 5.0
+    assert scores["GroundingAccuracy"]["success"] is True
+    assert scores["ParameterRecallAccuracy"] == 1.0

--- a/tests/unit/metrics/test_metrics_pipeline.py
+++ b/tests/unit/metrics/test_metrics_pipeline.py
@@ -12,24 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Self-contained tests for the batch metric scoring pipeline.
+"""Tests for the registry-driven batch scoring pipeline.
 
-Stub evaluators are registered into ``METRICS`` so the dispatch loop, evaluator
-ordering, and per-metric exception isolation are exercised without importing any
-concrete metric family that lands in a follow-up. The registry is snapshotted
-and restored so the stubs never leak into sibling tests.
+The first group registers stub evaluators into ``METRICS`` so the dispatch loop,
+evaluator ordering, and per-metric exception isolation are exercised in
+isolation; the ``registry`` fixture snapshots and restores the registry so the
+stubs never leak into sibling tests. The remaining groups exercise the concrete
+metric families (checklist, outcome-validity, tool-invocation, grounding, chaos)
+end to end with ``deepeval`` mocked.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
 from devops_bench.core import Registry
-from devops_bench.metrics.base import METRICS, MetricContext, MetricScore
-from devops_bench.metrics.pipeline import evaluate_metrics_batch
+from devops_bench.metrics import checklist, pipeline
+from devops_bench.metrics.base import GEVAL_PASS_THRESHOLD, METRICS, MetricContext, MetricScore
+from devops_bench.metrics.pipeline import (
+    CHECKLIST_THRESHOLD,
+    evaluate_metrics_batch,
+    extract_checklist_items,
+)
+
+# --- pipeline dispatch loop (stub evaluators, no concrete families) -----------
 
 
 class _StubEvaluator:
@@ -168,3 +179,369 @@ def test_each_result_in_batch_is_scored(registry: Registry[Any]) -> None:
     evaluate_metrics_batch(results, None, use_mcp=False)
 
     assert all(r["scores"].get("stub_score") for r in results)
+
+
+# --- extract_checklist_items (pure logic) -------------------------------------
+
+
+def test_checklist_extracts_critical_requirements_bullets():
+    expected = (
+        "Critical Requirements:\n- Deployment must use 3 replicas\n- Service exposes port 8080\n"
+    )
+    assert extract_checklist_items(expected, use_mcp=True) == [
+        "Deployment must use 3 replicas",
+        "Service exposes port 8080",
+    ]
+
+
+def test_checklist_stops_at_expected_manifest_marker():
+    expected = (
+        "Critical Requirements:\n"
+        "- Keep replicas at 3\n"
+        "Expected Manifest Generated:\n"
+        "- apiVersion: apps/v1\n"
+    )
+    assert extract_checklist_items(expected, use_mcp=True) == ["Keep replicas at 3"]
+
+
+def test_checklist_drops_tool_call_items_when_mcp_disabled():
+    expected = "Critical Requirements:\n- Expected Tool Call: apply_manifest\n- App is reachable\n"
+    assert extract_checklist_items(expected, use_mcp=False) == ["App is reachable"]
+    assert extract_checklist_items(expected, use_mcp=True) == [
+        "Expected Tool Call: apply_manifest",
+        "App is reachable",
+    ]
+
+
+def test_checklist_empty_when_no_bullets():
+    assert extract_checklist_items("Some prose without bullets", use_mcp=True) == []
+
+
+def test_checklist_preserves_trailing_hyphen():
+    # ``lstrip("- ")`` must not eat a trailing hyphen the way ``strip("- ")`` would.
+    expected = "Critical Requirements:\n- Deploy to namespace staging-\n"
+    assert extract_checklist_items(expected, use_mcp=True) == ["Deploy to namespace staging-"]
+
+
+def test_checklist_threshold_is_value_independent_of_tool_invocation():
+    # Phase-0 fix #1: a dedicated constant so the checklist cutoff is not
+    # silently coupled to ``TOOL_INVOCATION_THRESHOLD``.
+    assert CHECKLIST_THRESHOLD == 0.8
+
+
+# --- evaluate_metrics_batch (deepeval mocked) ---------------------------------
+
+
+def _metric_result(name, score=1.0, success=True, reason="ok"):
+    metric_data = SimpleNamespace(name=name, score=score, success=success, reason=reason)
+    test_result = SimpleNamespace(metrics_data=[metric_data])
+    return SimpleNamespace(test_results=[test_result])
+
+
+def _evaluate_by_metric_name(successes=None):
+    """Build an order-agnostic ``evaluate`` side effect.
+
+    The pipeline always calls ``evaluate([tc], metrics=[m])`` with a single
+    metric, so the result is derived from that metric's real ``name`` rather
+    than call order. The reported name carries DeepEval's ``" [GEval]"`` suffix
+    so the test actually exercises the suffix stripping. ``successes`` optionally
+    maps a metric name (pre-suffix) to its success bool (default True).
+    """
+    successes = successes or {}
+
+    def _side_effect(test_cases, metrics):
+        metric = metrics[0]
+        name = metric.name
+        return _metric_result(f"{name} [GEval]", success=successes.get(name, True))
+
+    return _side_effect
+
+
+def _base_result(**overrides):
+    res = {
+        "input": "deploy the app",
+        "output": "done, applied to cluster",
+        "trajectory": [{"tool": "apply"}],
+        "expected_output": "App deployed",
+        "latency": 1.0,
+        "name": "case-1",
+        "retrieval_context": [],
+        "tools": ["apply"],
+    }
+    res.update(overrides)
+    return res
+
+
+def _patch_judges(mocker):
+    from devops_bench.metrics import outcome_validity, tool_invocation
+
+    mocker.patch.object(
+        outcome_validity,
+        "build_outcome_validity_metric",
+        return_value=SimpleNamespace(name="OutcomeValidity"),
+    )
+    mocker.patch.object(
+        tool_invocation,
+        "build_tool_invocation_metric",
+        return_value=SimpleNamespace(name="ToolInvocation"),
+    )
+
+
+def test_batch_scores_outcome_and_tool(mocker):
+    _patch_judges(mocker)
+    mocker.patch.object(pipeline, "LLMTestCase")
+    # Order-agnostic: result keyed off the metric name with the [GEval] suffix
+    # exercised through the strip path.
+    mocker.patch("deepeval.evaluate", side_effect=_evaluate_by_metric_name())
+    judge = MagicMock()
+    results = [_base_result(expected_output="App deployed")]  # no bullets
+
+    evaluate_metrics_batch(results, judge, use_mcp=True)
+
+    scores = results[0]["scores"]
+    assert "OutcomeValidity" in scores
+    assert "ToolInvocation" in scores
+    assert "OutcomeValidity [GEval]" not in scores
+    assert "ToolInvocation [GEval]" not in scores
+    assert "ChecklistScore" not in scores
+
+
+def test_batch_skips_tool_when_mcp_disabled(mocker):
+    _patch_judges(mocker)
+    mocker.patch.object(pipeline, "LLMTestCase")
+    evaluate = mocker.patch("deepeval.evaluate", side_effect=_evaluate_by_metric_name())
+    judge = MagicMock()
+    results = [_base_result()]
+
+    evaluate_metrics_batch(results, judge, use_mcp=False)
+
+    # Only the outcome evaluation runs (ToolInvocation gated by ctx.use_mcp).
+    assert evaluate.call_count == 1
+    assert "OutcomeValidity" in results[0]["scores"]
+    assert "ToolInvocation" not in results[0]["scores"]
+
+
+def test_batch_use_mcp_falls_back_to_env(mocker):
+    _patch_judges(mocker)
+    mocker.patch.object(pipeline, "LLMTestCase")
+    mocker.patch("deepeval.evaluate", side_effect=_evaluate_by_metric_name())
+    mocker.patch.object(pipeline, "get_bool", return_value=False)
+    judge = MagicMock()
+    results = [_base_result()]
+
+    evaluate_metrics_batch(results, judge)  # use_mcp omitted → env fallback
+
+    assert "ToolInvocation" not in results[0]["scores"]
+
+
+def test_batch_computes_checklist_score(mocker):
+    _patch_judges(mocker)
+    mocker.patch.object(pipeline, "LLMTestCase")
+    # Give the dynamic GEval metric a stable name so success is matchable.
+    mocker.patch.object(
+        checklist, "GEval", side_effect=lambda **kw: SimpleNamespace(name=kw["name"])
+    )
+    mocker.patch("deepeval.evaluate", side_effect=_evaluate_by_metric_name())
+    judge = MagicMock()
+    results = [_base_result(expected_output="Critical Requirements:\n- replicas=3\n")]
+
+    evaluate_metrics_batch(results, judge, use_mcp=True)
+
+    scores = results[0]["scores"]
+    # The dynamic check key is also stripped of the [GEval] suffix.
+    assert "Check: replicas=3" in scores
+    assert scores["ChecklistScore"]["score"] == 1.0
+    assert scores["ChecklistScore"]["success"] is True
+
+
+def test_checklist_per_item_geval_uses_explicit_pass_threshold(mocker):
+    # Per-item checklist GEvals must pass the explicit 0.8 cutoff rather than
+    # inheriting deepeval's looser 0.5 default, since their success flags feed
+    # the aggregate ChecklistScore.
+    geval_cls = mocker.patch.object(
+        checklist, "GEval", side_effect=lambda **kw: SimpleNamespace(name=kw["name"])
+    )
+    _patch_judges(mocker)
+    mocker.patch.object(pipeline, "LLMTestCase")
+    mocker.patch("deepeval.evaluate", side_effect=_evaluate_by_metric_name())
+    judge = MagicMock()
+    results = [_base_result(expected_output="Critical Requirements:\n- replicas=3\n")]
+
+    evaluate_metrics_batch(results, judge, use_mcp=True)
+
+    assert geval_cls.call_args.kwargs["threshold"] == GEVAL_PASS_THRESHOLD
+
+
+def test_batch_invokes_grounding_and_chaos(mocker):
+    _patch_judges(mocker)
+    mocker.patch.object(pipeline, "LLMTestCase")
+    mocker.patch("deepeval.evaluate", side_effect=_evaluate_by_metric_name())
+
+    from devops_bench.metrics import chaos_metrics, grounding
+
+    grounding_call = mocker.patch.object(grounding, "evaluate_documentation_grounding")
+    retrieval = mocker.patch.object(grounding, "calculate_doc_retrieval_rate", return_value=0.5)
+    chaos = mocker.patch.object(chaos_metrics, "evaluate_chaos_metrics")
+    judge = MagicMock()
+    results = [
+        _base_result(
+            documentation=[{"doc_name": "g", "url": "u", "constraints": []}],
+            chaos_spec=[{"fault": "kill"}],
+            chaos_report={"injected_fault": "kill"},
+            perf_report={"uptime_percentage": 99.9},
+        )
+    ]
+
+    evaluate_metrics_batch(results, judge, use_mcp=True)
+
+    grounding_call.assert_called_once()
+    retrieval.assert_called_once()
+    chaos.assert_called_once()
+    assert results[0]["scores"]["DocRetrievalRate"] == 0.5
+
+
+def test_batch_score_insertion_order_matches_legacy_results_json(mocker):
+    # D3: ``res["scores"]`` insertion order lands on disk; pin the legacy
+    # ordering (outcome -> tool -> checklist -> grounding -> chaos) so
+    # downstream results.json consumers do not see a reshuffle.
+    _patch_judges(mocker)
+    mocker.patch.object(pipeline, "LLMTestCase")
+    mocker.patch.object(
+        checklist, "GEval", side_effect=lambda **kw: SimpleNamespace(name=kw["name"])
+    )
+    mocker.patch("deepeval.evaluate", side_effect=_evaluate_by_metric_name())
+
+    from devops_bench.metrics import chaos_metrics, grounding
+
+    mocker.patch.object(
+        grounding,
+        "evaluate_documentation_grounding",
+        side_effect=lambda docs, tc, judge, scores: scores.update(
+            {
+                "Doc Constraint: x": {"score": 1.0, "success": True, "reason": "r"},
+                "GroundingAccuracy": {"score": 5.0, "success": True, "reason": "r"},
+                "ParameterRecallAccuracy": 1.0,
+            }
+        ),
+    )
+    mocker.patch.object(grounding, "calculate_doc_retrieval_rate", return_value=0.5)
+    mocker.patch.object(
+        chaos_metrics,
+        "evaluate_chaos_metrics",
+        side_effect=lambda tc, judge, cr, pr, scores: scores.update(
+            {
+                "DiagnosisAccuracy": {"score": 5.0, "success": True, "reason": "r"},
+                "GracefulRecovery": {"score": 4.0, "success": True, "reason": "r"},
+                "Workload_Deployment_Time_Seconds": 12.0,
+                "Workload_Uptime_Percentage": 99.5,
+                "Resource_Utilization_Efficiency": 0.8,
+            }
+        ),
+    )
+
+    results = [
+        _base_result(
+            expected_output="Critical Requirements:\n- replicas=3\n",
+            documentation=[{"doc_name": "g", "url": "u", "constraints": []}],
+            chaos_spec=[{"fault": "kill"}],
+            chaos_report={"injected_fault": "kill"},
+            perf_report={"uptime_percentage": 99.5},
+        )
+    ]
+    evaluate_metrics_batch(results, MagicMock(), use_mcp=True)
+
+    keys = list(results[0]["scores"].keys())
+
+    # Locate the section anchors and assert outcome -> tool -> checklist ->
+    # grounding -> chaos. We pin the first-occurrence index of one canonical
+    # key from each family so the assertion is robust to the per-family
+    # internal ordering (grounding emits multiple keys, chaos likewise).
+    def idx(name: str) -> int:
+        return keys.index(name)
+
+    assert (
+        idx("OutcomeValidity")
+        < idx("ToolInvocation")
+        < idx("Check: replicas=3")
+        < idx("ChecklistScore")
+        < idx("GroundingAccuracy")
+        < idx("DiagnosisAccuracy")
+    )
+
+
+# --- generation_only flow + MCP tool-name normalization -----------------------
+
+
+def test_canonical_tool_name_strips_mcp_prefix():
+    assert pipeline._canonical_tool_name("default__generate_manifest") == "generate_manifest"
+    assert pipeline._canonical_tool_name("run_shell_command") == "run_shell_command"
+
+
+def test_build_context_threads_generation_only(mocker):
+    mocker.patch.object(pipeline, "LLMTestCase", side_effect=lambda **kw: SimpleNamespace(**kw))
+    ctx = pipeline._build_context(_base_result(generation_only=True), MagicMock(), True)
+    assert ctx.generation_only is True
+    # Absent key defaults to False.
+    assert pipeline._build_context(_base_result(), MagicMock(), True).generation_only is False
+
+
+def test_build_context_normalizes_tool_names_for_judge(mocker):
+    mocker.patch.object(pipeline, "LLMTestCase", side_effect=lambda **kw: SimpleNamespace(**kw))
+    res = _base_result(
+        tools=["default__generate_manifest"],
+        trajectory=[{"name": "default__generate_manifest", "status": "completed"}],
+    )
+    ctx = pipeline._build_context(res, MagicMock(), True)
+    # Judge sees the canonical name; the on-disk record keeps the raw prefix.
+    assert "generate_manifest" in ctx.tool_case.actual_output
+    assert "default__generate_manifest" not in ctx.tool_case.actual_output
+    assert res["tools"] == ["default__generate_manifest"]
+    assert res["trajectory"][0]["name"] == "default__generate_manifest"
+
+
+def test_outcome_validity_override_only_when_generation_only(mocker):
+    from devops_bench.metrics import outcome_validity
+
+    captured = {}
+    mocker.patch.object(
+        outcome_validity,
+        "GEval",
+        side_effect=lambda **kw: captured.update(kw) or SimpleNamespace(**kw),
+    )
+    outcome_validity.build_outcome_validity_metric(MagicMock(), generation_only=False)
+    assert outcome_validity._GENERATION_ONLY_OVERRIDE not in captured["criteria"]
+    outcome_validity.build_outcome_validity_metric(MagicMock(), generation_only=True)
+    assert outcome_validity._GENERATION_ONLY_OVERRIDE in captured["criteria"]
+
+
+def test_build_context_warns_on_empty_expected_output(caplog, mocker):
+    mocker.patch.object(pipeline, "LLMTestCase", side_effect=lambda **kw: SimpleNamespace(**kw))
+    import logging
+
+    res = _base_result(expected_output="")
+    with caplog.at_level(logging.WARNING):
+        pipeline._build_context(res, MagicMock(), True)
+    assert len(caplog.records) == 1
+    assert "has an empty expected_output" in caplog.text
+
+
+def test_build_context_no_warning_when_expected_output_set(caplog, mocker):
+    mocker.patch.object(pipeline, "LLMTestCase", side_effect=lambda **kw: SimpleNamespace(**kw))
+    import logging
+
+    res = _base_result(expected_output="App deployed")
+    with caplog.at_level(logging.WARNING):
+        pipeline._build_context(res, MagicMock(), True)
+    assert len(caplog.records) == 0
+
+
+def test_build_context_missing_expected_output_defaults_and_warns(caplog, mocker):
+    mocker.patch.object(pipeline, "LLMTestCase", side_effect=lambda **kw: SimpleNamespace(**kw))
+    import logging
+
+    res = _base_result()
+    del res["expected_output"]
+    with caplog.at_level(logging.WARNING):
+        pipeline._build_context(res, MagicMock(), True)
+    assert len(caplog.records) == 1
+    assert "has an empty expected_output" in caplog.text

--- a/tests/unit/metrics/test_metrics_pipeline.py
+++ b/tests/unit/metrics/test_metrics_pipeline.py
@@ -30,6 +30,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from devops_bench.core import Registry
 from devops_bench.metrics import checklist, pipeline
@@ -184,7 +185,7 @@ def test_each_result_in_batch_is_scored(registry: Registry[Any]) -> None:
 # --- extract_checklist_items (pure logic) -------------------------------------
 
 
-def test_checklist_extracts_critical_requirements_bullets():
+def test_checklist_extracts_critical_requirements_bullets() -> None:
     expected = (
         "Critical Requirements:\n- Deployment must use 3 replicas\n- Service exposes port 8080\n"
     )
@@ -194,7 +195,7 @@ def test_checklist_extracts_critical_requirements_bullets():
     ]
 
 
-def test_checklist_stops_at_expected_manifest_marker():
+def test_checklist_stops_at_expected_manifest_marker() -> None:
     expected = (
         "Critical Requirements:\n"
         "- Keep replicas at 3\n"
@@ -204,7 +205,7 @@ def test_checklist_stops_at_expected_manifest_marker():
     assert extract_checklist_items(expected, use_mcp=True) == ["Keep replicas at 3"]
 
 
-def test_checklist_drops_tool_call_items_when_mcp_disabled():
+def test_checklist_drops_tool_call_items_when_mcp_disabled() -> None:
     expected = "Critical Requirements:\n- Expected Tool Call: apply_manifest\n- App is reachable\n"
     assert extract_checklist_items(expected, use_mcp=False) == ["App is reachable"]
     assert extract_checklist_items(expected, use_mcp=True) == [
@@ -213,17 +214,17 @@ def test_checklist_drops_tool_call_items_when_mcp_disabled():
     ]
 
 
-def test_checklist_empty_when_no_bullets():
+def test_checklist_empty_when_no_bullets() -> None:
     assert extract_checklist_items("Some prose without bullets", use_mcp=True) == []
 
 
-def test_checklist_preserves_trailing_hyphen():
+def test_checklist_preserves_trailing_hyphen() -> None:
     # ``lstrip("- ")`` must not eat a trailing hyphen the way ``strip("- ")`` would.
     expected = "Critical Requirements:\n- Deploy to namespace staging-\n"
     assert extract_checklist_items(expected, use_mcp=True) == ["Deploy to namespace staging-"]
 
 
-def test_checklist_threshold_is_value_independent_of_tool_invocation():
+def test_checklist_threshold_is_value_independent_of_tool_invocation() -> None:
     # Phase-0 fix #1: a dedicated constant so the checklist cutoff is not
     # silently coupled to ``TOOL_INVOCATION_THRESHOLD``.
     assert CHECKLIST_THRESHOLD == 0.8
@@ -232,7 +233,7 @@ def test_checklist_threshold_is_value_independent_of_tool_invocation():
 # --- evaluate_metrics_batch (deepeval mocked) ---------------------------------
 
 
-def _metric_result(name, score=1.0, success=True, reason="ok"):
+def _metric_result(name, score=1.0, success=True, reason="ok") -> SimpleNamespace:
     metric_data = SimpleNamespace(name=name, score=score, success=success, reason=reason)
     test_result = SimpleNamespace(metrics_data=[metric_data])
     return SimpleNamespace(test_results=[test_result])
@@ -257,7 +258,7 @@ def _evaluate_by_metric_name(successes=None):
     return _side_effect
 
 
-def _base_result(**overrides):
+def _base_result(**overrides) -> dict[str, Any]:
     res = {
         "input": "deploy the app",
         "output": "done, applied to cluster",
@@ -272,7 +273,7 @@ def _base_result(**overrides):
     return res
 
 
-def _patch_judges(mocker):
+def _patch_judges(mocker: MockerFixture) -> None:
     from devops_bench.metrics import outcome_validity, tool_invocation
 
     mocker.patch.object(
@@ -287,7 +288,7 @@ def _patch_judges(mocker):
     )
 
 
-def test_batch_scores_outcome_and_tool(mocker):
+def test_batch_scores_outcome_and_tool(mocker: MockerFixture) -> None:
     _patch_judges(mocker)
     mocker.patch.object(pipeline, "LLMTestCase")
     # Order-agnostic: result keyed off the metric name with the [GEval] suffix
@@ -306,7 +307,7 @@ def test_batch_scores_outcome_and_tool(mocker):
     assert "ChecklistScore" not in scores
 
 
-def test_batch_skips_tool_when_mcp_disabled(mocker):
+def test_batch_skips_tool_when_mcp_disabled(mocker: MockerFixture) -> None:
     _patch_judges(mocker)
     mocker.patch.object(pipeline, "LLMTestCase")
     evaluate = mocker.patch("deepeval.evaluate", side_effect=_evaluate_by_metric_name())
@@ -321,7 +322,7 @@ def test_batch_skips_tool_when_mcp_disabled(mocker):
     assert "ToolInvocation" not in results[0]["scores"]
 
 
-def test_batch_use_mcp_falls_back_to_env(mocker):
+def test_batch_use_mcp_falls_back_to_env(mocker: MockerFixture) -> None:
     _patch_judges(mocker)
     mocker.patch.object(pipeline, "LLMTestCase")
     mocker.patch("deepeval.evaluate", side_effect=_evaluate_by_metric_name())
@@ -334,7 +335,7 @@ def test_batch_use_mcp_falls_back_to_env(mocker):
     assert "ToolInvocation" not in results[0]["scores"]
 
 
-def test_batch_computes_checklist_score(mocker):
+def test_batch_computes_checklist_score(mocker: MockerFixture) -> None:
     _patch_judges(mocker)
     mocker.patch.object(pipeline, "LLMTestCase")
     # Give the dynamic GEval metric a stable name so success is matchable.
@@ -354,7 +355,7 @@ def test_batch_computes_checklist_score(mocker):
     assert scores["ChecklistScore"]["success"] is True
 
 
-def test_checklist_per_item_geval_uses_explicit_pass_threshold(mocker):
+def test_checklist_per_item_geval_uses_explicit_pass_threshold(mocker: MockerFixture) -> None:
     # Per-item checklist GEvals must pass the explicit 0.8 cutoff rather than
     # inheriting deepeval's looser 0.5 default, since their success flags feed
     # the aggregate ChecklistScore.
@@ -372,7 +373,7 @@ def test_checklist_per_item_geval_uses_explicit_pass_threshold(mocker):
     assert geval_cls.call_args.kwargs["threshold"] == GEVAL_PASS_THRESHOLD
 
 
-def test_batch_invokes_grounding_and_chaos(mocker):
+def test_batch_invokes_grounding_and_chaos(mocker: MockerFixture) -> None:
     _patch_judges(mocker)
     mocker.patch.object(pipeline, "LLMTestCase")
     mocker.patch("deepeval.evaluate", side_effect=_evaluate_by_metric_name())
@@ -400,7 +401,7 @@ def test_batch_invokes_grounding_and_chaos(mocker):
     assert results[0]["scores"]["DocRetrievalRate"] == 0.5
 
 
-def test_batch_score_insertion_order_matches_legacy_results_json(mocker):
+def test_batch_score_insertion_order_matches_legacy_results_json(mocker: MockerFixture) -> None:
     # D3: ``res["scores"]`` insertion order lands on disk; pin the legacy
     # ordering (outcome -> tool -> checklist -> grounding -> chaos) so
     # downstream results.json consumers do not see a reshuffle.
@@ -472,12 +473,12 @@ def test_batch_score_insertion_order_matches_legacy_results_json(mocker):
 # --- generation_only flow + MCP tool-name normalization -----------------------
 
 
-def test_canonical_tool_name_strips_mcp_prefix():
+def test_canonical_tool_name_strips_mcp_prefix() -> None:
     assert pipeline._canonical_tool_name("default__generate_manifest") == "generate_manifest"
     assert pipeline._canonical_tool_name("run_shell_command") == "run_shell_command"
 
 
-def test_build_context_threads_generation_only(mocker):
+def test_build_context_threads_generation_only(mocker: MockerFixture) -> None:
     mocker.patch.object(pipeline, "LLMTestCase", side_effect=lambda **kw: SimpleNamespace(**kw))
     ctx = pipeline._build_context(_base_result(generation_only=True), MagicMock(), True)
     assert ctx.generation_only is True
@@ -485,7 +486,7 @@ def test_build_context_threads_generation_only(mocker):
     assert pipeline._build_context(_base_result(), MagicMock(), True).generation_only is False
 
 
-def test_build_context_normalizes_tool_names_for_judge(mocker):
+def test_build_context_normalizes_tool_names_for_judge(mocker: MockerFixture) -> None:
     mocker.patch.object(pipeline, "LLMTestCase", side_effect=lambda **kw: SimpleNamespace(**kw))
     res = _base_result(
         tools=["default__generate_manifest"],
@@ -499,7 +500,7 @@ def test_build_context_normalizes_tool_names_for_judge(mocker):
     assert res["trajectory"][0]["name"] == "default__generate_manifest"
 
 
-def test_outcome_validity_override_only_when_generation_only(mocker):
+def test_outcome_validity_override_only_when_generation_only(mocker: MockerFixture) -> None:
     from devops_bench.metrics import outcome_validity
 
     captured = {}
@@ -514,7 +515,9 @@ def test_outcome_validity_override_only_when_generation_only(mocker):
     assert outcome_validity._GENERATION_ONLY_OVERRIDE in captured["criteria"]
 
 
-def test_build_context_warns_on_empty_expected_output(caplog, mocker):
+def test_build_context_warns_on_empty_expected_output(
+    caplog: pytest.LogCaptureFixture, mocker: MockerFixture
+) -> None:
     mocker.patch.object(pipeline, "LLMTestCase", side_effect=lambda **kw: SimpleNamespace(**kw))
     import logging
 
@@ -525,7 +528,9 @@ def test_build_context_warns_on_empty_expected_output(caplog, mocker):
     assert "has an empty expected_output" in caplog.text
 
 
-def test_build_context_no_warning_when_expected_output_set(caplog, mocker):
+def test_build_context_no_warning_when_expected_output_set(
+    caplog: pytest.LogCaptureFixture, mocker: MockerFixture
+) -> None:
     mocker.patch.object(pipeline, "LLMTestCase", side_effect=lambda **kw: SimpleNamespace(**kw))
     import logging
 
@@ -535,7 +540,9 @@ def test_build_context_no_warning_when_expected_output_set(caplog, mocker):
     assert len(caplog.records) == 0
 
 
-def test_build_context_missing_expected_output_defaults_and_warns(caplog, mocker):
+def test_build_context_missing_expected_output_defaults_and_warns(
+    caplog: pytest.LogCaptureFixture, mocker: MockerFixture
+) -> None:
     mocker.patch.object(pipeline, "LLMTestCase", side_effect=lambda **kw: SimpleNamespace(**kw))
     import logging
 

--- a/tests/unit/metrics/test_metrics_pipeline.py
+++ b/tests/unit/metrics/test_metrics_pipeline.py
@@ -224,6 +224,13 @@ def test_checklist_preserves_trailing_hyphen() -> None:
     assert extract_checklist_items(expected, use_mcp=True) == ["Deploy to namespace staging-"]
 
 
+def test_checklist_preserves_leading_flag_double_dash() -> None:
+    # Stripping the bullet must remove only the "- " marker, not a leading "--"
+    # on a flag requirement (e.g. "- --dry-run flag must be set").
+    expected = "Critical Requirements:\n- --dry-run flag must be set\n"
+    assert extract_checklist_items(expected, use_mcp=True) == ["--dry-run flag must be set"]
+
+
 def test_checklist_threshold_is_value_independent_of_tool_invocation() -> None:
     # Phase-0 fix #1: a dedicated constant so the checklist cutoff is not
     # silently coupled to ``TOOL_INVOCATION_THRESHOLD``.

--- a/tests/unit/metrics/test_metrics_skills.py
+++ b/tests/unit/metrics/test_metrics_skills.py
@@ -22,6 +22,7 @@ import pytest
 from deepeval.metrics.g_eval.utils import construct_test_case_string
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.test_case import LLMTestCase, SingleTurnParams
+from pytest_mock import MockerFixture
 
 from devops_bench.metrics import _skills, outcome_validity, tool_invocation
 from devops_bench.metrics.base import GEVAL_PASS_THRESHOLD
@@ -44,7 +45,7 @@ class _StubJudgeModel(DeepEvalBaseLLM):
         return "stub-judge"
 
 
-def _patch_resources(mocker, files_by_name):
+def _patch_resources(mocker: MockerFixture, files_by_name: dict[str, str]) -> None:
     """Patch ``_skills.resources.files`` with a fake package traversable.
 
     ``files_by_name`` maps a filename to its text content; any name absent from
@@ -68,28 +69,28 @@ def _patch_resources(mocker, files_by_name):
     mocker.patch.object(_skills.resources, "files", return_value=_FakePackage())
 
 
-def test_load_skill_text_reads_packaged_resource(mocker):
+def test_load_skill_text_reads_packaged_resource(mocker: MockerFixture) -> None:
     _patch_resources(mocker, {"outcome-validity-checklist.md": "## Evaluation Criteria"})
     assert _skills.load_skill_text("outcome-validity-checklist.md") == "## Evaluation Criteria"
 
 
-def test_load_outcome_criteria_uses_loader(mocker):
+def test_load_outcome_criteria_uses_loader(mocker: MockerFixture) -> None:
     _patch_resources(mocker, {outcome_validity.OUTCOME_SKILL_FILENAME: "OUTCOME-MD"})
     assert outcome_validity.load_outcome_criteria() == "OUTCOME-MD"
 
 
-def test_load_tool_criteria_uses_loader(mocker):
+def test_load_tool_criteria_uses_loader(mocker: MockerFixture) -> None:
     _patch_resources(mocker, {tool_invocation.TOOL_SKILL_FILENAME: "TOOL-MD"})
     assert tool_invocation.load_tool_criteria() == "TOOL-MD"
 
 
-def test_load_skill_text_missing_raises(mocker):
+def test_load_skill_text_missing_raises(mocker: MockerFixture) -> None:
     _patch_resources(mocker, {})  # nothing exists
     with pytest.raises(FileNotFoundError):
         _skills.load_skill_text("does-not-exist.md")
 
 
-def test_build_outcome_validity_metric(mocker):
+def test_build_outcome_validity_metric(mocker: MockerFixture) -> None:
     geval_cls = mocker.patch.object(outcome_validity, "GEval")
     mocker.patch.object(outcome_validity, "load_outcome_criteria", return_value="CRIT")
     model = MagicMock()
@@ -103,7 +104,7 @@ def test_build_outcome_validity_metric(mocker):
     assert kwargs["model"] is model
 
 
-def test_build_tool_invocation_metric_applies_threshold(mocker):
+def test_build_tool_invocation_metric_applies_threshold(mocker: MockerFixture) -> None:
     geval_cls = mocker.patch.object(tool_invocation, "GEval")
     mocker.patch.object(tool_invocation, "load_tool_criteria", return_value="CRIT")
     model = MagicMock()
@@ -116,7 +117,7 @@ def test_build_tool_invocation_metric_applies_threshold(mocker):
     assert kwargs["model"] is model
 
 
-def test_build_outcome_validity_metric_includes_expected_output(mocker):
+def test_build_outcome_validity_metric_includes_expected_output(mocker: MockerFixture) -> None:
     mocker.patch.object(outcome_validity, "load_outcome_criteria", return_value="CRIT")
 
     metric = outcome_validity.build_outcome_validity_metric(_StubJudgeModel())
@@ -126,7 +127,7 @@ def test_build_outcome_validity_metric_includes_expected_output(mocker):
     assert SingleTurnParams.EXPECTED_OUTPUT in metric.evaluation_params
 
 
-def test_build_tool_invocation_metric_includes_expected_output(mocker):
+def test_build_tool_invocation_metric_includes_expected_output(mocker: MockerFixture) -> None:
     mocker.patch.object(tool_invocation, "load_tool_criteria", return_value="CRIT")
 
     metric = tool_invocation.build_tool_invocation_metric(_StubJudgeModel())
@@ -136,7 +137,7 @@ def test_build_tool_invocation_metric_includes_expected_output(mocker):
     assert SingleTurnParams.EXPECTED_OUTPUT in metric.evaluation_params
 
 
-def test_outcome_validity_judge_text_includes_expected_output(mocker):
+def test_outcome_validity_judge_text_includes_expected_output(mocker: MockerFixture) -> None:
     mocker.patch.object(outcome_validity, "load_outcome_criteria", return_value="CRIT")
     metric = outcome_validity.build_outcome_validity_metric(_StubJudgeModel())
     case = LLMTestCase(

--- a/tests/unit/metrics/test_metrics_skills.py
+++ b/tests/unit/metrics/test_metrics_skills.py
@@ -1,0 +1,150 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for skill loading and GEval metric construction (outcome + tool)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from deepeval.metrics.g_eval.utils import construct_test_case_string
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+
+from devops_bench.metrics import _skills, outcome_validity, tool_invocation
+from devops_bench.metrics.base import GEVAL_PASS_THRESHOLD
+from devops_bench.metrics.tool_invocation import TOOL_INVOCATION_THRESHOLD
+
+
+class _StubJudgeModel(DeepEvalBaseLLM):
+    """Minimal DeepEvalBaseLLM stub so GEval can be constructed without credentials."""
+
+    def load_model(self):
+        return self
+
+    def generate(self, prompt: str) -> str:
+        return ""
+
+    async def a_generate(self, prompt: str) -> str:
+        return ""
+
+    def get_model_name(self) -> str:
+        return "stub-judge"
+
+
+def _patch_resources(mocker, files_by_name):
+    """Patch ``_skills.resources.files`` with a fake package traversable.
+
+    ``files_by_name`` maps a filename to its text content; any name absent from
+    the mapping is treated as a missing resource (``is_file()`` is False).
+    """
+
+    class _FakeResource:
+        def __init__(self, name):
+            self._name = name
+
+        def is_file(self):
+            return self._name in files_by_name
+
+        def read_text(self, encoding="utf-8"):
+            return files_by_name[self._name]
+
+    class _FakePackage:
+        def __truediv__(self, name):
+            return _FakeResource(name)
+
+    mocker.patch.object(_skills.resources, "files", return_value=_FakePackage())
+
+
+def test_load_skill_text_reads_packaged_resource(mocker):
+    _patch_resources(mocker, {"outcome-validity-checklist.md": "## Evaluation Criteria"})
+    assert _skills.load_skill_text("outcome-validity-checklist.md") == "## Evaluation Criteria"
+
+
+def test_load_outcome_criteria_uses_loader(mocker):
+    _patch_resources(mocker, {outcome_validity.OUTCOME_SKILL_FILENAME: "OUTCOME-MD"})
+    assert outcome_validity.load_outcome_criteria() == "OUTCOME-MD"
+
+
+def test_load_tool_criteria_uses_loader(mocker):
+    _patch_resources(mocker, {tool_invocation.TOOL_SKILL_FILENAME: "TOOL-MD"})
+    assert tool_invocation.load_tool_criteria() == "TOOL-MD"
+
+
+def test_load_skill_text_missing_raises(mocker):
+    _patch_resources(mocker, {})  # nothing exists
+    with pytest.raises(FileNotFoundError):
+        _skills.load_skill_text("does-not-exist.md")
+
+
+def test_build_outcome_validity_metric(mocker):
+    geval_cls = mocker.patch.object(outcome_validity, "GEval")
+    mocker.patch.object(outcome_validity, "load_outcome_criteria", return_value="CRIT")
+    model = MagicMock()
+
+    outcome_validity.build_outcome_validity_metric(model)
+
+    kwargs = geval_cls.call_args.kwargs
+    assert kwargs["name"] == "OutcomeValidity"
+    assert kwargs["criteria"] == "CRIT"
+    assert kwargs["threshold"] == GEVAL_PASS_THRESHOLD
+    assert kwargs["model"] is model
+
+
+def test_build_tool_invocation_metric_applies_threshold(mocker):
+    geval_cls = mocker.patch.object(tool_invocation, "GEval")
+    mocker.patch.object(tool_invocation, "load_tool_criteria", return_value="CRIT")
+    model = MagicMock()
+
+    tool_invocation.build_tool_invocation_metric(model)
+
+    kwargs = geval_cls.call_args.kwargs
+    assert kwargs["name"] == "ToolInvocation"
+    assert kwargs["threshold"] == TOOL_INVOCATION_THRESHOLD
+    assert kwargs["model"] is model
+
+
+def test_build_outcome_validity_metric_includes_expected_output(mocker):
+    mocker.patch.object(outcome_validity, "load_outcome_criteria", return_value="CRIT")
+
+    metric = outcome_validity.build_outcome_validity_metric(_StubJudgeModel())
+
+    assert SingleTurnParams.INPUT in metric.evaluation_params
+    assert SingleTurnParams.ACTUAL_OUTPUT in metric.evaluation_params
+    assert SingleTurnParams.EXPECTED_OUTPUT in metric.evaluation_params
+
+
+def test_build_tool_invocation_metric_includes_expected_output(mocker):
+    mocker.patch.object(tool_invocation, "load_tool_criteria", return_value="CRIT")
+
+    metric = tool_invocation.build_tool_invocation_metric(_StubJudgeModel())
+
+    assert SingleTurnParams.INPUT in metric.evaluation_params
+    assert SingleTurnParams.ACTUAL_OUTPUT in metric.evaluation_params
+    assert SingleTurnParams.EXPECTED_OUTPUT in metric.evaluation_params
+
+
+def test_outcome_validity_judge_text_includes_expected_output(mocker):
+    mocker.patch.object(outcome_validity, "load_outcome_criteria", return_value="CRIT")
+    metric = outcome_validity.build_outcome_validity_metric(_StubJudgeModel())
+    case = LLMTestCase(
+        input="do the task",
+        actual_output="did something",
+        expected_output="UNIQUE_EXPECTED_OUTPUT_MARKER",
+    )
+
+    judge_text = construct_test_case_string(metric.evaluation_params, case)
+
+    assert "UNIQUE_EXPECTED_OUTPUT_MARKER" in judge_text


### PR DESCRIPTION
Adds the five judge metric families and wires them into the scoring surface.

**Metric families** (`devops_bench/metrics/`)
- `grounding.py` — documentation-grounding scoring and doc-retrieval rate.
- `tool_invocation.py` — tool-invocation correctness metric.
- `checklist.py` — checklist extraction and scoring.
- `outcome_validity.py` — outcome-validity metric.
- `chaos_metrics.py` — chaos-scenario scoring.

Each family self-registers into the `METRICS` registry on import. `pipeline.py`
imports them for those registration side effects and re-exports the checklist
helpers, and the package `__init__` now exposes the full scoring surface
(`evaluate_metrics_batch`, the judge accessors, and the per-family builders).

Unit tests are co-located under `tests/unit/metrics/`: the existing
`test_metrics_pipeline.py` gains the concrete-family coverage alongside the
stub-based dispatch tests, and new tests cover grounding, chaos, and the skill
loaders.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added checklist-based evaluation of critical requirements.
  * Added outcome validity and tool-invocation scoring.
  * Added documentation grounding and retrieval-rate metrics.
  * Added chaos diagnosis, recovery, and performance evaluation.
  * Added batch processing across all applicable metrics with isolated failures.
  * Expanded the metrics API with additional evaluation helpers and model access.

* **Tests**
  * Added comprehensive coverage for metric scoring, filtering, aggregation, ordering, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->