### PR TITLE
feat(verification): add pod-healthy and scaling-complete verifiers

### DIFF
--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -139,6 +139,7 @@ def get_resource(
     selector: str | None = None,
     namespace: str | None = None,
     kubeconfig: KubeconfigSource = None,
+    timeout: float | None = None,
 ) -> dict[str, Any]:
     """Fetch a resource (or list) as parsed JSON via ``kubectl get -o json``.
 
@@ -148,6 +149,9 @@ def get_resource(
         selector: Optional label selector (``-l``).
         namespace: Optional namespace (``-n``).
         kubeconfig: Kubeconfig path or context-like object.
+        timeout: Optional seconds before the subprocess is killed. ``None``
+            (the default) blocks indefinitely, so pass one whenever the API
+            server might accept a connection and never respond.
 
     Returns:
         The parsed JSON document.
@@ -166,7 +170,7 @@ def get_resource(
         "json",
         *_namespace_args(namespace),
     ]
-    completed = _run_kubectl(argv, kubeconfig)
+    completed = _run_kubectl(argv, kubeconfig, timeout=timeout)
     return json.loads(completed.stdout)
 
 

--- a/devops_bench/verification/spec.py
+++ b/devops_bench/verification/spec.py
@@ -21,9 +21,8 @@ from typing import Any, Literal
 from pydantic import BaseModel, RootModel, ValidationError, model_validator
 from pydantic_core import PydanticCustomError
 
-# Leaf verifiers populate the ``VERIFIERS`` registry via their
-# ``@VERIFIERS.register`` decorators when their modules are imported.
 from devops_bench.core import NotRegisteredError
+from devops_bench.verification import verifiers as _verifiers  # noqa: F401
 from devops_bench.verification.base import VERIFIERS
 
 __all__ = [

--- a/devops_bench/verification/verifiers/__init__.py
+++ b/devops_bench/verification/verifiers/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Concrete single-condition verifiers."""
+
+from devops_bench.verification.verifiers.pod_healthy import PodHealthyVerifier
+from devops_bench.verification.verifiers.scaling_complete import ScalingCompleteVerifier
+
+__all__ = ["PodHealthyVerifier", "ScalingCompleteVerifier"]

--- a/devops_bench/verification/verifiers/pod_healthy.py
+++ b/devops_bench/verification/verifiers/pod_healthy.py
@@ -1,0 +1,126 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verifier that waits for selected pods to become Ready/Running."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Literal
+
+from devops_bench.core import SubprocessError, get_logger
+from devops_bench.k8s import get_resource, wait
+from devops_bench.verification.base import VERIFIERS, BaseVerifier, VerificationResult
+
+__all__ = ["PodHealthyVerifier"]
+
+_log = get_logger("verification.pod_healthy")
+
+
+@VERIFIERS.register("pod_healthy")
+class PodHealthyVerifier(BaseVerifier):
+    """Verify that pods matched by a selector are Ready (Running on fallback).
+
+    The primary path blocks on ``kubectl wait --for=condition=Ready``. If that
+    fails or times out, it falls back to inspecting pod phases and succeeds when
+    every matched pod is ``Running``.
+
+    Attributes:
+        type: Discriminator literal, always ``"pod_healthy"``.
+        selector: Label selector (``-l``) identifying the pods.
+        namespace: Optional namespace; defaults to the active one.
+    """
+
+    type: Literal["pod_healthy"] = "pod_healthy"
+    selector: str
+    namespace: str | None = None
+
+    def verify(self, timeout_sec: float) -> VerificationResult:
+        """Wait for the selected pods to become Ready.
+
+        Args:
+            timeout_sec: Maximum seconds to wait via ``kubectl wait``.
+
+        Returns:
+            A result that is successful when the readiness condition is met or
+            the Running-phase fallback holds.
+        """
+        start_time = time.monotonic()
+        try:
+            completed = wait(
+                "pod",
+                selector=self.selector,
+                for_condition="condition=Ready",
+                timeout_sec=timeout_sec,
+                namespace=self.namespace,
+                kubeconfig=self.kubeconfig,
+            )
+            return VerificationResult(
+                success=True,
+                elapsed_time=time.monotonic() - start_time,
+                reason="Condition met via kubectl wait",
+                name=self.name,
+                raw={"output": completed.stdout.strip()},
+            )
+        except SubprocessError as exc:
+            # ``kubectl wait`` returns nonzero on timeout even for healthy pods
+            # that never reach Ready (probe-less pods, or the condition not yet
+            # propagated), so fall back to checking the Running phase directly.
+            elapsed = time.monotonic() - start_time
+            _log.debug(
+                "kubectl wait failed for selector %s; falling back to phase check",
+                self.selector,
+            )
+            raw = self._get_pods_details()
+            if self._check_pods_status(raw):
+                return VerificationResult(
+                    success=True,
+                    elapsed_time=elapsed,
+                    reason="Condition met via polling fallback",
+                    name=self.name,
+                    raw=raw,
+                )
+
+            stderr = (exc.stderr or "").strip()
+            return VerificationResult(
+                success=False,
+                elapsed_time=elapsed,
+                reason=f"kubectl wait failed or timed out: {stderr}",
+                name=self.name,
+                raw=raw,
+            )
+
+    def _get_pods_details(self) -> dict[str, Any]:
+        """Fetch matched pods as JSON, returning an error dict on failure."""
+        try:
+            return get_resource(
+                "pods",
+                selector=self.selector,
+                namespace=self.namespace,
+                kubeconfig=self.kubeconfig,
+            )
+        except Exception as exc:  # noqa: BLE001 - diagnostics path, never raises
+            _log.warning("Failed to fetch pod details for selector %s: %s", self.selector, exc)
+            return {"error": str(exc)}
+
+    def _check_pods_status(self, raw: dict[str, Any]) -> bool:
+        """Return True when at least one pod matched and all are ``Running``.
+
+        A pod whose ``status`` is explicitly ``null`` is treated as not Running
+        rather than crashing the check.
+        """
+        items = raw.get("items", [])
+        return len(items) > 0 and all(
+            (p.get("status") or {}).get("phase") == "Running" for p in items
+        )

--- a/devops_bench/verification/verifiers/pod_healthy.py
+++ b/devops_bench/verification/verifiers/pod_healthy.py
@@ -81,7 +81,7 @@ class PodHealthyVerifier(BaseVerifier):
                 "kubectl wait failed for selector %s; falling back to phase check",
                 self.selector,
             )
-            raw = self._get_pods_details()
+            raw = self._get_pods_details(timeout_sec)
             elapsed = time.monotonic() - start_time
             if self._check_pods_status(raw):
                 return VerificationResult(
@@ -101,7 +101,7 @@ class PodHealthyVerifier(BaseVerifier):
                 raw=raw,
             )
 
-    def _get_pods_details(self) -> dict[str, Any]:
+    def _get_pods_details(self, timeout_sec: float) -> dict[str, Any]:
         """Fetch matched pods as JSON, returning an error dict on failure."""
         try:
             return get_resource(
@@ -109,18 +109,33 @@ class PodHealthyVerifier(BaseVerifier):
                 selector=self.selector,
                 namespace=self.namespace,
                 kubeconfig=self.kubeconfig,
+                timeout=timeout_sec,
             )
         except Exception as exc:  # noqa: BLE001 - diagnostics path, never raises
             _log.warning("Failed to fetch pod details for selector %s: %s", self.selector, exc)
             return {"error": str(exc)}
 
     def _check_pods_status(self, raw: dict[str, Any]) -> bool:
-        """Return True when at least one pod matched and all are ``Running``.
+        """Return True when at least one pod matched and all are healthy.
 
-        A pod whose ``status`` is explicitly ``null`` is treated as not Running
+        A pod whose ``status`` is explicitly ``null`` is treated as not healthy
         rather than crashing the check.
         """
         items = raw.get("items", [])
-        return len(items) > 0 and all(
-            (p.get("status") or {}).get("phase") == "Running" for p in items
-        )
+        return len(items) > 0 and all(self._pod_is_healthy(p) for p in items)
+
+    @staticmethod
+    def _pod_is_healthy(pod: dict[str, Any]) -> bool:
+        """Prefer the ``Ready`` condition; fall back to the ``Running`` phase.
+
+        A pod stuck in ``CrashLoopBackOff`` still reports phase ``Running``
+        while its container keeps restarting, so phase alone is not
+        sufficient. Fall back to phase only when no conditions are reported
+        yet (e.g. immediately after scheduling).
+        """
+        status = pod.get("status") or {}
+        conditions = status.get("conditions") or []
+        ready = next((c for c in conditions if c.get("type") == "Ready"), None)
+        if ready is not None:
+            return ready.get("status") == "True"
+        return status.get("phase") == "Running"

--- a/devops_bench/verification/verifiers/pod_healthy.py
+++ b/devops_bench/verification/verifiers/pod_healthy.py
@@ -77,12 +77,12 @@ class PodHealthyVerifier(BaseVerifier):
             # ``kubectl wait`` returns nonzero on timeout even for healthy pods
             # that never reach Ready (probe-less pods, or the condition not yet
             # propagated), so fall back to checking the Running phase directly.
-            elapsed = time.monotonic() - start_time
             _log.debug(
                 "kubectl wait failed for selector %s; falling back to phase check",
                 self.selector,
             )
             raw = self._get_pods_details()
+            elapsed = time.monotonic() - start_time
             if self._check_pods_status(raw):
                 return VerificationResult(
                     success=True,

--- a/devops_bench/verification/verifiers/scaling_complete.py
+++ b/devops_bench/verification/verifiers/scaling_complete.py
@@ -83,10 +83,14 @@ class ScalingCompleteVerifier(BaseVerifier):
             A result reflecting the last observed scaling state; successful once
             ready replicas fall within ``[min_replicas, max_replicas]``.
         """
-        return self._poll_to_result(self._check_scaling, timeout_sec)
+        return self._poll_to_result(lambda: self._check_scaling(timeout_sec), timeout_sec)
 
-    def _check_scaling(self) -> tuple[bool, str, dict[str, Any] | None]:
+    def _check_scaling(self, timeout_sec: float) -> tuple[bool, str, dict[str, Any] | None]:
         """Read the deployment once and compare ready replicas to the target.
+
+        Args:
+            timeout_sec: Seconds before the ``kubectl get`` call is killed, so
+                a single hung API request cannot block the whole poll.
 
         Returns:
             A ``(success, reason, raw)`` triple. ``raw`` carries the raw
@@ -98,6 +102,7 @@ class ScalingCompleteVerifier(BaseVerifier):
                 self.deployment,
                 namespace=self.namespace,
                 kubeconfig=self.kubeconfig,
+                timeout=timeout_sec,
             )
         except SubprocessError as exc:
             stderr = (exc.stderr or "").strip()

--- a/devops_bench/verification/verifiers/scaling_complete.py
+++ b/devops_bench/verification/verifiers/scaling_complete.py
@@ -1,0 +1,106 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verifier that waits for a deployment to converge to a ready replica target."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from devops_bench.core import SubprocessError, get_logger
+from devops_bench.k8s import get_resource
+from devops_bench.verification.base import VERIFIERS, BaseVerifier, VerificationResult
+
+__all__ = ["ScalingCompleteVerifier"]
+
+_log = get_logger("verification.scaling_complete")
+
+
+@VERIFIERS.register("scaling_complete")
+class ScalingCompleteVerifier(BaseVerifier):
+    """Verify that a deployment has converged to a ready replica target.
+
+    The deployment's ``status.readyReplicas`` is polled with exponential backoff
+    (via :func:`devops_bench.k8s.poll_until`) until it falls within
+    ``[min_replicas, max_replicas]`` or the timeout elapses. Leaving
+    ``max_replicas`` unset checks only the lower bound (scale-up); setting it
+    bounds the count from above as well, covering scale-down and optimization
+    targets where the deployment must shrink to or stay within a ceiling.
+
+    Attributes:
+        type: Discriminator literal, always ``"scaling_complete"``.
+        deployment: Name of the deployment to inspect.
+        min_replicas: Minimum ready replicas required for success.
+        max_replicas: Optional maximum ready replicas allowed for success; when
+            ``None`` only the lower bound is enforced.
+        namespace: Optional namespace; defaults to the active one.
+    """
+
+    type: Literal["scaling_complete"] = "scaling_complete"
+    deployment: str
+    min_replicas: int = 1
+    max_replicas: int | None = None
+    namespace: str | None = None
+
+    def verify(self, timeout_sec: float) -> VerificationResult:
+        """Poll the deployment until its ready replicas reach the target range.
+
+        Args:
+            timeout_sec: Maximum seconds to keep polling.
+
+        Returns:
+            A result reflecting the last observed scaling state; successful once
+            ready replicas fall within ``[min_replicas, max_replicas]``.
+        """
+        return self._poll_to_result(self._check_scaling, timeout_sec)
+
+    def _check_scaling(self) -> tuple[bool, str, dict[str, Any] | None]:
+        """Read the deployment once and compare ready replicas to the target.
+
+        Returns:
+            A ``(success, reason, raw)`` triple. ``raw`` carries the raw
+            deployment document once one could be read, else ``None``.
+        """
+        try:
+            dep_data = get_resource(
+                "deployment",
+                self.deployment,
+                namespace=self.namespace,
+                kubeconfig=self.kubeconfig,
+            )
+        except SubprocessError as exc:
+            stderr = (exc.stderr or "").strip()
+            _log.warning("Failed to get deployment %s: %s", self.deployment, stderr)
+            return False, f"Failed to get deployment: {stderr}", None
+        except ValueError:
+            _log.warning("Failed to parse deployment JSON for %s", self.deployment)
+            return False, "Failed to parse deployment JSON", None
+
+        # ``status`` may be explicitly null before the controller populates it.
+        ready_replicas = (dep_data.get("status") or {}).get("readyReplicas", 0)
+        raw = {"deployment": dep_data}
+        if ready_replicas < self.min_replicas:
+            reason = f"Ready replicas ({ready_replicas}) < min replicas ({self.min_replicas})"
+            return False, reason, raw
+        if self.max_replicas is not None and ready_replicas > self.max_replicas:
+            reason = f"Ready replicas ({ready_replicas}) > max replicas ({self.max_replicas})"
+            return False, reason, raw
+        if self.max_replicas is None:
+            reason = f"Ready replicas ({ready_replicas}) >= min replicas ({self.min_replicas})"
+        else:
+            reason = (
+                f"Ready replicas ({ready_replicas}) within bounds "
+                f"[{self.min_replicas}, {self.max_replicas}]"
+            )
+        return True, reason, raw

--- a/devops_bench/verification/verifiers/scaling_complete.py
+++ b/devops_bench/verification/verifiers/scaling_complete.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
+from pydantic import model_validator
+
 from devops_bench.core import SubprocessError, get_logger
 from devops_bench.k8s import get_resource
 from devops_bench.verification.base import VERIFIERS, BaseVerifier, VerificationResult
@@ -45,6 +47,10 @@ class ScalingCompleteVerifier(BaseVerifier):
         max_replicas: Optional maximum ready replicas allowed for success; when
             ``None`` only the lower bound is enforced.
         namespace: Optional namespace; defaults to the active one.
+
+    Raises:
+        pydantic.ValidationError: If ``min_replicas`` or ``max_replicas`` is
+            negative, or ``min_replicas`` exceeds ``max_replicas``.
     """
 
     type: Literal["scaling_complete"] = "scaling_complete"
@@ -52,6 +58,20 @@ class ScalingCompleteVerifier(BaseVerifier):
     min_replicas: int = 1
     max_replicas: int | None = None
     namespace: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_replica_bounds(self) -> ScalingCompleteVerifier:
+        if self.min_replicas < 0:
+            raise ValueError(f"min_replicas must be >= 0, got {self.min_replicas}")
+        if self.max_replicas is not None:
+            if self.max_replicas < 0:
+                raise ValueError(f"max_replicas must be >= 0, got {self.max_replicas}")
+            if self.min_replicas > self.max_replicas:
+                raise ValueError(
+                    f"min_replicas ({self.min_replicas}) must be <= "
+                    f"max_replicas ({self.max_replicas})"
+                )
+        return self
 
     def verify(self, timeout_sec: float) -> VerificationResult:
         """Poll the deployment until its ready replicas reach the target range.

--- a/tests/unit/k8s/test_k8s_kubectl.py
+++ b/tests/unit/k8s/test_k8s_kubectl.py
@@ -115,6 +115,29 @@ def test_get_resource_with_name(mocker: MockerFixture) -> None:
     assert argv == ["kubectl", "get", "deployment", "my-dep", "-o", "json"]
 
 
+def test_get_resource_forwards_timeout(mocker: MockerFixture) -> None:
+    payload = {"items": []}
+    mock_run = mocker.patch(
+        "devops_bench.k8s.kubectl.run",
+        return_value=_completed(stdout=json.dumps(payload)),
+    )
+
+    kubectl.get_resource("pods", timeout=30)
+
+    assert mock_run.call_args.kwargs["timeout"] == 30
+
+
+def test_get_resource_timeout_defaults_to_none(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch(
+        "devops_bench.k8s.kubectl.run",
+        return_value=_completed(stdout="{}"),
+    )
+
+    kubectl.get_resource("pods")
+
+    assert mock_run.call_args.kwargs["timeout"] is None
+
+
 def test_apply_builds_argv(mocker: MockerFixture) -> None:
     mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
 

--- a/tests/unit/verification/test_package_import.py
+++ b/tests/unit/verification/test_package_import.py
@@ -37,3 +37,18 @@ def test_import_pulls_no_heavy_sdks():
     proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=30)
     assert proc.returncode == 0, proc.stderr
     assert "ok" in proc.stdout
+
+
+def test_parse_node_finds_leaf_verifiers_without_importing_them_directly():
+    # A fresh interpreter that only imports devops_bench.verification: nothing
+    # else has imported devops_bench.verification.verifiers yet, so this fails
+    # unless the package itself registers the leaf verifiers on import.
+    code = (
+        "from devops_bench.verification.spec import parse_node\n"
+        "node = parse_node({'type': 'pod_healthy', 'selector': 'app=web'})\n"
+        "assert node.type == 'pod_healthy'\n"
+        "print('ok')\n"
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, proc.stderr
+    assert "ok" in proc.stdout

--- a/tests/unit/verification/test_pod_healthy.py
+++ b/tests/unit/verification/test_pod_healthy.py
@@ -27,7 +27,7 @@ from devops_bench.core import SubprocessError
 from devops_bench.verification.verifiers import PodHealthyVerifier
 
 
-def test_kubectl_wait_success_returns_raw_output():
+def test_kubectl_wait_success_returns_raw_output() -> None:
     completed = SimpleNamespace(stdout="pod/web condition met\n")
     with patch(
         "devops_bench.verification.verifiers.pod_healthy.wait",
@@ -40,7 +40,7 @@ def test_kubectl_wait_success_returns_raw_output():
     assert result.children == []
 
 
-def test_polling_fallback_when_kubectl_wait_fails_and_pods_running():
+def test_polling_fallback_when_kubectl_wait_fails_and_pods_running() -> None:
     fake_pods = {
         "items": [
             {"status": {"phase": "Running"}},
@@ -64,7 +64,7 @@ def test_polling_fallback_when_kubectl_wait_fails_and_pods_running():
     assert result.raw == fake_pods
 
 
-def test_fallback_reports_failure_when_no_pods_match():
+def test_fallback_reports_failure_when_no_pods_match() -> None:
     with (
         patch(
             "devops_bench.verification.verifiers.pod_healthy.wait",
@@ -81,7 +81,7 @@ def test_fallback_reports_failure_when_no_pods_match():
     assert "no match" in result.reason
 
 
-def test_null_status_does_not_crash_phase_check():
+def test_null_status_does_not_crash_phase_check() -> None:
     # A pod returned with an explicitly null ``status`` field would crash a
     # naive ``p["status"]["phase"]`` lookup. The verifier must null-guard.
     fake_pods = {
@@ -108,7 +108,39 @@ def test_null_status_does_not_crash_phase_check():
     assert result.raw == fake_pods
 
 
-def test_name_is_echoed_onto_result():
+def test_elapsed_time_includes_fallback_fetch_duration() -> None:
+    # A plain monotonic() mock can't distinguish call ordering, so drive a fake
+    # clock that advances inside the fetch itself: elapsed_time must reflect
+    # that advance, which only holds if it's computed after the fetch returns.
+    clock = {"t": 100.0}
+
+    def fake_monotonic() -> float:
+        return clock["t"]
+
+    def fake_get_resource(*args: object, **kwargs: object) -> dict:
+        clock["t"] += 5.0
+        return {"items": [{"status": {"phase": "Running"}}]}
+
+    with (
+        patch(
+            "devops_bench.verification.verifiers.pod_healthy.wait",
+            side_effect=SubprocessError(["kubectl"], returncode=1, stderr="timeout"),
+        ),
+        patch(
+            "devops_bench.verification.verifiers.pod_healthy.get_resource",
+            side_effect=fake_get_resource,
+        ),
+        patch(
+            "devops_bench.verification.verifiers.pod_healthy.time.monotonic",
+            side_effect=fake_monotonic,
+        ),
+    ):
+        result = PodHealthyVerifier(selector="app=web").verify(timeout_sec=10)
+
+    assert result.elapsed_time >= 5.0
+
+
+def test_name_is_echoed_onto_result() -> None:
     completed = SimpleNamespace(stdout="ok")
     with patch(
         "devops_bench.verification.verifiers.pod_healthy.wait",

--- a/tests/unit/verification/test_pod_healthy.py
+++ b/tests/unit/verification/test_pod_healthy.py
@@ -108,6 +108,60 @@ def test_null_status_does_not_crash_phase_check() -> None:
     assert result.raw == fake_pods
 
 
+def test_crashloop_pod_reporting_running_phase_is_not_healthy() -> None:
+    # A CrashLoopBackOff pod still reports phase "Running" while its container
+    # keeps restarting; the Ready condition must be checked, not just phase.
+    fake_pods = {
+        "items": [
+            {
+                "status": {
+                    "phase": "Running",
+                    "conditions": [{"type": "Ready", "status": "False"}],
+                }
+            }
+        ]
+    }
+    with (
+        patch(
+            "devops_bench.verification.verifiers.pod_healthy.wait",
+            side_effect=SubprocessError(["kubectl"], returncode=1, stderr="timeout"),
+        ),
+        patch(
+            "devops_bench.verification.verifiers.pod_healthy.get_resource",
+            return_value=fake_pods,
+        ),
+    ):
+        result = PodHealthyVerifier(selector="app=web").verify(timeout_sec=5)
+
+    assert result.success is False
+
+
+def test_ready_condition_true_is_healthy_even_with_other_phase() -> None:
+    fake_pods = {
+        "items": [
+            {
+                "status": {
+                    "phase": "Running",
+                    "conditions": [{"type": "Ready", "status": "True"}],
+                }
+            }
+        ]
+    }
+    with (
+        patch(
+            "devops_bench.verification.verifiers.pod_healthy.wait",
+            side_effect=SubprocessError(["kubectl"], returncode=1, stderr="timeout"),
+        ),
+        patch(
+            "devops_bench.verification.verifiers.pod_healthy.get_resource",
+            return_value=fake_pods,
+        ),
+    ):
+        result = PodHealthyVerifier(selector="app=web").verify(timeout_sec=5)
+
+    assert result.success is True
+
+
 def test_elapsed_time_includes_fallback_fetch_duration() -> None:
     # A plain monotonic() mock can't distinguish call ordering, so drive a fake
     # clock that advances inside the fetch itself: elapsed_time must reflect

--- a/tests/unit/verification/test_pod_healthy.py
+++ b/tests/unit/verification/test_pod_healthy.py
@@ -1,0 +1,119 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``PodHealthyVerifier``.
+
+The underlying ``kubectl`` calls are stubbed via ``unittest.mock.patch`` so the
+verifier can be exercised without a real cluster.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from devops_bench.core import SubprocessError
+from devops_bench.verification.verifiers import PodHealthyVerifier
+
+
+def test_kubectl_wait_success_returns_raw_output():
+    completed = SimpleNamespace(stdout="pod/web condition met\n")
+    with patch(
+        "devops_bench.verification.verifiers.pod_healthy.wait",
+        return_value=completed,
+    ):
+        result = PodHealthyVerifier(selector="app=web").verify(timeout_sec=10)
+
+    assert result.success is True
+    assert result.raw == {"output": "pod/web condition met"}
+    assert result.children == []
+
+
+def test_polling_fallback_when_kubectl_wait_fails_and_pods_running():
+    fake_pods = {
+        "items": [
+            {"status": {"phase": "Running"}},
+            {"status": {"phase": "Running"}},
+        ]
+    }
+    with (
+        patch(
+            "devops_bench.verification.verifiers.pod_healthy.wait",
+            side_effect=SubprocessError(["kubectl"], returncode=1, stderr="timeout"),
+        ),
+        patch(
+            "devops_bench.verification.verifiers.pod_healthy.get_resource",
+            return_value=fake_pods,
+        ),
+    ):
+        result = PodHealthyVerifier(selector="app=web").verify(timeout_sec=10)
+
+    assert result.success is True
+    assert "polling fallback" in result.reason
+    assert result.raw == fake_pods
+
+
+def test_fallback_reports_failure_when_no_pods_match():
+    with (
+        patch(
+            "devops_bench.verification.verifiers.pod_healthy.wait",
+            side_effect=SubprocessError(["kubectl"], returncode=1, stderr="no match"),
+        ),
+        patch(
+            "devops_bench.verification.verifiers.pod_healthy.get_resource",
+            return_value={"items": []},
+        ),
+    ):
+        result = PodHealthyVerifier(selector="app=ghost").verify(timeout_sec=5)
+
+    assert result.success is False
+    assert "no match" in result.reason
+
+
+def test_null_status_does_not_crash_phase_check():
+    # A pod returned with an explicitly null ``status`` field would crash a
+    # naive ``p["status"]["phase"]`` lookup. The verifier must null-guard.
+    fake_pods = {
+        "items": [
+            {"status": None},
+            {"status": {"phase": "Running"}},
+        ]
+    }
+    with (
+        patch(
+            "devops_bench.verification.verifiers.pod_healthy.wait",
+            side_effect=SubprocessError(["kubectl"], returncode=1, stderr="wait failed"),
+        ),
+        patch(
+            "devops_bench.verification.verifiers.pod_healthy.get_resource",
+            return_value=fake_pods,
+        ),
+    ):
+        result = PodHealthyVerifier(selector="app=mixed").verify(timeout_sec=5)
+
+    # Not all pods are Running, so it fails — but it must fail cleanly, not
+    # raise on the null status.
+    assert result.success is False
+    assert result.raw == fake_pods
+
+
+def test_name_is_echoed_onto_result():
+    completed = SimpleNamespace(stdout="ok")
+    with patch(
+        "devops_bench.verification.verifiers.pod_healthy.wait",
+        return_value=completed,
+    ):
+        result = PodHealthyVerifier(name="web-pods", selector="app=web").verify(timeout_sec=10)
+
+    assert result.name == "web-pods"

--- a/tests/unit/verification/test_scaling_complete.py
+++ b/tests/unit/verification/test_scaling_complete.py
@@ -1,0 +1,120 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``ScalingCompleteVerifier``.
+
+The poll function and kubectl primitives are stubbed; no real cluster work.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from devops_bench.core import SubprocessError
+from devops_bench.verification.verifiers import ScalingCompleteVerifier
+
+
+def test_success_when_ready_replicas_meet_minimum():
+    deployment = {"status": {"readyReplicas": 3}}
+    with patch(
+        "devops_bench.verification.verifiers.scaling_complete.get_resource",
+        return_value=deployment,
+    ):
+        result = ScalingCompleteVerifier(deployment="web", min_replicas=2).verify(timeout_sec=5)
+
+    assert result.success is True
+    assert "Ready replicas (3) >= min replicas (2)" in result.reason
+    assert result.raw["deployment"] == deployment
+
+
+def test_failure_when_ready_replicas_below_minimum():
+    # The poll runs once with a zero timeout, returns False, and we report the
+    # last observed reason — replicas are below the threshold.
+    deployment = {"status": {"readyReplicas": 1}}
+    with patch(
+        "devops_bench.verification.verifiers.scaling_complete.get_resource",
+        return_value=deployment,
+    ):
+        result = ScalingCompleteVerifier(deployment="web", min_replicas=3).verify(timeout_sec=0)
+
+    assert result.success is False
+    assert "Ready replicas (1) < min replicas (3)" in result.reason
+
+
+def test_null_status_does_not_crash_check():
+    # ``status`` may be explicitly null before the deployment controller
+    # populates it; the verifier must treat ready replicas as 0.
+    deployment = {"status": None}
+    with patch(
+        "devops_bench.verification.verifiers.scaling_complete.get_resource",
+        return_value=deployment,
+    ):
+        result = ScalingCompleteVerifier(deployment="web", min_replicas=1).verify(timeout_sec=0)
+
+    assert result.success is False
+    assert "Ready replicas (0) < min replicas (1)" in result.reason
+
+
+def test_subprocess_error_is_reported_in_reason():
+    with patch(
+        "devops_bench.verification.verifiers.scaling_complete.get_resource",
+        side_effect=SubprocessError(["kubectl"], returncode=1, stderr="not found"),
+    ):
+        result = ScalingCompleteVerifier(deployment="web", min_replicas=1).verify(timeout_sec=0)
+
+    assert result.success is False
+    assert "Failed to get deployment" in result.reason
+
+
+def test_success_when_ready_replicas_within_bounds():
+    # With both bounds set, a count inside [min, max] succeeds — the scale-down /
+    # optimization case where the deployment must shrink to a ceiling.
+    deployment = {"status": {"readyReplicas": 2}}
+    with patch(
+        "devops_bench.verification.verifiers.scaling_complete.get_resource",
+        return_value=deployment,
+    ):
+        result = ScalingCompleteVerifier(deployment="web", min_replicas=1, max_replicas=3).verify(
+            timeout_sec=5
+        )
+
+    assert result.success is True
+    assert "within bounds [1, 3]" in result.reason
+
+
+def test_failure_when_ready_replicas_above_maximum():
+    deployment = {"status": {"readyReplicas": 5}}
+    with patch(
+        "devops_bench.verification.verifiers.scaling_complete.get_resource",
+        return_value=deployment,
+    ):
+        result = ScalingCompleteVerifier(deployment="web", min_replicas=1, max_replicas=3).verify(
+            timeout_sec=0
+        )
+
+    assert result.success is False
+    assert "Ready replicas (5) > max replicas (3)" in result.reason
+
+
+def test_name_is_echoed_onto_result():
+    deployment = {"status": {"readyReplicas": 5}}
+    with patch(
+        "devops_bench.verification.verifiers.scaling_complete.get_resource",
+        return_value=deployment,
+    ):
+        result = ScalingCompleteVerifier(
+            name="scale-to-two", deployment="web", min_replicas=2
+        ).verify(timeout_sec=5)
+
+    assert result.name == "scale-to-two"

--- a/tests/unit/verification/test_scaling_complete.py
+++ b/tests/unit/verification/test_scaling_complete.py
@@ -21,11 +21,14 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+from pydantic import ValidationError
+
 from devops_bench.core import SubprocessError
 from devops_bench.verification.verifiers import ScalingCompleteVerifier
 
 
-def test_success_when_ready_replicas_meet_minimum():
+def test_success_when_ready_replicas_meet_minimum() -> None:
     deployment = {"status": {"readyReplicas": 3}}
     with patch(
         "devops_bench.verification.verifiers.scaling_complete.get_resource",
@@ -38,7 +41,7 @@ def test_success_when_ready_replicas_meet_minimum():
     assert result.raw["deployment"] == deployment
 
 
-def test_failure_when_ready_replicas_below_minimum():
+def test_failure_when_ready_replicas_below_minimum() -> None:
     # The poll runs once with a zero timeout, returns False, and we report the
     # last observed reason — replicas are below the threshold.
     deployment = {"status": {"readyReplicas": 1}}
@@ -52,7 +55,7 @@ def test_failure_when_ready_replicas_below_minimum():
     assert "Ready replicas (1) < min replicas (3)" in result.reason
 
 
-def test_null_status_does_not_crash_check():
+def test_null_status_does_not_crash_check() -> None:
     # ``status`` may be explicitly null before the deployment controller
     # populates it; the verifier must treat ready replicas as 0.
     deployment = {"status": None}
@@ -66,7 +69,7 @@ def test_null_status_does_not_crash_check():
     assert "Ready replicas (0) < min replicas (1)" in result.reason
 
 
-def test_subprocess_error_is_reported_in_reason():
+def test_subprocess_error_is_reported_in_reason() -> None:
     with patch(
         "devops_bench.verification.verifiers.scaling_complete.get_resource",
         side_effect=SubprocessError(["kubectl"], returncode=1, stderr="not found"),
@@ -77,7 +80,7 @@ def test_subprocess_error_is_reported_in_reason():
     assert "Failed to get deployment" in result.reason
 
 
-def test_success_when_ready_replicas_within_bounds():
+def test_success_when_ready_replicas_within_bounds() -> None:
     # With both bounds set, a count inside [min, max] succeeds — the scale-down /
     # optimization case where the deployment must shrink to a ceiling.
     deployment = {"status": {"readyReplicas": 2}}
@@ -93,7 +96,7 @@ def test_success_when_ready_replicas_within_bounds():
     assert "within bounds [1, 3]" in result.reason
 
 
-def test_failure_when_ready_replicas_above_maximum():
+def test_failure_when_ready_replicas_above_maximum() -> None:
     deployment = {"status": {"readyReplicas": 5}}
     with patch(
         "devops_bench.verification.verifiers.scaling_complete.get_resource",
@@ -107,7 +110,22 @@ def test_failure_when_ready_replicas_above_maximum():
     assert "Ready replicas (5) > max replicas (3)" in result.reason
 
 
-def test_name_is_echoed_onto_result():
+def test_negative_min_replicas_raises() -> None:
+    with pytest.raises(ValidationError, match="min_replicas must be >= 0"):
+        ScalingCompleteVerifier(deployment="web", min_replicas=-1)
+
+
+def test_negative_max_replicas_raises() -> None:
+    with pytest.raises(ValidationError, match="max_replicas must be >= 0"):
+        ScalingCompleteVerifier(deployment="web", min_replicas=0, max_replicas=-1)
+
+
+def test_min_greater_than_max_raises() -> None:
+    with pytest.raises(ValidationError, match="must be <="):
+        ScalingCompleteVerifier(deployment="web", min_replicas=5, max_replicas=3)
+
+
+def test_name_is_echoed_onto_result() -> None:
     deployment = {"status": {"readyReplicas": 5}}
     with patch(
         "devops_bench.verification.verifiers.scaling_complete.get_resource",


### PR DESCRIPTION
Adds two concrete leaf verifiers registered against the verification registry. PodHealthyVerifier blocks on kubectl wait for matched pods to reach Ready, falling back to checking pod phase directly if the wait fails or times out. ScalingCompleteVerifier polls a deployment ready replica count with exponential backoff until it converges into a [min, max] range, covering both scale-up and scale-down/optimization targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pod health verification that confirms matching pods become ready and falls back to checking their running status when readiness checks fail.
  - Added scaling completion verification for deployments, including minimum and optional maximum replica requirements.
  - Verification results now provide clear success or failure reasons and relevant resource details.

- **Tests**
  - Added coverage for pod readiness, fallback behavior, missing status data, replica limits, and deployment retrieval failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->