### PR TITLE
Add the evaluation harness (base, scenario, and default harness)

### DIFF
--- a/devops_bench/evalharness/__init__.py
+++ b/devops_bench/evalharness/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Orchestration engine: the harness that wires every component into one pipeline."""
+
+from __future__ import annotations
+
+from devops_bench.evalharness.base import Harness
+from devops_bench.evalharness.default import DefaultEvalHarness
+from devops_bench.evalharness.reporter import ResultReporter
+from devops_bench.evalharness.scenario import ScenarioManager
+
+__all__ = ["DefaultEvalHarness", "Harness", "ResultReporter", "ScenarioManager"]

--- a/devops_bench/evalharness/artifacts.py
+++ b/devops_bench/evalharness/artifacts.py
@@ -1,0 +1,100 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Capture files an agent generates by diffing a directory before and after."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+from devops_bench.core import get_logger
+
+__all__ = ["snapshot_dir", "collect_generated_files"]
+
+_log = get_logger("evalharness.artifacts")
+
+
+def snapshot_dir(path: str | os.PathLike[str] = ".") -> set[str]:
+    """Snapshot the immediate entries of a directory.
+
+    Args:
+        path: Directory to list; defaults to the current working directory.
+
+    Returns:
+        The set of entry names directly under ``path``. An empty set is
+        returned when ``path`` does not exist, so the diff stays well-defined
+        when the workspace is created lazily by the agent.
+    """
+    target = os.fspath(path)
+    if not os.path.isdir(target):
+        return set()
+    return set(os.listdir(target))
+
+
+def collect_generated_files(
+    before: set[str],
+    run_dir: str | os.PathLike[str],
+    *,
+    source_dir: str | os.PathLike[str] = ".",
+) -> list[str]:
+    """Copy entries created since ``before`` into the run's artifact directory.
+
+    New files and directories (those present now but absent from ``before``) are
+    copied into ``<run_dir>/generated_files/``. The destination directory is
+    created only when there is at least one new entry to copy.
+
+    Args:
+        before: Entry names captured by :func:`snapshot_dir` prior to the run.
+        run_dir: The run output directory; artifacts land under its
+            ``generated_files`` subdirectory.
+        source_dir: Directory the agent wrote into; defaults to the current
+            working directory. The harness threads its harness-owned, per-run
+            :attr:`~devops_bench.core.RunContext.workspace_path` here — the
+            same directory the CLI agent wrapper executes in — so the
+            artifact diff is bound to the per-task workspace, not the
+            harness process's cwd.
+
+    Returns:
+        The names of the entries that were copied.
+    """
+    after = snapshot_dir(source_dir)
+    new_entries = after - before
+    if not new_entries:
+        return []
+
+    gen_files_dir = Path(run_dir) / "generated_files"
+    gen_files_dir.mkdir(parents=True, exist_ok=True)
+
+    copied: list[str] = []
+    src_root = os.fspath(source_dir)
+    for name in new_entries:
+        src = os.path.join(src_root, name)
+        dst = os.fspath(gen_files_dir / name)
+        # An agent could plant a symlink pointing outside the workspace; following
+        # it would copy host files/credentials into the run artifacts. Skip links
+        # at the top level and preserve (don't follow) any nested ones.
+        if os.path.islink(src):
+            _log.warning("skipping symlinked artifact %s", src)
+            continue
+        if os.path.isdir(src):
+            shutil.copytree(src, dst, dirs_exist_ok=True, symlinks=True)
+            copied.append(name)
+        elif os.path.isfile(src):
+            shutil.copy(src, dst)
+            copied.append(name)
+
+    _log.info("collected %d generated artifact(s) into %s", len(copied), gen_files_dir)
+    return copied

--- a/devops_bench/evalharness/base.py
+++ b/devops_bench/evalharness/base.py
@@ -1,0 +1,82 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Harness interface: the engine that runs the end-to-end evaluation pipeline."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+from devops_bench.core import RunContext
+from devops_bench.tasks import Task
+
+__all__ = ["Harness"]
+
+
+class Harness(ABC):
+    """Abstract engine orchestrating a full benchmark evaluation.
+
+    A harness sits above every component (deployers, agents, chaos, verification,
+    metrics) and threads them together for each task: provision infrastructure,
+    optionally start a background chaos scenario, run the agent under test,
+    collect artifacts, tear down, then score and report. It owns the
+    :class:`~devops_bench.core.RunContext` carried across these phases.
+
+    Concrete harnesses implement :meth:`run` to execute a batch of typed
+    :class:`~devops_bench.tasks.Task` objects; :meth:`make_context` is a helper
+    for building the per-task context.
+    """
+
+    @abstractmethod
+    def run(self, tasks: list[Task]) -> list[dict[str, Any]]:
+        """Run the full pipeline over a batch of typed tasks.
+
+        Args:
+            tasks: The :class:`~devops_bench.tasks.Task` objects to evaluate
+                in order. Each task is provisioned, run, scored, and torn
+                down independently.
+
+        Returns:
+            The detailed per-task result dicts, scored in place, in the
+            ``results.json`` schema produced by routing every typed component
+            result through ``to_dict()``/``to_entry()``.
+        """
+
+    def make_context(
+        self,
+        task: Task,
+        *,
+        cluster: Any | None = None,
+        workspace_path: Path | None = None,
+    ) -> RunContext:
+        """Build the per-task run context carried across pipeline phases.
+
+        Args:
+            task: The task being evaluated.
+            cluster: Provisioned cluster details, if any.
+            workspace_path: Working directory the agent operates in; ``None``
+                lets the caller leave the field unset until it builds a
+                concrete per-run workspace.
+
+        Returns:
+            A :class:`~devops_bench.core.RunContext` seeded with task metadata.
+        """
+        return RunContext(
+            task_id=str(task.id or task.name or ""),
+            task_name=task.name,
+            workspace_path=workspace_path,
+            cluster=cluster,
+        )

--- a/devops_bench/evalharness/default.py
+++ b/devops_bench/evalharness/default.py
@@ -1,0 +1,1090 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DefaultEvalHarness: wires agents, chaos, verification, and metrics into one pipeline."""
+
+from __future__ import annotations
+
+import datetime
+import importlib
+import json
+import shutil
+import tempfile
+import threading
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from devops_bench.agents import AGENTS, AgentConfig, AgentResult
+from devops_bench.agents.capabilities import (
+    AgentRules,
+    AllCapabilities,
+    McpBinding,
+    SkillBinding,
+)
+from devops_bench.chaos import ChaosSpec
+from devops_bench.core import (
+    ConfigError,
+    MissingDependencyError,
+    NotRegisteredError,
+    RunContext,
+    get_bool,
+    get_env,
+    get_logger,
+)
+from devops_bench.deployers.factory import get_deployer
+from devops_bench.evalharness.artifacts import collect_generated_files, snapshot_dir
+from devops_bench.evalharness.base import Harness
+from devops_bench.evalharness.reporter import ResultReporter
+from devops_bench.evalharness.scenario import (
+    VERIFICATION_TIMEOUT_SEC,
+    ScenarioManager,
+    pick_free_port,
+)
+from devops_bench.tasks import Task
+from devops_bench.verification import VerificationSpec
+
+__all__ = ["DefaultEvalHarness"]
+
+_log = get_logger("evalharness.default")
+
+# Builtin agent modules imported at call time so their ``@AGENTS.register``
+# decorators run. External packages add agents by registering with the same
+# registry, with no edit here.
+_BUILTIN_AGENT_MODULES: tuple[str, ...] = (
+    "devops_bench.agents.cli.gemini_cli",
+    "devops_bench.agents.cli.openclaw",
+    "devops_bench.agents.cli.antigravity",
+    "devops_bench.agents.api.agent",
+)
+
+# Aliases normalized to canonical agent keys before registry lookup.
+_AGENT_TYPE_ALIASES: dict[str, str] = {
+    "gemini-cli": "gemini",
+}
+
+# Default agent type when neither --agent-type nor BENCH_AGENT_TYPE is set.
+_DEFAULT_AGENT_TYPE = "gemini-cli"
+
+# Default target deployment + namespace used both for placeholder
+# substitution in the agent prompt and as the chaos port-forward target, so the
+# operator agent and the chaos injector address the same workload when env is
+# unset.
+_DEFAULT_TARGET_DEPLOYMENT = "hypercomputer-d1-frontend"
+_DEFAULT_NAMESPACE = "default"
+
+# How long to wait for the chaos agent to establish its load spike before
+# starting the operator agent.
+_CHAOS_ACTIVE_WAIT_SEC = 45
+
+# Budget for draining the scenario thread. Kept above the verification budget
+# so a slow-but-completing verification is not cut off, which would otherwise
+# yield partial reports and race teardown.
+_SCENARIO_JOIN_SEC = VERIFICATION_TIMEOUT_SEC + 60
+
+
+def _ensure_builtin_agents_registered() -> None:
+    """Import the builtin agent modules so their registrations fire.
+
+    The registry is the only source of truth — this function exists so the
+    harness can resolve canonical keys at call time without naming any module
+    path in ``AGENTS.get``. Re-imports are no-ops thanks to ``sys.modules``.
+
+    Catches **only** missing-dependency / import errors (an agent module may
+    pull an optional SDK like ``anthropic`` that is absent on the host) — a
+    real bug in an agent module (``SyntaxError``, an ``AttributeError`` at
+    module top) re-raises so it cannot hide behind a silent ``debug`` log.
+    """
+    for module in _BUILTIN_AGENT_MODULES:
+        try:
+            importlib.import_module(module)
+        except (ImportError, MissingDependencyError) as exc:
+            # Optional SDK absent on this host. ``AGENTS.get`` will still
+            # raise a clear ``NotRegisteredError`` later if the user selects
+            # an agent whose module did not load.
+            _log.debug("optional agent module %s not importable: %s", module, exc)
+
+
+class DefaultEvalHarness(Harness):
+    """Standard harness wiring every component into one pipeline.
+
+    Each task flows through provisioning, optional background chaos, agent
+    execution, artifact collection, teardown, and batch scoring. Every layer
+    is consumed through its typed contract: ``Task`` in, ``AgentResult`` from
+    the agent, ``ChaosResult`` / ``VerificationResult`` from the scenario,
+    ``MetricScore`` from each metric. The harness routes those typed values
+    through ``to_dict()`` / ``to_entry()`` / ``model_dump()`` so the on-disk
+    ``results.json`` schema stays byte-stable.
+
+    Args:
+        project_id: Default GCP project ID for provisioning and placeholders.
+        cluster_name: Default cluster name for provisioning and placeholders.
+        judge_model: A ``DeepEvalBaseLLM`` judge used for scoring; when ``None``
+            one is built from ``JUDGE_PROVIDER`` / ``JUDGE_MODEL`` on first use.
+        results_root: Directory under which timestamped run dirs are created.
+        reporter: Optional explicit result reporter. A default
+            :class:`ResultReporter` rooted at ``results_root`` is built when
+            omitted.
+        default_target_deployment: Fallback deployment name used both for
+            placeholder substitution and as the chaos port-forward target when
+            ``TARGET_DEPLOYMENT_NAME`` is unset.
+        default_namespace: Fallback namespace used for the same two purposes
+            when ``NAMESPACE`` is unset.
+    """
+
+    def __init__(
+        self,
+        project_id: str,
+        cluster_name: str,
+        judge_model: Any | None = None,
+        results_root: str = "results",
+        *,
+        reporter: ResultReporter | None = None,
+        default_target_deployment: str = _DEFAULT_TARGET_DEPLOYMENT,
+        default_namespace: str = _DEFAULT_NAMESPACE,
+        agent_type: str | None = None,
+        no_infra: bool | None = None,
+        no_teardown: bool | None = None,
+    ) -> None:
+        self.project_id = project_id
+        self.cluster_name = cluster_name
+        self._judge_model = judge_model
+        self.results_root = results_root
+        resolved_agent_type = (
+            agent_type
+            if agent_type is not None
+            else get_env("BENCH_AGENT_TYPE", _DEFAULT_AGENT_TYPE)
+        )
+        self.agent_type = (resolved_agent_type or _DEFAULT_AGENT_TYPE).lower()
+        self.no_infra = no_infra if no_infra is not None else get_bool("BENCH_NO_INFRA")
+        self.no_teardown = no_teardown if no_teardown is not None else get_bool("BENCH_NO_TEARDOWN")
+        # Resolved once so capabilities and scoring observe the same value.
+        self.use_mcp: bool = get_bool("BENCH_USE_MCP", True)
+        # When running concurrently with other benchmark processes, allocate a
+        # free local port for the chaos port-forward instead of the fixed
+        # default so two scenarios on one host do not contend for the same port.
+        self.parallel: bool = get_bool("BENCH_PARALLEL", False)
+        # Build the gated :class:`AgentConfig` once and hold the snapshot for
+        # the lifetime of this harness, so every agent run and every record's
+        # ``capabilities_granted`` field reads the same object.
+        self._agent_config: AgentConfig = self._build_agent_config_snapshot()
+        self.default_target_deployment = default_target_deployment
+        self.default_namespace = default_namespace
+        # Resolve the run-level placeholder inputs once into instance
+        # attributes that ``replace_placeholders`` / ``start_scenario`` read.
+        self.app_location = get_env("APP_LOCATION", "") or ""
+        self.target_deployment = (
+            get_env("TARGET_DEPLOYMENT_NAME", self.default_target_deployment)
+            or self.default_target_deployment
+        )
+        self.namespace = get_env("NAMESPACE", self.default_namespace) or self.default_namespace
+        self.reporter = reporter or ResultReporter(results_root)
+
+    @property
+    def _granted_skill_paths(self) -> tuple[str, ...]:
+        """Skill paths the harness granted, derived from the config snapshot.
+
+        Single source of truth: the same tuple lives on
+        ``self._agent_config.capabilities.skills.paths`` and is read by every
+        agent the harness constructs. Keeping it as a derived property (not a
+        second copy) makes it structurally impossible for the recorded
+        ``skills`` to disagree with what the agent saw.
+        """
+        return self._agent_config.capabilities.skills.paths
+
+    # -- agent resolution (model/provider-agnostic) -----------------------
+
+    def resolve_agent(self, agent_type: str) -> Any:
+        """Resolve and instantiate the agent under test from the registry.
+
+        The builtin agent modules are imported once so their
+        ``@AGENTS.register`` decorators run, the alias is normalized to the
+        canonical key, and the class is fetched from
+        :data:`~devops_bench.agents.AGENTS`. An externally-registered agent
+        resolves the same way with no harness edit.
+
+        Args:
+            agent_type: Configured agent type (e.g. ``gemini-cli`` / ``api`` /
+                ``gemini`` / ``openclaw``).
+
+        Returns:
+            An instantiated agent harness. The instance is built with the
+            harness-resolved :class:`AgentConfig` so capabilities (MCP / skills /
+            rules) reflect the orchestrator's catalog × run-arm decision.
+
+        Raises:
+            NotRegisteredError: If no agent is registered under the resolved
+                canonical key.
+        """
+        _ensure_builtin_agents_registered()
+        key = _AGENT_TYPE_ALIASES.get(agent_type, agent_type)
+        agent_cls = AGENTS.get(key)
+        if agent_cls is None:
+            raise NotRegisteredError(AGENTS.name, key, AGENTS.keys())
+        return agent_cls(self.build_agent_config())
+
+    # -- agent config + capabilities (explicit; no env detour) ------------
+
+    def build_agent_config(self) -> AgentConfig:
+        """Return the harness's snapshotted :class:`AgentConfig`.
+
+        The config is built once in :meth:`__init__` and reused for every agent
+        run plus every record's ``capabilities_granted`` field.
+
+        Returns:
+            The :class:`AgentConfig` snapshot. The same object is handed to
+            every agent the harness constructs.
+        """
+        return self._agent_config
+
+    def _build_agent_config_snapshot(self) -> AgentConfig:
+        """Build the gated :class:`AgentConfig` from the env layer.
+
+        Called exactly once, from :meth:`__init__`. Starts from
+        :meth:`AgentConfig.from_env` so existing ``AGENT_*`` knobs continue
+        to flow through (``model``, ``provider``, ``api_key``, ``target``,
+        ``timeout``, ``max_turns``, ``extra_env``), then replaces
+        capabilities with the orchestrator-owned aggregate so the agent
+        cannot see a granted MCP binding when ``use_mcp`` is False.
+        """
+        base = AgentConfig.from_env()
+        capabilities = self._gate_capabilities(base.capabilities, self.use_mcp)
+        return AgentConfig(
+            model=base.model,
+            provider=base.provider,
+            api_key=base.api_key,
+            target=base.target,
+            timeout_sec=base.timeout_sec,
+            max_turns=base.max_turns,
+            capabilities=capabilities,
+            extra_env=base.extra_env,
+        )
+
+    @staticmethod
+    def _gate_capabilities(env_caps: AllCapabilities, use_mcp: bool) -> AllCapabilities:
+        """Apply the harness's ``use_mcp`` gate to an env-derived capability set.
+
+        Skills and rules are independent of MCP and pass through unchanged;
+        only the MCP binding is dropped when ``use_mcp`` is False. The
+        returned aggregate is always a fresh frozen dataclass so the caller
+        does not mutate the input.
+
+        Args:
+            env_caps: Capabilities derived from the ``AGENT_*`` env layer.
+            use_mcp: Whether the orchestrator granted MCP for this run.
+
+        Returns:
+            The gated :class:`AllCapabilities` to attach to the next
+            :class:`AgentConfig`.
+        """
+        if use_mcp:
+            mcp_servers: tuple[McpBinding, ...] = env_caps.mcp_servers
+        else:
+            # MCP gated off: drop the binding so the agent's tools-enabled gate
+            # is False and metrics' ``use_mcp`` agrees with what ran.
+            mcp_servers = ()
+
+        return AllCapabilities(
+            mcp_servers=mcp_servers,
+            skills=env_caps.skills if env_caps.skills.paths else SkillBinding(),
+            rules=env_caps.rules if env_caps.rules.text else AgentRules(),
+        )
+
+    def _resolve_deployment_and_namespace(self, task: Task | None = None) -> tuple[str, str]:
+        """Resolve the target deployment name and namespace.
+
+        Precedence: env var → task variables → harness default.
+        """
+        infra_vars = {}
+        if task and task.infrastructure:
+            infra_vars = task.infrastructure.get("variables") or {}
+
+        target_dep = (
+            get_env("TARGET_DEPLOYMENT_NAME", "")
+            or infra_vars.get("target_deployment_name", "")
+            or self.target_deployment
+        )
+        ns = get_env("NAMESPACE", "") or infra_vars.get("namespace", "") or self.namespace
+        return (
+            str(target_dep) if target_dep is not None else "",
+            str(ns) if ns is not None else "",
+        )
+
+    # -- placeholder substitution -----------------------------------------
+
+    def replace_placeholders(
+        self,
+        text: str,
+        cluster_name: str,
+        target_deployment: str | None = None,
+        namespace: str | None = None,
+    ) -> str:
+        """Substitute infrastructure placeholders in a prompt or expectation.
+
+        ``TARGET_DEPLOYMENT_NAME`` and ``NAMESPACE`` form the integration
+        contract supplied by the provisioning layer after cluster bring-up;
+        their fallbacks come from the constructor's
+        :attr:`default_target_deployment` / :attr:`default_namespace`.
+
+        Args:
+            text: Text containing ``{{...}}`` placeholders.
+            cluster_name: Active cluster name to substitute.
+            target_deployment: Optional target deployment name override.
+            namespace: Optional namespace override.
+
+        Returns:
+            The text with all known placeholders replaced.
+        """
+        target_dep = target_deployment or self.target_deployment
+        ns = namespace or self.namespace
+        return (
+            text.replace("{{PROJECT_ID}}", self.project_id)
+            .replace("{{GCP_PROJECT_ID}}", self.project_id)
+            .replace("{{CLUSTER_NAME}}", cluster_name)
+            .replace("{{GKE_CLUSTER_NAME}}", cluster_name)
+            .replace("{{APP_LOCATION}}", self.app_location)
+            .replace("{{TARGET_DEPLOYMENT_NAME}}", target_dep)
+            .replace("{{NAMESPACE}}", ns)
+        )
+
+    def _resolve_spec_placeholders(
+        self,
+        spec: Any,
+        cluster_name: str,
+        target_deployment: str | None = None,
+        namespace: str | None = None,
+    ) -> Any:
+        """Walk a nested spec and substitute placeholders in every string leaf.
+
+        Args:
+            spec: An opaque chaos / verification spec value (mapping, list,
+                scalar, or ``None``).
+            cluster_name: Active cluster name passed through to
+                :meth:`replace_placeholders`.
+            target_deployment: Optional target deployment name override.
+            namespace: Optional namespace override.
+
+        Returns:
+            A new structure with placeholders resolved. ``None`` round-trips
+            unchanged so a missing spec stays missing.
+        """
+        if spec is None:
+            return None
+        if isinstance(spec, str):
+            return self.replace_placeholders(spec, cluster_name, target_deployment, namespace)
+        if isinstance(spec, list):
+            return [
+                self._resolve_spec_placeholders(item, cluster_name, target_deployment, namespace)
+                for item in spec
+            ]
+        if isinstance(spec, dict):
+            return {
+                key: self._resolve_spec_placeholders(
+                    value, cluster_name, target_deployment, namespace
+                )
+                for key, value in spec.items()
+            }
+        return spec
+
+    # -- spec parsing (typed contracts at every seam) ---------------------
+
+    def _parse_chaos_specs(
+        self,
+        raw: Any,
+        cluster_name: str,
+        target_deployment: str | None = None,
+        namespace: str | None = None,
+    ) -> list[ChaosSpec]:
+        """Parse the raw task ``chaos_spec`` blob into typed :class:`ChaosSpec` list.
+
+        Accepts either a JSON-in-YAML string or a native-YAML list. Each entry
+        is placeholder-substituted, then validated through :class:`ChaosSpec`.
+        """
+        if not raw:
+            return []
+        resolved = self._resolve_spec_placeholders(raw, cluster_name, target_deployment, namespace)
+        # A placeholder-substituted JSON string round-trips through
+        # ``json.loads`` to a list/dict the discriminated union can validate.
+        if isinstance(resolved, str):
+            try:
+                resolved = json.loads(resolved)
+            except json.JSONDecodeError as exc:
+                # A task that declares chaos but whose spec fails to parse must
+                # fail loudly: silently dropping it would run the eval without the
+                # intended disruption and score a quietly-invalid result.
+                raise ConfigError(f"could not parse chaos_spec JSON string: {exc}") from exc
+        entries = resolved if isinstance(resolved, list) else [resolved]
+        return [ChaosSpec.model_validate(entry) for entry in entries if entry]
+
+    def _build_verification_mapping(
+        self,
+        raw: Any,
+        cluster_name: str,
+        target_deployment: str | None = None,
+        namespace: str | None = None,
+    ) -> tuple[dict[str, Any], list[dict[str, str]]]:
+        """Build a name-keyed verification mapping the chaos seam consumes.
+
+        Canonical authoring shape is a list of wrapped entries::
+
+            verification_spec:
+              - name: "Planned Load Spike Verification"
+                spec:
+                  type: parallel
+                  checks: [...]
+
+        ``name`` is the cross-reference key the chaos ``verify:`` field
+        resolves against; ``spec`` carries the typed verification node. When no
+        ``spec`` key is present the entry mapping itself is accepted as the
+        node. Every authoring failure is **surfaced** — both warn-logged and
+        accumulated into the returned ``errors`` list so the harness can
+        record it on the run result, instead of silently dropping a
+        verification (which would make a typo'd cross-reference invisible to
+        the operator).
+
+        Args:
+            raw: The task's ``verification_spec`` blob.
+            cluster_name: Active cluster name for placeholder substitution.
+            target_deployment: Optional target deployment name override.
+            namespace: Optional namespace override.
+
+        Returns:
+            A pair ``(mapping, errors)``:
+
+            * ``mapping`` — ``{name -> parsed VerificationSpec}``.
+            * ``errors`` — one ``{"name", "reason"}`` entry per authoring
+              failure (a non-mapping entry, a missing ``name``, a JSON
+              parse failure on a string blob, or a ``VerificationSpec``
+              validation failure). Empty when every entry parsed.
+        """
+        if not raw:
+            return {}, []
+
+        errors: list[dict[str, str]] = []
+        resolved = self._resolve_spec_placeholders(raw, cluster_name, target_deployment, namespace)
+        if isinstance(resolved, str):
+            try:
+                resolved = json.loads(resolved)
+            except json.JSONDecodeError as exc:
+                _log.warning("could not parse verification_spec JSON string: %s", exc)
+                errors.append({"name": "<root>", "reason": f"json parse: {exc}"})
+                return {}, errors
+        entries = resolved if isinstance(resolved, list) else [resolved]
+
+        mapping: dict[str, Any] = {}
+        for index, entry in enumerate(entries):
+            if not isinstance(entry, dict):
+                msg = (
+                    f"verification_spec entry [{index}] must be a mapping, "
+                    f"got {type(entry).__name__}"
+                )
+                _log.warning(msg)
+                errors.append({"name": f"<index {index}>", "reason": msg})
+                continue
+            name = entry.get("name")
+            if not name:
+                msg = f"verification_spec entry [{index}] missing required ``name`` key"
+                _log.warning(msg)
+                errors.append({"name": f"<index {index}>", "reason": msg})
+                continue
+            if name in mapping:
+                msg = (
+                    f"verification_spec entry [{index}] has a duplicate name {name!r}; "
+                    "names must be unique so a chaos ``verify`` reference is unambiguous"
+                )
+                _log.warning(msg)
+                errors.append({"name": str(name), "reason": msg})
+                continue
+            # Canonical shape ``{name, spec: <typed-node>}``; an entry without
+            # a ``spec`` key is itself treated as the typed node.
+            node = entry.get("spec") if "spec" in entry else entry
+            try:
+                mapping[name] = VerificationSpec(node)
+            except Exception as exc:  # noqa: BLE001 - surface every failure
+                _log.warning(
+                    "verification entry %r failed to validate; skipping: %s",
+                    name,
+                    exc,
+                )
+                errors.append({"name": str(name), "reason": str(exc)})
+        return mapping, errors
+
+    # -- scenario (background chaos) --------------------------------------
+
+    def start_scenario(
+        self,
+        chaos_specs: list[ChaosSpec],
+        verification_mapping: dict[str, Any],
+        ctx: RunContext,
+        target_deployment: str | None = None,
+        namespace: str | None = None,
+        *,
+        skip_port_forward: bool = False,
+    ) -> tuple[ScenarioManager, threading.Thread] | None:
+        """Start a background chaos+verification scenario on a daemon thread.
+
+        Args:
+            chaos_specs: Typed chaos entries. Only the first spec is driven.
+            verification_mapping: Name-keyed mapping of typed verification
+                specs the chaos ``verify:`` key is resolved against.
+            ctx: Per-task run context handed to triggers / faults.
+            target_deployment: Optional resolved target deployment name.
+            namespace: Optional resolved namespace.
+            skip_port_forward: When True, do not open ``kubectl port-forward``;
+                used by the E2E smoke harness when running against the
+                :class:`~devops_bench.deployers.NoOpDeployer`.
+
+        Returns:
+            A ``(scenario_manager, thread)`` pair, or ``None`` when no chaos
+            specs were provided.
+        """
+        if not chaos_specs:
+            return None
+
+        # Only the first spec is scheduled today; the field is a list to leave
+        # room for multiple planned disruptions. Warn rather than silently drop
+        # the rest so a task authored with several is not quietly under-run.
+        if len(chaos_specs) > 1:
+            _log.warning(
+                "chaos_spec declares %d entries but only the first is scheduled; "
+                "the remaining %d are ignored",
+                len(chaos_specs),
+                len(chaos_specs) - 1,
+            )
+
+        spec = chaos_specs[0]
+        local_port = pick_free_port() if self.parallel else None
+        target_dep = target_deployment or self.target_deployment
+        ns = namespace or self.namespace
+        scenario_manager = ScenarioManager(
+            target_dep,
+            ns,
+            verification_mapping=verification_mapping,
+            skip_port_forward=skip_port_forward,
+            local_port=local_port,
+        )
+        thread = threading.Thread(
+            target=scenario_manager.run_chaos_and_verification,
+            args=(spec, ctx),
+            daemon=True,
+        )
+        thread.start()
+        return scenario_manager, thread
+
+    # -- agent execution --------------------------------------------------
+
+    def execute_agent(self, prompt: str, ctx: RunContext) -> AgentResult:
+        """Run the configured agent against ``prompt`` through the registry.
+
+        Args:
+            prompt: The (placeholder-resolved) task prompt.
+            ctx: The per-task run context. ``ctx.workspace_path`` is handed to
+                the agent so a CLI wrapper executes in the harness-owned
+                workspace instead of a throwaway directory the harness never
+                inspects.
+
+        Returns:
+            The typed :class:`AgentResult` the agent emitted.
+        """
+        agent = self.resolve_agent(self.agent_type)
+        return agent.run(prompt, workspace_path=ctx.workspace_path)
+
+    # -- pipeline ---------------------------------------------------------
+
+    def run(self, tasks: list[Task]) -> list[dict[str, Any]]:
+        """Run the full pipeline over ``tasks`` and return scored results.
+
+        Args:
+            tasks: Typed :class:`Task` objects produced by
+                :func:`~devops_bench.tasks.load_tasks`.
+
+        Returns:
+            The detailed per-task result dicts, scored in place, in the
+            ``results.json`` schema.
+        """
+        run_dir = self.reporter.new_run_dir()
+        detailed_results: list[dict[str, Any]] = [self._run_one(task, run_dir) for task in tasks]
+
+        # Persist raw execution outputs before the (slower) scoring pass.
+        self.reporter.write(run_dir, detailed_results)
+        _log.info("execution complete; results saved to %s/results.json", run_dir)
+
+        # Scoring is best-effort: a judge/config failure (e.g. get_judge_model()
+        # or an unexpected error in a metric) must not sink an otherwise
+        # successful execution pass, whose raw results are already on disk above.
+        try:
+            self._score(detailed_results)
+            self.reporter.write(run_dir, detailed_results)
+            _log.info(
+                "post-processing evaluation complete; updated results saved to %s/results.json",
+                run_dir,
+            )
+        except Exception:  # noqa: BLE001 - execution results must survive scoring errors
+            _log.exception("scoring failed; returning unscored execution results from %s", run_dir)
+
+        # Emit the flattened, ingest-ready rows + run manifest. Best-effort: the
+        # detailed results.json is already on disk, so a failure here must not
+        # sink the run.
+        try:
+            self._write_run_artifacts(run_dir, detailed_results)
+        except Exception:  # noqa: BLE001 - rows/manifest are derived, never load-bearing
+            _log.exception("failed to write rows.json/manifest.json for %s", run_dir)
+        return detailed_results
+
+    def _write_run_artifacts(self, run_dir: Path, detailed_results: list[dict[str, Any]]) -> None:
+        """Flatten ``detailed_results`` into ``rows.json`` + ``manifest.json``.
+
+        Assembles the run-level :class:`~devops_bench.results.Manifest` from the
+        harness's resolved model / harness key / capabilities, flattens every
+        record through :func:`~devops_bench.results.build_rows`, and writes both
+        artifacts via the reporter.
+
+        Args:
+            run_dir: The run directory the artifacts are written under.
+            detailed_results: The scored per-task records.
+        """
+        from devops_bench.results import (
+            SCHEMA_VERSION,
+            Manifest,
+            build_rows,
+            derive_augmentation,
+        )
+        from devops_bench.results import setup_id as results_setup_id
+
+        augmentation = derive_augmentation(
+            {"use_mcp": self.use_mcp, "skills": list(self._granted_skill_paths)}
+        )
+        model = self._agent_config.model or self._agent_config.provider or self.agent_type
+        manifest = Manifest(
+            schema_version=SCHEMA_VERSION,
+            run_id=run_dir.name,
+            t=datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            setup_id=results_setup_id(model, self.agent_type, augmentation),
+            model=model,
+            harness=self.agent_type,
+            augmentation=augmentation,
+        )
+        rows = build_rows(detailed_results, manifest)
+        self.reporter.write_rows(run_dir, [row.to_dict() for row in rows])
+        self.reporter.write_manifest(run_dir, manifest.to_dict())
+
+    def _run_one(self, task: Task, run_dir: Path) -> dict[str, Any]:
+        """Provision, run the agent, collect artifacts, tear down for one task.
+
+        Args:
+            task: The typed task being evaluated.
+            run_dir: The run output directory for generated artifacts.
+
+        Returns:
+            The detailed result dict. On any failure a ``status: "failed"``
+            record is returned instead of being dropped, so failures stay
+            visible to downstream parsers. Success and failed records carry
+            the same top-level key set so a parser can iterate either shape
+            without a ``KeyError``.
+        """
+        infra_config = task.infrastructure or {}
+        if self.no_infra:
+            # no_infra is implemented by forcing the noop deployer.
+            infra_config = {**infra_config, "deployer": "noop"}
+        deployer: Any | None = None
+        scenario_manager: ScenarioManager | None = None
+        scenario_thread: threading.Thread | None = None
+        result: dict[str, Any] | None = None
+        workspace_path: Path | None = None
+        verification_parse_errors: list[dict[str, str]] = []
+        # Track the substituted prompt / expectation as they are computed so a
+        # failed record can carry the same resolved strings a success record
+        # would, falling back to the raw task fields before substitution.
+        prompt: str | None = None
+        expected_output: str | None = None
+
+        try:
+            # Build the deployer inside the try so a factory failure (e.g. an
+            # unknown deployer type) becomes a failed record for this task
+            # rather than crashing the whole batch.
+            deployer = get_deployer(infra_config, self.project_id, self.cluster_name)
+            _log.info("provisioning infrastructure for: %s", task.name)
+            deployer.up()
+            cluster_info = deployer.get_cluster_info()
+            active_cluster_name = cluster_info.name or self.cluster_name
+            # Own a real per-run workspace so the artifact diff is rooted at
+            # the directory the agent actually writes to (its CLI wrapper's
+            # working directory), not the harness process's launch cwd.
+            workspace_path = Path(tempfile.mkdtemp(prefix="devops-bench-workspace-"))
+            context = self.make_context(task, cluster=cluster_info, workspace_path=workspace_path)
+
+            target_dep, ns = self._resolve_deployment_and_namespace(task)
+
+            prompt = self.replace_placeholders(task.prompt, active_cluster_name, target_dep, ns)
+
+            chaos_specs = self._parse_chaos_specs(
+                task.chaos_spec, active_cluster_name, target_dep, ns
+            )
+            verification_mapping, verification_parse_errors = self._build_verification_mapping(
+                task.verification_spec, active_cluster_name, target_dep, ns
+            )
+
+            # Hand the background scenario its own context with an isolated
+            # env dict so its in-thread env mutations never touch the context
+            # the agent runs against.
+            scenario = self.start_scenario(
+                chaos_specs,
+                verification_mapping,
+                replace(context, env=dict(context.env)),
+                target_deployment=target_dep,
+                namespace=ns,
+            )
+            if scenario is not None:
+                scenario_manager, scenario_thread = scenario
+                _log.info("waiting for chaos agent to establish the cluster load spike...")
+                chaos_active = scenario_manager.chaos_active_event.wait(
+                    timeout=_CHAOS_ACTIVE_WAIT_SEC
+                )
+                if chaos_active:
+                    _log.info("cluster load spike active; proceeding with operator agent...")
+                else:
+                    # The event is also set when injection fails (to unblock us), so
+                    # a False here means it never signalled within the budget. The
+                    # agent still runs, but flag it: the run may not reflect the
+                    # intended disruption. The drained chaos_report carries the detail.
+                    _log.warning(
+                        "chaos did not signal active within %ss; proceeding, but the "
+                        "run may not reflect the intended disruption",
+                        _CHAOS_ACTIVE_WAIT_SEC,
+                    )
+
+            _log.info("executing agent for prompt: %s", prompt)
+            before_files = snapshot_dir(workspace_path)
+            agent_res = self.execute_agent(prompt, context)
+            # NOTE/TODO: This collects ALL frontmatter from bootstrapping, not just generated files.
+            # Consider a more targeted filter in a future iteration.
+            # Best-effort: a collection failure (I/O, permissions, a bad link in the
+            # workspace) must not turn an already-completed agent run into a failed,
+            # unscored record, so isolate it like the other non-critical steps.
+            try:
+                collect_generated_files(before_files, run_dir, source_dir=workspace_path)
+            except Exception:  # noqa: BLE001 - artifact collection must not sink a completed run
+                _log.exception("artifact collection failed for %s; continuing", task.name)
+
+            expected_output = self.replace_placeholders(
+                task.expected_output, active_cluster_name, target_dep, ns
+            )
+
+            chaos_report, perf_report = self._drain_scenario(scenario_manager, scenario_thread)
+
+            result = self._build_success_record(
+                task=task,
+                prompt=prompt,
+                expected_output=expected_output,
+                agent_res=agent_res,
+                chaos_report=chaos_report,
+                perf_report=perf_report,
+                verification_parse_errors=verification_parse_errors,
+            )
+            _log.info("agent response for %s:\n%s", task.name, result["output"])
+        except Exception as exc:  # noqa: BLE001 - surface every task failure
+            _log.error("critical error during task %s: %s", task.name, exc)
+            result = self._build_failed_record(
+                task,
+                exc,
+                prompt=prompt,
+                expected_output=expected_output,
+                verification_parse_errors=verification_parse_errors,
+            )
+        finally:
+            if scenario_manager is not None:
+                scenario_manager.stop()
+                # stop() only signals the abort flag; join the daemon thread with
+                # a bounded timeout so teardown does not race a still-running
+                # background scenario (the success path joins via _drain_scenario,
+                # but the exception path reaches here without draining).
+                if scenario_thread is not None:
+                    scenario_thread.join(timeout=_SCENARIO_JOIN_SEC)
+            if deployer is not None:
+                self._teardown(deployer, infra_config, task.name)
+            if workspace_path is not None:
+                shutil.rmtree(workspace_path, ignore_errors=True)
+
+        return result
+
+    #: Top-level keys present on **every** record (success and failed alike).
+    #: Exposed so downstream parsers / tests can pin the symmetric schema
+    #: without reproducing the literal in every spot.
+    _RECORD_KEYS: frozenset[str] = frozenset(
+        {
+            "input",
+            "output",
+            "latency",
+            "tokens",
+            "tools",
+            "trajectory",
+            "skills",
+            "name",
+            "folder",
+            "status",
+            "error",
+            "errors",
+            "scores",
+            "expected_output",
+            "expected_output_raw",
+            "retrieval_context",
+            "chaos_spec",
+            "verification_spec",
+            "chaos_report",
+            "perf_report",
+            "documentation",
+            "capabilities_granted",
+            "verification_parse_errors",
+            "generation_only",
+            "validated",
+        }
+    )
+
+    def _build_success_record(
+        self,
+        *,
+        task: Task,
+        prompt: str,
+        expected_output: str,
+        agent_res: AgentResult,
+        chaos_report: dict[str, Any],
+        perf_report: dict[str, Any],
+        verification_parse_errors: list[dict[str, str]] | None = None,
+    ) -> dict[str, Any]:
+        """Shape a typed :class:`AgentResult` + reports into the on-disk schema.
+
+        Routes every typed value through ``to_dict()`` / ``model_dump()`` and
+        emits the **symmetric** key union (every key in :attr:`_RECORD_KEYS`
+        is present on every record), so success and failed records never differ
+        in top-level shape — a downstream parser iterating one shape can never
+        ``KeyError`` crossing into the other.
+
+        Capability metadata (``capabilities_granted``) is recorded so metrics
+        / downstream consumers can read what the agent was actually granted
+        rather than re-reading ``BENCH_USE_MCP``.
+        """
+        dumped = agent_res.to_dict()
+        agent_errors = list(dumped.get("errors") or [])
+        record = self._empty_record(task)
+        record.update(
+            {
+                "input": prompt,
+                "output": dumped.get("output", ""),
+                "latency": dumped.get("latency", 0.0),
+                "tokens": dumped.get("tokens", {}),
+                # Expose a flat ``tools`` key alongside the typed trajectory
+                # for consumers that only sample tool names; the trajectory is
+                # the source of truth.
+                "tools": [
+                    entry.get("name") for entry in dumped.get("trajectory", []) if entry.get("name")
+                ],
+                "trajectory": dumped.get("trajectory", []),
+                "status": "success",
+                # Run-level validity gate: a vetted task only promotes to the
+                # leaderboard when this run actually produced a usable result.
+                # ``AgentResult.errored()`` (429 / SDK fault / agent timeout)
+                # yields populated ``errors`` + an empty trajectory while the
+                # record still reads ``status:"success"``, so gating on the task
+                # flag alone would let an empty/errored run pass as a genuine low
+                # score. Require no agent error *and* a non-empty trajectory.
+                "validated": (
+                    task.validated and not agent_errors and bool(dumped.get("trajectory"))
+                ),
+                "errors": agent_errors,
+                # First-error scalar so a parser reading ``error`` finds the
+                # same key on the success shape (None when nothing went wrong).
+                "error": agent_errors[0] if agent_errors else None,
+                "expected_output": expected_output,
+                "chaos_report": chaos_report,
+                "perf_report": perf_report,
+                "verification_parse_errors": list(verification_parse_errors or []),
+            }
+        )
+        return record
+
+    def _build_failed_record(
+        self,
+        task: Task,
+        exc: Exception,
+        *,
+        prompt: str | None = None,
+        expected_output: str | None = None,
+        verification_parse_errors: list[dict[str, str]] | None = None,
+    ) -> dict[str, Any]:
+        """Build a failed-task record so the failure stays visible.
+
+        Emits the **same** top-level key set as :meth:`_build_success_record`
+        (pinned in :attr:`_RECORD_KEYS`): a downstream parser iterating either
+        shape never trips a ``KeyError`` crossing between them. The differences
+        are values only — ``status=\"failed\"``, ``error`` carries the
+        exception text, ``scores`` stays empty.
+
+        Args:
+            task: The task that failed.
+            exc: The exception that aborted the run.
+            prompt: The placeholder-substituted prompt if it was computed before
+                the failure; falls back to the raw ``task.prompt`` otherwise, so
+                the record matches the success shape when substitution had run.
+            expected_output: The substituted expectation if computed; falls back
+                to the raw ``task.expected_output``.
+            verification_parse_errors: Any spec-parse errors collected so far.
+        """
+        error_text = str(exc)
+        record = self._empty_record(task)
+        record.update(
+            {
+                "input": prompt if prompt is not None else task.prompt,
+                "expected_output": (
+                    expected_output if expected_output is not None else task.expected_output
+                ),
+                "status": "failed",
+                "error": error_text,
+                "errors": [error_text],
+                # A failed run never promotes, even on a vetted task.
+                "validated": False,
+                "verification_parse_errors": list(verification_parse_errors or []),
+            }
+        )
+        return record
+
+    def _empty_record(self, task: Task) -> dict[str, Any]:
+        """Seed every record with the symmetric key set.
+
+        Centralizes the default values for the keys that match across
+        success/failed records (task identifying fields, opaque blobs, empty
+        containers for ``scores`` / ``tools`` / ``trajectory`` etc.). Both
+        builder methods overlay the differing keys on top of this seed; the
+        seed itself never contains a ``status`` value so the caller must set
+        it explicitly.
+        """
+        return {
+            "input": task.prompt,
+            "output": "",
+            "latency": 0.0,
+            "tokens": {},
+            "tools": [],
+            "trajectory": [],
+            "skills": list(self._granted_skill_paths),
+            "name": task.name,
+            "folder": task.folder,
+            "status": "",
+            "error": None,
+            "errors": [],
+            # ``scores`` (the per-metric mapping) is populated by ``_score`` for
+            # success records; failed records leave it as the empty dict so the
+            # key is always present. There is no aggregate scalar score: the
+            # per-metric map is the source of truth.
+            "scores": {},
+            "expected_output": "",
+            "expected_output_raw": task.expected_output,
+            "retrieval_context": list(task.retrieval_context),
+            "chaos_spec": task.chaos_spec,
+            "verification_spec": task.verification_spec,
+            "chaos_report": {},
+            "perf_report": {},
+            "documentation": [doc.model_dump() for doc in task.documentation],
+            "capabilities_granted": {
+                "use_mcp": self.use_mcp,
+                "skills": list(self._granted_skill_paths),
+            },
+            "verification_parse_errors": [],
+            # Generation-only tasks have no cluster, so the OutcomeValidity judge
+            # must not penalize them for "not applying". This holds both when the
+            # task declares ``deployer: noop`` and when ``BENCH_NO_INFRA`` skips
+            # provisioning for the whole run (mirrors get_deployer's own gate).
+            "generation_only": self.no_infra
+            or (task.infrastructure or {}).get("deployer") == "noop",
+            # Only tasks vetted as correct promote to the leaderboard; downstream
+            # ingest gates inclusion on this flag (default False until vetted).
+            "validated": task.validated,
+        }
+
+    def _drain_scenario(
+        self,
+        scenario_manager: ScenarioManager | None,
+        scenario_thread: threading.Thread | None,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Join the scenario thread and return its chaos and perf reports.
+
+        If the join times out (i.e. ``thread.is_alive()`` after the budget),
+        a warning is logged and the returned ``chaos_report["status"]`` is
+        stamped to ``"timed_out"`` so a partial report is flagged on the
+        record rather than silently mislabelled as the last status the
+        scenario reached before the cutoff.
+
+        Args:
+            scenario_manager: The running scenario, or None.
+            scenario_thread: The scenario's daemon thread, or None.
+
+        Returns:
+            A ``(chaos_report, perf_report)`` pair; both empty when no chaos
+            was scheduled for the task.
+        """
+        if scenario_manager is None or scenario_thread is None:
+            return {}, {}
+        _log.info("waiting for background metrics collection to complete...")
+        scenario_thread.join(timeout=_SCENARIO_JOIN_SEC)
+        chaos_report, perf_report = scenario_manager.get_reports()
+        if scenario_thread.is_alive():
+            _log.warning(
+                "scenario thread still alive after %ss join budget; "
+                "stamping chaos_report.status='timed_out'",
+                _SCENARIO_JOIN_SEC,
+            )
+            # get_reports() already handed back a locked deep copy, so this
+            # snapshot is private and safe to stamp even though the daemon thread
+            # is still writing. It preserves any partial fields populated before
+            # the cutoff (injected_fault / name / output) so the operator sees
+            # how far it got.
+            chaos_report["status"] = "timed_out"
+        return chaos_report, perf_report
+
+    def _teardown(self, deployer: Any, infra_config: dict[str, Any], name: str) -> None:
+        """Tear down infrastructure unless disabled by config or env.
+
+        Args:
+            deployer: The deployer to tear down.
+            infra_config: Task infrastructure config (``teardown`` flag).
+            name: Task name, for logging.
+        """
+        if self.no_teardown:
+            return
+        if not infra_config.get("teardown", True):
+            return
+        _log.info("tearing down infrastructure for: %s", name)
+        try:
+            deployer.down()
+        except Exception as exc:  # noqa: BLE001 - never raise during teardown
+            _log.error("teardown failed (potential resource leak): %s", exc)
+
+    def _score(self, detailed_results: list[dict[str, Any]]) -> None:
+        """Score the batch in place via the metrics pipeline.
+
+        The harness threads its single resolved ``use_mcp`` boolean into the
+        metrics call, so the agent and the judge cannot disagree on whether
+        tools were enabled.
+
+        Args:
+            detailed_results: Execution results to score; ``scores`` is written
+                into each in place. Records marked ``status: "failed"`` are
+                skipped, since there is no agent output to judge.
+        """
+        scorable = [r for r in detailed_results if r.get("status") != "failed"]
+        if not scorable:
+            return
+        # Lazy import keeps ``deepeval`` / provider SDKs out of harness import.
+        from devops_bench.metrics import evaluate_metrics_batch, get_judge_model
+
+        judge_model = self._judge_model or get_judge_model()
+        evaluate_metrics_batch(scorable, judge_model, use_mcp=self.use_mcp)

--- a/devops_bench/evalharness/scenario.py
+++ b/devops_bench/evalharness/scenario.py
@@ -24,12 +24,13 @@ verification mapping supplied by the caller.
 from __future__ import annotations
 
 import contextlib
+import copy
 import socket
 import threading
 import time
 from typing import Any
 
-from devops_bench.chaos import ChaosSpec
+from devops_bench.chaos import ChaosResult, ChaosSpec
 from devops_bench.chaos.faults.generate_load import (
     _ENV_LOCAL_PORT,
     _ENV_SKIP_PORT_FORWARD,
@@ -136,6 +137,10 @@ class ScenarioManager:
         }
         self.start_time: float | None = None
         self._aborted = threading.Event()
+        # Guards writes to ``result_holder`` against a concurrent snapshot in
+        # ``get_reports`` — the reader can run while this thread is still writing
+        # (the timeout path in the harness drains reports without a completed join).
+        self._report_lock = threading.Lock()
 
     def run_chaos_and_verification(
         self,
@@ -153,19 +158,24 @@ class ScenarioManager:
 
         # Record initial chaos metadata before injection begins, so a crash
         # mid-injection still produces a partial report rather than silence.
-        self.result_holder["chaos_report"] = {
-            "injected_fault": spec.action.type,
-            "name": spec.name,
-            "status": "initiated",
-        }
+        with self._report_lock:
+            self.result_holder["chaos_report"] = {
+                "injected_fault": spec.action.type,
+                "name": spec.name,
+                "status": "initiated",
+            }
 
         try:
             chaos_result = self._inject_chaos(spec, ctx)
-            self.result_holder["chaos_report"] = self._chaos_report_from_result(spec, chaos_result)
+            with self._report_lock:
+                self.result_holder["chaos_report"] = self._chaos_report_from_result(
+                    spec, chaos_result
+                )
         except Exception as exc:  # noqa: BLE001 - surface failure into the report
             _log.error("error running scenario: %s", exc)
-            self.result_holder["chaos_report"]["status"] = "failed"
-            self.result_holder["chaos_report"]["error"] = str(exc)
+            with self._report_lock:
+                self.result_holder["chaos_report"]["status"] = "failed"
+                self.result_holder["chaos_report"]["error"] = str(exc)
             # Unblock the main thread immediately: it waits on this event to
             # learn the disruption is active, and a failed injection never sets
             # it via the fault, so without this it stalls for the full
@@ -194,16 +204,22 @@ class ScenarioManager:
                 "verification completed: %s",
                 verification_result.model_dump_json(indent=2),
             )
-            self.result_holder["chaos_report"]["verification"] = verification_result.model_dump()
-            self.result_holder["perf_report"] = self._perf_from_verification(verification_result)
+            with self._report_lock:
+                self.result_holder["chaos_report"]["verification"] = (
+                    verification_result.model_dump()
+                )
+                self.result_holder["perf_report"] = self._perf_from_verification(
+                    verification_result
+                )
         except Exception as exc:  # noqa: BLE001 - surface failure into the report
             _log.error("verification failed with exception: %s", exc)
-            self.result_holder["chaos_report"]["verification"] = {
-                "success": False,
-                "reason": f"Verification exception: {exc}",
-            }
+            with self._report_lock:
+                self.result_holder["chaos_report"]["verification"] = {
+                    "success": False,
+                    "reason": f"Verification exception: {exc}",
+                }
 
-    def _inject_chaos(self, spec: ChaosSpec, ctx: RunContext):
+    def _inject_chaos(self, spec: ChaosSpec, ctx: RunContext) -> ChaosResult:
         """Wait on the trigger, then drive ``action.inject`` with the target env.
 
         The trigger is a typed node; wait through its own ``wait(ctx)`` rather
@@ -401,13 +417,14 @@ class ScenarioManager:
             # just in the log. The shape mirrors the typed
             # VerificationResult dump (success/reason/name) so downstream
             # consumers don't need a special-case parse path.
-            self.result_holder["chaos_report"]["verification"] = {
-                "success": False,
-                "reason": reason,
-                "name": verify_ref,
-                "unresolved_reference": verify_ref,
-                "known_references": known,
-            }
+            with self._report_lock:
+                self.result_holder["chaos_report"]["verification"] = {
+                    "success": False,
+                    "reason": reason,
+                    "name": verify_ref,
+                    "unresolved_reference": verify_ref,
+                    "known_references": known,
+                }
             return None
         return node
 
@@ -416,12 +433,15 @@ class ScenarioManager:
 
         Returns:
             A ``(chaos_report, perf_report)`` pair derived from the most recent
-            scenario run; each is an empty dict before the run produces it.
+            scenario run; each is an empty dict before the run produces it. The
+            snapshot is a deep copy taken under the report lock, so a caller may
+            read it safely while the scenario thread is still writing.
         """
-        return (
-            self.result_holder.get("chaos_report", {}),
-            self.result_holder.get("perf_report", {}),
-        )
+        with self._report_lock:
+            return (
+                copy.deepcopy(self.result_holder.get("chaos_report", {})),
+                copy.deepcopy(self.result_holder.get("perf_report", {})),
+            )
 
     def stop(self) -> None:
         """Abort the scenario so a pending verification is skipped.

--- a/devops_bench/evalharness/scenario.py
+++ b/devops_bench/evalharness/scenario.py
@@ -1,0 +1,436 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Background chaos + verification on a daemon thread.
+
+The :class:`ScenarioManager` resolves the target Service's external
+LoadBalancer IP, points the load action at it, threads the port-forward target
+env onto the run context as a fallback, and runs chaos plus verification on a
+daemon thread, resolving :attr:`ChaosSpec.verify` against a name-keyed
+verification mapping supplied by the caller.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import socket
+import threading
+import time
+from typing import Any
+
+from devops_bench.chaos import ChaosSpec
+from devops_bench.chaos.faults.generate_load import (
+    _ENV_LOCAL_PORT,
+    _ENV_SKIP_PORT_FORWARD,
+    _ENV_TARGET_DEPLOYMENT,
+    _ENV_TARGET_NAMESPACE,
+    _LOCAL_PORT,
+)
+from devops_bench.core import get_logger
+from devops_bench.core.context import RunContext
+from devops_bench.k8s import get_resource, poll_until
+from devops_bench.verification import VerifierAgent
+
+__all__ = ["ScenarioManager", "VERIFICATION_TIMEOUT_SEC", "pick_free_port"]
+
+_log = get_logger("evalharness.scenario")
+
+# Verification budget shared across the (possibly nested) checks.
+VERIFICATION_TIMEOUT_SEC = 120
+
+# Seconds to wait for the target Service's external LoadBalancer IP to be
+# assigned by GKE. LB provisioning typically completes within a minute but can
+# lag — bound it so a stuck assignment falls back to the port-forward path
+# instead of stalling the run.
+_LB_IP_TIMEOUT_SEC = 180
+
+
+def pick_free_port() -> int:
+    """Return an ephemeral TCP port currently free on the loopback interface.
+
+    Binds to port 0 and reads back the kernel-assigned port. There is an
+    inherent (small) race between releasing the probe socket and ``kubectl``
+    binding the port; callers accept it as the cost of avoiding a fixed-port
+    collision across concurrent runs.
+
+    Returns:
+        A port number that was free at probe time.
+    """
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
+class ScenarioManager:
+    """Orchestrate a background chaos disruption and its verification.
+
+    The manager runs on a daemon thread alongside the agent under test: it
+    waits on the typed trigger, drives the typed
+    :class:`~devops_bench.chaos.base.Fault` (via ``action.inject``) to inject
+    the planned disruption, then resolves the spec's ``verify:`` key against the
+    per-task verification mapping and runs
+    :meth:`~devops_bench.verification.VerifierAgent.wait_for_condition` on the
+    resolved node. The load fault reaches its target through the target
+    Service's external LoadBalancer IP — the manager resolves it from the
+    Service status and rewrites the action's load URL before injection — so the
+    fortio spike works from any runner location (in-VPC bastion or off-VPC
+    local). The ``kubectl port-forward`` the fault still owns is kept as a
+    fallback for when LB resolution fails or the caller opts out.
+
+    Args:
+        target_deployment: Deployment the load fault should disrupt. Also the
+            Service name (the optimize-scale stack seeds the Service with the
+            same name), used here to look up the external LB IP and threaded
+            onto ``ctx.env`` for the fault's port-forward fallback.
+        namespace: Namespace the deployment / Service lives in; threaded onto
+            ``ctx.env``.
+        verification_mapping: Name-keyed mapping of verification specs the
+            chaos ``verify:`` reference is resolved against. The mapping carries
+            already-validated :class:`VerificationSpec` instances (or any value
+            ``VerifierAgent.wait_for_condition`` accepts); the manager never
+            re-validates. Empty mapping disables verification lookups.
+        skip_port_forward: When True, the fault runs without resolving an LB IP
+            and without opening a ``kubectl port-forward``. The E2E smoke
+            harness (against :class:`~devops_bench.deployers.NoOpDeployer`)
+            flips this on so tests can exercise the wiring without a real
+            cluster.
+
+    Attributes:
+        chaos_active_event: Set by the chaos fault once the disruption is
+            observably active, so the harness can synchronize the operator
+            agent's start.
+    """
+
+    def __init__(
+        self,
+        target_deployment: str,
+        namespace: str,
+        verification_mapping: dict[str, Any] | None = None,
+        *,
+        skip_port_forward: bool = False,
+        local_port: int | None = None,
+    ) -> None:
+        self.target_deployment = target_deployment
+        self.namespace = namespace
+        self.verification_mapping: dict[str, Any] = dict(verification_mapping or {})
+        self.skip_port_forward = skip_port_forward
+        # Per-run local port for the fault's port-forward; None keeps the
+        # fault's default. Parallel runs pass a free port to avoid contention.
+        self.local_port = local_port
+        self.chaos_active_event = threading.Event()
+        self.verifier_agent = VerifierAgent()
+        self.result_holder: dict[str, dict[str, Any]] = {
+            "chaos_report": {},
+            "perf_report": {},
+        }
+        self.start_time: float | None = None
+        self._aborted = threading.Event()
+
+    def run_chaos_and_verification(
+        self,
+        spec: ChaosSpec,
+        ctx: RunContext,
+    ) -> None:
+        """Inject the planned fault, then gather verification metrics.
+
+        Args:
+            spec: A typed :class:`ChaosSpec` carrying the trigger, action, and
+                opaque ``verify:`` key to resolve.
+            ctx: The per-task run context (forwarded to the trigger / fault).
+        """
+        self.start_time = time.time()
+
+        # Record initial chaos metadata before injection begins, so a crash
+        # mid-injection still produces a partial report rather than silence.
+        self.result_holder["chaos_report"] = {
+            "injected_fault": spec.action.type,
+            "name": spec.name,
+            "status": "initiated",
+        }
+
+        try:
+            chaos_result = self._inject_chaos(spec, ctx)
+            self.result_holder["chaos_report"] = self._chaos_report_from_result(spec, chaos_result)
+        except Exception as exc:  # noqa: BLE001 - surface failure into the report
+            _log.error("error running scenario: %s", exc)
+            self.result_holder["chaos_report"]["status"] = "failed"
+            self.result_holder["chaos_report"]["error"] = str(exc)
+            # Unblock the main thread immediately: it waits on this event to
+            # learn the disruption is active, and a failed injection never sets
+            # it via the fault, so without this it stalls for the full
+            # ``_CHAOS_ACTIVE_WAIT_SEC`` timeout before proceeding.
+            self.chaos_active_event.set()
+            return
+
+        if self._aborted.is_set():
+            return
+
+        verification_node = self._resolve_verification(spec.verify)
+        if verification_node is None:
+            # No verification scheduled (``verify`` was None) — leave the
+            # chaos_report alone. An UNKNOWN key, on the other hand, has
+            # already stamped ``chaos_report["verification"]`` with the
+            # failure record so the operator sees the typo'd cross-reference
+            # on the run record, not just in the log.
+            return
+
+        _log.info("starting planned verification using VerifierAgent...")
+        try:
+            verification_result = self.verifier_agent.wait_for_condition(
+                verification_node, timeout_sec=VERIFICATION_TIMEOUT_SEC
+            )
+            _log.info(
+                "verification completed: %s",
+                verification_result.model_dump_json(indent=2),
+            )
+            self.result_holder["chaos_report"]["verification"] = verification_result.model_dump()
+            self.result_holder["perf_report"] = self._perf_from_verification(verification_result)
+        except Exception as exc:  # noqa: BLE001 - surface failure into the report
+            _log.error("verification failed with exception: %s", exc)
+            self.result_holder["chaos_report"]["verification"] = {
+                "success": False,
+                "reason": f"Verification exception: {exc}",
+            }
+
+    def _inject_chaos(self, spec: ChaosSpec, ctx: RunContext):
+        """Wait on the trigger, then drive ``action.inject`` with the target env.
+
+        The trigger is a typed node; wait through its own ``wait(ctx)`` rather
+        than reading raw ``delay_seconds`` here — the harness only knows the
+        ``Trigger`` Protocol, not the concrete trigger's parameters. Before
+        injecting, the manager resolves the target Service's external
+        LoadBalancer IP and points the action's load URL at
+        ``http://<lb-ip>:8080`` (so the fortio spike hits the workload directly
+        from any runner location); the port-forward target is also threaded onto
+        ``ctx.env`` as a fallback for when LB resolution fails. When
+        ``skip_port_forward`` is True (E2E smoke / no real cluster), the LB
+        resolution is skipped and the fault runs against whatever URL the
+        action already carries.
+
+        Args:
+            spec: Typed chaos spec.
+            ctx: Run context handed to the trigger / fault.
+
+        Returns:
+            The :class:`~devops_bench.chaos.ChaosResult` returned by the fault.
+        """
+        spec.trigger.wait(ctx)
+
+        # Thread the port-forward target onto the context. ``ctx.env`` values
+        # are strings; flags are written only when truthy so the fault's
+        # ``bool(env.get(...))`` reads cleanly.
+        ctx.env[_ENV_TARGET_DEPLOYMENT] = self.target_deployment
+        ctx.env[_ENV_TARGET_NAMESPACE] = self.namespace
+        if self.local_port is not None:
+            ctx.env[_ENV_LOCAL_PORT] = str(self.local_port)
+
+        if self.skip_port_forward:
+            # Smoke / no-cluster path: there is no cluster to query for an LB
+            # IP, so leave the action's URL alone and just flag the fault to
+            # skip the tunnel.
+            ctx.env[_ENV_SKIP_PORT_FORWARD] = "1"
+        else:
+            is_local = ctx.cluster is not None and ctx.cluster.location == "local"
+            if is_local:
+                _log.info(
+                    "local cluster (location=%r) detected; skipping LoadBalancer IP resolution "
+                    "to rely directly on port-forward fallback",
+                    ctx.cluster.location,
+                )
+                lb_ip = None
+            else:
+                # Real-cluster path (GKE): resolve the external LB IP and rewrite the
+                # action's load URL to point at it directly. Fall back to the
+                # port-forward path if resolution fails or times out — that way a
+                # delayed LB still produces a load attempt instead of an aborted
+                # run.
+                lb_ip = self._resolve_lb_ip(self.target_deployment, self.namespace)
+
+            if lb_ip is not None and hasattr(spec.action, "target"):
+                target = spec.action.target
+                if hasattr(target, "service_url"):
+                    lb_url = f"http://{lb_ip}:{_LOCAL_PORT}"
+                    _log.info(
+                        "chaos load will hit external LB %s (no port-forward)",
+                        lb_url,
+                    )
+                    target.service_url = lb_url
+                    ctx.env[_ENV_SKIP_PORT_FORWARD] = "1"
+            # If lb_ip is None (timeout / local skip / kubectl error) the skip env is left
+            # unset; the fault then opens its own port-forward as the fallback.
+
+        return spec.action.inject(ctx, self.chaos_active_event)
+
+    @staticmethod
+    def _resolve_lb_ip(service: str, namespace: str) -> str | None:
+        """Poll the target Service for an external LoadBalancer IP.
+
+        Reads ``status.loadBalancer.ingress[0].ip`` (falling back to
+        ``hostname`` when the cloud provider hands back a DNS name instead of an
+        IP) and waits up to :data:`_LB_IP_TIMEOUT_SEC` for it to appear, since
+        GKE may take a minute or two to provision the underlying network LB
+        and firewall rule.
+
+        Args:
+            service: Service name (the optimize-scale target Service is named
+                after the target deployment, so the manager reuses
+                ``target_deployment`` here).
+            namespace: Namespace the Service lives in.
+
+        Returns:
+            The external IP/hostname as a string, or ``None`` if the timeout
+            elapses or kubectl fails. The caller treats ``None`` as a signal to
+            fall back to the port-forward transport.
+        """
+        resolved: dict[str, str] = {}
+
+        def _has_ip() -> bool:
+            try:
+                doc = get_resource("service", service, namespace=namespace)
+            except Exception as exc:  # noqa: BLE001 - poll keeps retrying
+                _log.debug("waiting for LB IP on %s/%s: %s", namespace, service, exc)
+                return False
+            ingress = (doc.get("status") or {}).get("loadBalancer", {}).get("ingress") or []
+            if not ingress:
+                return False
+            entry = ingress[0] or {}
+            ip = entry.get("ip") or entry.get("hostname")
+            if not ip:
+                return False
+            resolved["ip"] = ip
+            return True
+
+        _log.info(
+            "resolving external LB IP for service %s/%s (timeout %ss)",
+            namespace,
+            service,
+            _LB_IP_TIMEOUT_SEC,
+        )
+        ok = poll_until(_has_ip, timeout_sec=_LB_IP_TIMEOUT_SEC)
+        if not ok:
+            _log.warning(
+                "external LB IP for service %s/%s not assigned within %ss; "
+                "falling back to port-forward",
+                namespace,
+                service,
+                _LB_IP_TIMEOUT_SEC,
+            )
+            return None
+        return resolved["ip"]
+
+    @staticmethod
+    def _chaos_report_from_result(spec: ChaosSpec, result: Any) -> dict[str, Any]:
+        """Shape a typed ``ChaosResult`` into the chaos-report dict.
+
+        Args:
+            spec: The originating spec (carries the human-readable ``name``).
+            result: A :class:`~devops_bench.chaos.ChaosResult`.
+
+        Returns:
+            The ``chaos_report`` dict consumed by the result reporter; the
+            ``status`` field is derived from ``ChaosResult.success``.
+        """
+        dumped = result.model_dump()
+        # Carry both the human-readable name and the typed result fields so
+        # downstream consumers see a superset of both.
+        report: dict[str, Any] = {
+            "injected_fault": result.injected_fault,
+            "name": spec.name,
+            "status": "success" if result.success else "failed",
+            "output": dumped.get("output", ""),
+            "elapsed_time": dumped.get("elapsed_time", 0.0),
+        }
+        if dumped.get("error") is not None:
+            report["error"] = dumped["error"]
+        return report
+
+    @staticmethod
+    def _perf_from_verification(result: Any) -> dict[str, Any]:
+        """Derive ``perf_report`` from a verification result.
+
+        Deployment time flows through on success; the uptime / utilization
+        fields collapse to a success binary.
+        """
+        success = bool(result.success)
+        elapsed = float(result.elapsed_time)
+        return {
+            "deployment_time_seconds": elapsed if success else None,
+            "uptime_percentage": 100.0 if success else 0.0,
+            "resource_utilization_efficiency": 1.0 if success else 0.0,
+        }
+
+    def _resolve_verification(self, verify_ref: str | None) -> Any | None:
+        """Resolve the chaos spec's opaque ``verify`` key against the mapping.
+
+        Args:
+            verify_ref: The string key carried on :attr:`ChaosSpec.verify`, or
+                ``None`` when the spec opts out of verification.
+
+        Returns:
+            The mapped verification node (already validated) when the key is
+            present and known; ``None`` when the spec opts out **or** the
+            key is unknown. The unknown-key case is *not* silent — a
+            verification-failure entry is written into ``chaos_report``
+            naming the missing key + the available keys, so a typo'd
+            cross-reference shows up on the run record (not just in the
+            log).
+        """
+        if not verify_ref:
+            return None
+        node = self.verification_mapping.get(verify_ref)
+        if node is None:
+            known = sorted(self.verification_mapping.keys())
+            reason = (
+                f"chaos verify reference {verify_ref!r} not found in "
+                f"verification mapping; known keys: {known}"
+            )
+            _log.warning(reason)
+            # Surface the unresolved reference on the chaos_report so the
+            # operator sees the typo'd cross-reference in results.json, not
+            # just in the log. The shape mirrors the typed
+            # VerificationResult dump (success/reason/name) so downstream
+            # consumers don't need a special-case parse path.
+            self.result_holder["chaos_report"]["verification"] = {
+                "success": False,
+                "reason": reason,
+                "name": verify_ref,
+                "unresolved_reference": verify_ref,
+                "known_references": known,
+            }
+            return None
+        return node
+
+    def get_reports(self) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Return the aggregated chaos and performance reports.
+
+        Returns:
+            A ``(chaos_report, perf_report)`` pair derived from the most recent
+            scenario run; each is an empty dict before the run produces it.
+        """
+        return (
+            self.result_holder.get("chaos_report", {}),
+            self.result_holder.get("perf_report", {}),
+        )
+
+    def stop(self) -> None:
+        """Abort the scenario so a pending verification is skipped.
+
+        Sets an abort flag the scenario thread checks before dispatching
+        verification. The ``kubectl port-forward`` is owned by the load fault
+        (which tears it down in its own ``finally``), so there is nothing for
+        the manager to release here. Safe to call more than once and from a
+        different thread than the scenario's; it never raises, so it can run
+        from a ``finally`` block during cleanup.
+        """
+        self._aborted.set()

--- a/tests/unit/evalharness/__init__.py
+++ b/tests/unit/evalharness/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit/evalharness/test_default_harness.py
+++ b/tests/unit/evalharness/test_default_harness.py
@@ -1,0 +1,520 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Targeted unit tests for ``DefaultEvalHarness`` internals not covered elsewhere.
+
+Tests in this file exercise the harness-level wiring beyond the agent /
+scenario / metrics seams (those have their own files): the scenario-drain
+timed-out path, the constructor-arg-driven deployment / namespace defaults,
+the cached granted-skill-paths snapshot, and the narrowed builtin-agent
+import behavior.
+"""
+
+from __future__ import annotations
+
+import importlib
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from devops_bench.agents import AGENTS, AgentHarness
+from devops_bench.agents.result import AgentResult, ToolCall
+from devops_bench.core import ConfigError, MissingDependencyError
+from devops_bench.evalharness import default as harness_default
+from devops_bench.evalharness.default import DefaultEvalHarness
+from devops_bench.tasks import Task
+
+
+@pytest.fixture
+def isolated_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip BENCH_* / AGENT_* env so the harness reads predictable defaults."""
+    for var in (
+        "BENCH_USE_MCP",
+        "BENCH_AGENT_TYPE",
+        "AGENT_MCP_SERVER",
+        "AGENT_ALLOWED_TOOLS",
+        "AGENT_SKILLS_PATHS",
+        "AGENT_RULES_TEXT",
+        "AGENT_TARGET",
+        "AGENT_MODEL",
+        "AGENT_PROVIDER",
+        "TARGET_DEPLOYMENT_NAME",
+        "NAMESPACE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_parse_chaos_specs_raises_on_malformed_json(isolated_env: None) -> None:
+    """A declared-but-unparseable chaos spec fails loudly rather than dropping to no chaos."""
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+    with pytest.raises(ConfigError, match="chaos_spec"):
+        harness._parse_chaos_specs("{not valid json", "cluster")  # noqa: SLF001
+
+
+def test_drain_scenario_stamps_timed_out_when_thread_still_alive(
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A scenario thread that outlives the join budget is flagged on the report."""
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+
+    # Drive the join budget to ~0 so the thread is "still alive" on return
+    # without sleeping in the test. The harness reads the module global at
+    # call time, so patching the attribute on the module flexes the path.
+    monkeypatch.setattr(harness_default, "_SCENARIO_JOIN_SEC", 0.01)
+
+    class _StuckScenario:
+        """Stand-in scenario manager whose reports stay partial."""
+
+        def get_reports(self) -> tuple[dict[str, Any], dict[str, Any]]:
+            return ({"status": "initiated", "injected_fault": "x"}, {})
+
+    stop_event = threading.Event()
+
+    def _hang() -> None:
+        # Hold the thread alive past the join budget so ``is_alive`` is True
+        # on return; the event lets the test release the thread on cleanup.
+        stop_event.wait(timeout=2.0)
+
+    scenario_thread = threading.Thread(target=_hang, daemon=True)
+    scenario_thread.start()
+    try:
+        chaos_report, perf_report = harness._drain_scenario(  # noqa: SLF001
+            _StuckScenario(), scenario_thread
+        )
+        assert chaos_report["status"] == "timed_out"
+        # Partial fields from the underlying scenario carry through so the
+        # operator sees how far it got before the cutoff.
+        assert chaos_report["injected_fault"] == "x"
+        assert perf_report == {}
+    finally:
+        stop_event.set()
+        scenario_thread.join(timeout=2.0)
+
+
+def test_drain_scenario_returns_empty_when_no_scenario_scheduled(
+    isolated_env: None,
+) -> None:
+    """No chaos for the task → both reports are empty dicts (legacy contract)."""
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+    chaos_report, perf_report = harness._drain_scenario(None, None)  # noqa: SLF001
+    assert chaos_report == {} and perf_report == {}
+
+
+def test_default_target_deployment_and_namespace_are_ctor_args(
+    isolated_env: None,
+) -> None:
+    """A non-Hypercompute embedder can override the legacy defaults at ctor.
+
+    No env vars set; the harness's overrides flow through to
+    ``replace_placeholders`` so a task with
+    ``{{TARGET_DEPLOYMENT_NAME}}``/``{{NAMESPACE}}`` resolves to the
+    embedder's values rather than the legacy literals.
+    """
+    harness = DefaultEvalHarness(
+        project_id="p",
+        cluster_name="c",
+        default_target_deployment="my-app",
+        default_namespace="custom-ns",
+    )
+    resolved = harness.replace_placeholders(
+        "deploy={{TARGET_DEPLOYMENT_NAME}} ns={{NAMESPACE}}",
+        cluster_name="cl",
+    )
+    assert resolved == "deploy=my-app ns=custom-ns"
+
+
+def test_granted_skill_paths_snapshot_captured_once(
+    isolated_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_granted_skill_paths`` snapshots once at __init__, not per record.
+
+    Removes the env-drift surface: a mid-run change to
+    ``AGENT_SKILLS_PATHS`` must NOT show up in record records, because
+    the harness is the single source of truth for what was granted.
+    """
+    monkeypatch.setenv("AGENT_SKILLS_PATHS", "/skills/a,/skills/b")
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+    assert harness._granted_skill_paths == ("/skills/a", "/skills/b")  # noqa: SLF001
+
+    # A later env mutation must not move the snapshot — the captured
+    # tuple is the authority for the rest of the run.
+    monkeypatch.setenv("AGENT_SKILLS_PATHS", "/skills/x")
+    assert harness._granted_skill_paths == ("/skills/a", "/skills/b")  # noqa: SLF001
+
+
+def test_build_agent_config_returns_identical_snapshot_across_calls(
+    isolated_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``build_agent_config`` is a pure accessor over the __init__ snapshot.
+
+    Two back-to-back calls must return the **same object identity** so the
+    agent the harness constructs cannot differ from the config the
+    record's ``capabilities_granted`` was derived from. A previous version
+    re-read ``AgentConfig.from_env()`` per call, opening a desync window
+    that mid-batch env mutation could exploit.
+    """
+    monkeypatch.setenv("AGENT_SKILLS_PATHS", "/skills/a")
+    monkeypatch.setenv("BENCH_USE_MCP", "true")
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+
+    a = harness.build_agent_config()
+    b = harness.build_agent_config()
+    # Identity — not just equality — pins the no-rebuild invariant.
+    assert a is b
+    assert a.capabilities.skills.paths == ("/skills/a",)
+
+
+def test_capabilities_granted_matches_agent_config_even_after_env_mutation(
+    isolated_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``capabilities_granted`` exactly mirrors the agent's actual config.
+
+    This is the consistency invariant the senior reviewer flagged: env
+    mutated AFTER ``DefaultEvalHarness(...)`` construction must not desync
+    what the agent was built with from what the record claims it was
+    built with. Both come from the single ``__init__`` snapshot.
+    """
+    monkeypatch.setenv("AGENT_SKILLS_PATHS", "/skills/granted")
+    monkeypatch.setenv("AGENT_MCP_SERVER", "/path/to/mcp")
+    monkeypatch.setenv("AGENT_ALLOWED_TOOLS", "tool_a")
+    monkeypatch.setenv("BENCH_USE_MCP", "true")
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+
+    # Drift the env AFTER construction. The harness must still report
+    # what was granted at construction, not what the env now says.
+    monkeypatch.setenv("AGENT_SKILLS_PATHS", "/skills/leaked-after-init")
+    monkeypatch.setenv("BENCH_USE_MCP", "false")
+    monkeypatch.delenv("AGENT_MCP_SERVER", raising=False)
+
+    config = harness.build_agent_config()
+    task = Task.from_dict({"task_id": "t", "name": "demo", "prompt": "p"})
+    success = harness._build_success_record(  # noqa: SLF001
+        task=task,
+        prompt="p",
+        expected_output="e",
+        agent_res=AgentResult(output="ok", trajectory=[]),
+        chaos_report={},
+        perf_report={},
+    )
+    failed = harness._build_failed_record(  # noqa: SLF001
+        task, RuntimeError("boom")
+    )
+
+    # The record's ``skills`` and ``capabilities_granted.skills`` come
+    # from the same snapshot the agent was built from. The post-init env
+    # mutation must NOT leak through.
+    expected_skills = list(config.capabilities.skills.paths)
+    assert expected_skills == ["/skills/granted"]
+    for record in (success, failed):
+        assert record["skills"] == expected_skills
+        assert record["capabilities_granted"]["skills"] == expected_skills
+        # ``use_mcp`` was snapshotted True at __init__; the post-init
+        # mutation to "false" must not flip it on the record.
+        assert record["capabilities_granted"]["use_mcp"] is True
+    # And the agent's actual MCP binding agrees — the post-init delenv
+    # of AGENT_MCP_SERVER did NOT drop the binding the agent runs with.
+    assert config.capabilities.mcp is not None
+
+
+def test_run_one_returns_failed_record_when_get_deployer_raises(
+    isolated_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A deployer-factory failure becomes a failed record, not a batch crash.
+
+    ``get_deployer`` runs inside ``_run_one``'s try, so an unknown deployer
+    type fails just this task (status ``failed``) instead of aborting the whole
+    batch evaluation.
+    """
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+
+    def _boom(*_args: Any, **_kwargs: Any) -> Any:
+        raise ValueError("unknown deployer type")
+
+    monkeypatch.setattr(harness_default, "get_deployer", _boom)
+    task = Task.from_dict({"task_id": "t", "name": "demo", "prompt": "p"})
+
+    record = harness._run_one(task, tmp_path)  # noqa: SLF001
+
+    assert record["status"] == "failed"
+    assert "unknown deployer type" in record["error"]
+    assert record["name"] == "demo"
+
+
+class _WorkspaceWritingAgent(AgentHarness):
+    """Stand-in agent that writes a file into whatever workspace it is given."""
+
+    def _execute(self, prompt: str, workspace_path: Path | None = None) -> AgentResult:
+        assert workspace_path is not None
+        (workspace_path / "output.txt").write_text("agent wrote this")
+        return AgentResult(output="wrote a file", trajectory=[])
+
+
+def test_run_one_collects_files_the_agent_writes_to_its_workspace(
+    isolated_env: None, tmp_path: Path
+) -> None:
+    """Generated-file collection diffs the agent's real workspace, not the launch cwd.
+
+    Regression test: the harness used to snapshot/diff ``Path(os.getcwd())`` while
+    each CLI agent wrote into its own private ``tempfile.TemporaryDirectory`` that
+    was gone by the time artifacts were collected, so ``generated_files`` came back
+    empty. The harness now owns a per-run workspace and threads it to the agent via
+    ``RunContext.workspace_path``, so a file the agent writes there is collected.
+    """
+    AGENTS.register("fake-workspace-writer")(_WorkspaceWritingAgent)
+    try:
+        harness = DefaultEvalHarness(
+            project_id="p", cluster_name="c", agent_type="fake-workspace-writer", no_infra=True
+        )
+        task = Task.from_dict({"task_id": "t", "name": "demo", "prompt": "p"})
+        run_dir = tmp_path / "run_1"
+        run_dir.mkdir()
+
+        record = harness._run_one(task, run_dir)  # noqa: SLF001
+
+        assert record["status"] == "success"
+        generated = run_dir / "generated_files" / "output.txt"
+        assert generated.exists()
+        assert generated.read_text() == "agent wrote this"
+    finally:
+        AGENTS._items.pop("fake-workspace-writer", None)  # noqa: SLF001
+
+
+def test_ensure_builtin_agents_swallows_only_import_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Optional-SDK absence is swallowed; real bugs re-raise.
+
+    ``ImportError`` / ``MissingDependencyError`` are the narrow-catch
+    classes — anything else (``SyntaxError``, ``RuntimeError`` at module
+    top, etc.) must bubble out so the operator sees the real failure
+    instead of a silent ``debug`` log.
+    """
+
+    # Case 1: ImportError is swallowed — function returns normally.
+    def fake_import_missing_sdk(name: str) -> Any:
+        raise ImportError("anthropic SDK not installed")
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_missing_sdk)
+    harness_default._ensure_builtin_agents_registered()  # noqa: SLF001
+
+    # Case 2: a non-import bug must NOT be silently swallowed.
+    def fake_import_buggy_module(name: str) -> Any:
+        raise SyntaxError("agent module is broken")
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_buggy_module)
+    with pytest.raises(SyntaxError):
+        harness_default._ensure_builtin_agents_registered()  # noqa: SLF001
+
+    # Case 3: MissingDependencyError is also swallowed (its semantic class).
+    def fake_missing_dep(name: str) -> Any:
+        raise MissingDependencyError("optional-feature", "extras-marker")
+
+    monkeypatch.setattr(importlib, "import_module", fake_missing_dep)
+    harness_default._ensure_builtin_agents_registered()  # noqa: SLF001
+
+
+def test_resolve_deployment_and_namespace_precedence_and_types(
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # 1. Default case (no env, no task variables)
+    harness = DefaultEvalHarness(
+        project_id="p",
+        cluster_name="c",
+        default_target_deployment="my-default-dep",
+        default_namespace="my-default-ns",
+    )
+    dep, ns = harness._resolve_deployment_and_namespace(None)  # noqa: SLF001
+    assert dep == "my-default-dep"
+    assert ns == "my-default-ns"
+
+    # 2. Task variables override defaults
+    task = Task.from_dict(
+        {
+            "task_id": "t",
+            "name": "demo",
+            "prompt": "p",
+            "infrastructure": {
+                "variables": {
+                    "target_deployment_name": "task-dep",
+                    "namespace": "task-ns",
+                }
+            },
+        }
+    )
+    dep, ns = harness._resolve_deployment_and_namespace(task)  # noqa: SLF001
+    assert dep == "task-dep"
+    assert ns == "task-ns"
+
+    # 3. Env variables override task variables and defaults
+    monkeypatch.setenv("TARGET_DEPLOYMENT_NAME", "env-dep")
+    monkeypatch.setenv("NAMESPACE", "env-ns")
+    dep, ns = harness._resolve_deployment_and_namespace(task)  # noqa: SLF001
+    assert dep == "env-dep"
+    assert ns == "env-ns"
+
+    # Clean up env for next assertions
+    monkeypatch.delenv("TARGET_DEPLOYMENT_NAME")
+    monkeypatch.delenv("NAMESPACE")
+
+    # 4. Crash cases: empty variables (None)
+    task_empty_vars = Task.from_dict(
+        {"task_id": "t", "name": "demo", "prompt": "p", "infrastructure": {"variables": None}}
+    )
+    # Should not raise AttributeError, should fallback to defaults
+    dep, ns = harness._resolve_deployment_and_namespace(task_empty_vars)  # noqa: SLF001
+    assert dep == "my-default-dep"
+    assert ns == "my-default-ns"
+
+    # 5. Crash cases: non-string values (converted to string)
+    task_non_str_vars = Task.from_dict(
+        {
+            "task_id": "t",
+            "name": "demo",
+            "prompt": "p",
+            "infrastructure": {
+                "variables": {
+                    "target_deployment_name": 123,
+                    "namespace": 456,
+                }
+            },
+        }
+    )
+    # Should not raise TypeError, should convert to string
+    dep, ns = harness._resolve_deployment_and_namespace(task_non_str_vars)  # noqa: SLF001
+    assert dep == "123"
+    assert ns == "456"
+
+
+# --- results.json schema (Decision D3): _RECORD_KEYS is the source of truth ---
+
+# Pinned symmetric key set. Every key must be present on *both* the success and
+# failed record, so a downstream parser iterating one shape never KeyErrors on
+# the other.
+_RESULTS_JSON_REQUIRED_KEYS: frozenset[str] = frozenset(
+    {
+        "input",
+        "output",
+        "latency",
+        "tokens",
+        "tools",
+        "trajectory",
+        "skills",
+        "name",
+        "folder",
+        "status",
+        "error",
+        "errors",
+        "scores",
+        "expected_output",
+        "expected_output_raw",
+        "retrieval_context",
+        "chaos_spec",
+        "verification_spec",
+        "chaos_report",
+        "perf_report",
+        "documentation",
+        "capabilities_granted",
+        "verification_parse_errors",
+        "generation_only",
+        "validated",
+    }
+)
+
+
+def _stub_task() -> Task:
+    """Build a typed task with a few non-trivial fields the records carry."""
+    return Task.from_dict(
+        {
+            "task_id": "demo-1",
+            "name": "demo",
+            "prompt": "do the thing",
+            "expected_output": "exp",
+            "retrieval_context": ["doc-a"],
+            "chaos_spec": {"chaos": "yes"},
+            "verification_spec": {"verify": "yes"},
+        }
+    )
+
+
+def _stub_agent_result() -> AgentResult:
+    """Build an agent result with output, trajectory, tokens, latency populated."""
+    return AgentResult(
+        output="done",
+        trajectory=[
+            ToolCall(
+                name="run_command",
+                args={"command": "kubectl get pods"},
+                result="pod/web-app Running",
+                status="completed",
+            ).to_dict()
+        ],
+        tokens={"input": 10, "output": 5},
+        latency=1.5,
+    )
+
+
+def test_record_keys_class_constant_matches_golden(isolated_env: None) -> None:
+    """``_RECORD_KEYS`` is the authoritative schema; pin it against the golden set."""
+    assert DefaultEvalHarness._RECORD_KEYS == _RESULTS_JSON_REQUIRED_KEYS  # noqa: SLF001
+
+
+def test_success_record_keys_match_golden(isolated_env: None) -> None:
+    """A real ``_build_success_record`` invocation emits exactly the golden keys."""
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+    record = harness._build_success_record(  # noqa: SLF001 - testing internals
+        task=_stub_task(),
+        prompt="resolved prompt",
+        expected_output="resolved expected",
+        agent_res=_stub_agent_result(),
+        chaos_report={"status": "success"},
+        perf_report={"uptime_percentage": 100.0},
+    )
+    assert set(record.keys()) == _RESULTS_JSON_REQUIRED_KEYS
+    assert record["status"] == "success"
+    assert record["output"] == "done"
+    assert record["error"] is None
+    assert record["errors"] == []
+    assert record["scores"] == {}
+
+
+def test_failed_record_keys_match_golden(isolated_env: None) -> None:
+    """``_build_failed_record`` emits the SAME key set as the success record."""
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+    record = harness._build_failed_record(  # noqa: SLF001 - testing internals
+        _stub_task(), RuntimeError("deployer.up() failed")
+    )
+    assert set(record.keys()) == _RESULTS_JSON_REQUIRED_KEYS
+    assert record["status"] == "failed"
+    assert record["error"] == "deployer.up() failed"
+    assert record["errors"] == ["deployer.up() failed"]
+
+
+def test_success_and_failed_records_have_identical_top_level_keys(isolated_env: None) -> None:
+    """Direct invariant: the two record shapes carry the same top-level keys."""
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+    task = _stub_task()
+    success = harness._build_success_record(  # noqa: SLF001
+        task=task,
+        prompt="p",
+        expected_output="e",
+        agent_res=_stub_agent_result(),
+        chaos_report={},
+        perf_report={},
+    )
+    failed = harness._build_failed_record(task, RuntimeError("boom"))  # noqa: SLF001
+    assert set(success.keys()) == set(failed.keys()) == _RESULTS_JSON_REQUIRED_KEYS

--- a/tests/unit/evalharness/test_package_import.py
+++ b/tests/unit/evalharness/test_package_import.py
@@ -1,0 +1,81 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``import devops_bench.evalharness`` keeps the provider SDK chain lazy (§8 revised).
+
+The orchestrator is the only layer allowed to consume every component, so it
+sits structurally close to the heavy optional dependencies. Light init is now a
+guideline, not a rule: importing the package may pull ``deepeval`` / ``mcp``.
+What it must **never** pull is a provider model SDK: the metrics judge is
+imported lazily inside ``DefaultEvalHarness._score``, the API agent's SDK loads at
+construction, and the chaos fault's agent + models chain loads only when the
+fault actually injects.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+import textwrap
+
+
+def _run_in_subprocess(snippet: str) -> str:
+    """Run ``snippet`` in a clean Python process and return stdout.
+
+    A fresh interpreter prevents leaks from earlier test imports (the wider
+    test session has often already pulled ``deepeval``).
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(snippet)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def test_importing_harness_pulls_no_provider_sdk() -> None:
+    """A bare ``import devops_bench.evalharness`` does not pull a provider SDK.
+
+    ``deepeval`` / ``mcp`` are permitted eagerly now; only the provider model
+    SDKs must stay out until the judge / agent actually run.
+    """
+    output = _run_in_subprocess(
+        """
+        import sys
+        import devops_bench.evalharness  # noqa: F401
+        forbidden = {
+            "anthropic",
+            "google.genai",
+            "google.generativeai",
+            "openai",
+            "ollama",
+        }
+        leaked = sorted(name for name in forbidden if name in sys.modules)
+        print(",".join(leaked))
+        """
+    )
+    leaked = [name for name in output.strip().split(",") if name]
+    assert leaked == [], f"importing devops_bench.evalharness pulled: {leaked}"
+
+
+def test_harness_exports_present() -> None:
+    """The eager package exposes every public harness symbol."""
+    pkg = importlib.import_module("devops_bench.evalharness")
+    # All four public symbols are eagerly imported now (no ``__getattr__``).
+    assert pkg.Harness.__name__ == "Harness"
+    assert pkg.ResultReporter.__name__ == "ResultReporter"
+    assert pkg.DefaultEvalHarness.__name__ == "DefaultEvalHarness"
+    assert pkg.ScenarioManager.__name__ == "ScenarioManager"

--- a/tests/unit/evalharness/test_registry_resolution.py
+++ b/tests/unit/evalharness/test_registry_resolution.py
@@ -1,0 +1,97 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Registry-only agent resolution (CONVENTIONS.md §2 / harness handoff §5).
+
+The harness must resolve agents purely through :data:`AGENTS` — there is no
+``_AGENT_MODULES`` / ``_AGENT_KEYS`` dispatch table to edit when a new agent
+is added. The acceptance bar is exactly: a dummy ``@AGENTS.register("dummy")``
+resolves with **no harness edit**.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from devops_bench.agents import AGENTS, AgentConfig, AgentHarness, AgentResult
+from devops_bench.core import NotRegisteredError
+from devops_bench.evalharness.default import DefaultEvalHarness
+
+
+class _DummyAgent(AgentHarness):
+    """Trivial agent for the dropped-in-registration test.
+
+    Captures the config it was constructed with so the test can assert that
+    the harness threaded its resolved capabilities into the instance (rather
+    than handing the agent an env-only config).
+    """
+
+    last_config: AgentConfig | None = None
+
+    def __init__(self, config: AgentConfig | None = None) -> None:
+        super().__init__(config)
+        _DummyAgent.last_config = self.config
+
+    def _execute(  # pragma: no cover - never run
+        self, prompt: str, workspace_path=None
+    ) -> AgentResult:
+        return AgentResult(output=f"echo: {prompt}", trajectory=[])
+
+
+@pytest.fixture
+def dummy_agent_registered() -> None:
+    """Register ``_DummyAgent`` under the canonical ``dummy`` key for one test."""
+    AGENTS.register("dummy")(_DummyAgent)
+    try:
+        yield
+    finally:
+        # ``Registry`` has no public deregister; drop the key directly so the
+        # fixture is hermetic across the suite.
+        AGENTS._items.pop("dummy", None)  # noqa: SLF001 - test-only teardown
+        _DummyAgent.last_config = None
+
+
+def test_dummy_agent_resolves_with_no_harness_edit(
+    dummy_agent_registered: None,
+) -> None:
+    """A third-party-registered agent flows through the orchestrator unchanged."""
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+    harness.agent_type = "dummy"
+
+    agent = harness.resolve_agent("dummy")
+
+    assert isinstance(agent, _DummyAgent)
+    # The harness threaded its built config (not a bare ``AgentConfig()``).
+    assert _DummyAgent.last_config is not None
+    assert isinstance(_DummyAgent.last_config, AgentConfig)
+
+
+def test_alias_normalizes_to_canonical_key() -> None:
+    """``gemini-cli`` resolves to the canonical ``gemini`` agent."""
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+
+    # ``gemini-cli`` is the friendly alias for the gemini agent; resolution must
+    # not require a path table — the alias map normalizes to ``gemini`` and the
+    # registry returns the registered class.
+    agent_cls = AGENTS.get("gemini")
+    agent = harness.resolve_agent("gemini-cli")
+    assert isinstance(agent, agent_cls)
+
+
+def test_unknown_agent_type_raises_not_registered() -> None:
+    """An agent key with no registration produces ``NotRegisteredError``."""
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+
+    with pytest.raises(NotRegisteredError):
+        harness.resolve_agent("not-a-real-agent-key")

--- a/tests/unit/evalharness/test_scenario.py
+++ b/tests/unit/evalharness/test_scenario.py
@@ -1,0 +1,572 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scenario wiring tests (CONVENTIONS.md §4.2 / harness handoff §9.1/§9.2).
+
+The scenario manager runs the typed chaos seam (``trigger.wait`` then
+``action.inject``) and resolves the chaos ``verify`` key against a
+**mapping** (not a list scan) supplied by the orchestrator. Fakes stand in
+for both seams so the test exercises only the wiring — never a real cluster
+or a real LLM.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from devops_bench.chaos import ChaosResult, ChaosSpec
+from devops_bench.chaos.faults.generate_load import GenerateLoadFault
+from devops_bench.chaos.triggers.time_delay import TimeTrigger
+from devops_bench.core.context import RunContext
+from devops_bench.evalharness.scenario import ScenarioManager, pick_free_port
+from devops_bench.verification import VerificationResult, VerifierAgent
+
+
+def _build_spec(*, verify_key: str | None) -> ChaosSpec:
+    """Build a typed :class:`ChaosSpec` mirroring the optimize-scale entry."""
+    return ChaosSpec.model_validate(
+        {
+            "name": "Test Disruption",
+            "trigger": {"type": "time", "delay_seconds": 0},
+            "action": {
+                "type": "generate_load",
+                "target": {
+                    "service_url": "http://example.svc.cluster.local",
+                    "qps": 50,
+                },
+            },
+            "verify": verify_key,
+        }
+    )
+
+
+def _build_ctx() -> RunContext:
+    return RunContext(task_id="t", task_name="t")
+
+
+def test_scenario_drives_trigger_wait_then_action_inject() -> None:
+    """The seam: trigger.wait runs first, then action.inject — no inline goal builder."""
+    spec = _build_spec(verify_key=None)
+    order: list[str] = []
+
+    def fake_wait(self: TimeTrigger, ctx: RunContext) -> None:
+        order.append("trigger.wait")
+
+    def fake_inject(
+        self: GenerateLoadFault,
+        ctx: RunContext,
+        event: threading.Event | None,
+    ) -> ChaosResult:
+        order.append("action.inject")
+        if event is not None:
+            event.set()
+        return ChaosResult(
+            success=True,
+            injected_fault=self.type,
+            output="ok",
+            elapsed_time=0.1,
+        )
+
+    with (
+        patch.object(TimeTrigger, "wait", fake_wait),
+        patch.object(GenerateLoadFault, "inject", fake_inject),
+    ):
+        manager = ScenarioManager(
+            target_deployment="dep",
+            namespace="ns",
+            verification_mapping={},
+            skip_port_forward=True,
+        )
+        manager.run_chaos_and_verification(spec, _build_ctx())
+
+    assert order == ["trigger.wait", "action.inject"]
+    chaos_report, perf_report = manager.get_reports()
+    assert chaos_report["status"] == "success"
+    assert chaos_report["injected_fault"] == "generate_load"
+    assert chaos_report["name"] == "Test Disruption"
+    # No verification mapping resolution happened (verify_key was None).
+    assert "verification" not in chaos_report
+    assert perf_report == {}
+
+
+def test_scenario_threads_port_forward_target_onto_ctx_env() -> None:
+    """The manager threads the port-forward target onto ``ctx.env`` for the fault.
+
+    Connectivity moved into the load fault (#33): the manager no longer rewrites
+    the action URL or opens a port-forward itself — it hands the fault the
+    target deployment / namespace (and the skip flag) via the run context's
+    ``env`` so the fault can open its own tunnel.
+    """
+    from devops_bench.chaos.faults.generate_load import (
+        _ENV_SKIP_PORT_FORWARD,
+        _ENV_TARGET_DEPLOYMENT,
+        _ENV_TARGET_NAMESPACE,
+    )
+
+    spec = _build_spec(verify_key=None)
+    captured: dict[str, Any] = {}
+
+    def fake_inject(self: GenerateLoadFault, ctx: RunContext, event):
+        captured["env"] = dict(ctx.env)
+        # The in-cluster URL is untouched by the manager now; the fault is what
+        # would point it at the local tunnel (skipped here).
+        captured["service_url"] = self.target.service_url
+        return ChaosResult(success=True, injected_fault=self.type, elapsed_time=0.0)
+
+    with (
+        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
+        patch.object(GenerateLoadFault, "inject", fake_inject),
+    ):
+        manager = ScenarioManager(
+            target_deployment="dep",
+            namespace="ns",
+            skip_port_forward=True,
+        )
+        manager.run_chaos_and_verification(spec, _build_ctx())
+
+    assert captured["env"][_ENV_TARGET_DEPLOYMENT] == "dep"
+    assert captured["env"][_ENV_TARGET_NAMESPACE] == "ns"
+    # ``skip_port_forward=True`` flips the fault's opt-out flag on the env.
+    assert captured["env"][_ENV_SKIP_PORT_FORWARD] == "1"
+    # The manager leaves the action's in-cluster URL alone — no rewrite seam.
+    assert captured["service_url"] == "http://example.svc.cluster.local"
+
+
+def test_scenario_threads_custom_local_port_onto_ctx_env() -> None:
+    """A per-run ``local_port`` is threaded onto ``ctx.env`` for the fault.
+
+    Connectivity lives in the fault, so the manager hands it the per-run local
+    port via ``CHAOS_LOCAL_PORT``; the fault binds the port-forward's local side
+    there. No port is threaded when ``local_port`` is None (default behavior).
+    """
+    from devops_bench.chaos.faults.generate_load import _ENV_LOCAL_PORT
+
+    spec = _build_spec(verify_key=None)
+    captured: dict[str, Any] = {}
+
+    def fake_inject(self: GenerateLoadFault, ctx: RunContext, event):
+        captured["env"] = dict(ctx.env)
+        return ChaosResult(success=True, injected_fault=self.type, elapsed_time=0.0)
+
+    with (
+        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
+        patch.object(GenerateLoadFault, "inject", fake_inject),
+    ):
+        manager = ScenarioManager(
+            target_deployment="dep",
+            namespace="ns",
+            skip_port_forward=True,
+            local_port=34567,
+        )
+        assert manager.local_port == 34567
+        manager.run_chaos_and_verification(spec, _build_ctx())
+
+    assert captured["env"][_ENV_LOCAL_PORT] == "34567"
+
+
+def test_scenario_omits_local_port_env_by_default() -> None:
+    """Without a per-run port, no ``CHAOS_LOCAL_PORT`` is threaded (fault default)."""
+    from devops_bench.chaos.faults.generate_load import _ENV_LOCAL_PORT
+
+    spec = _build_spec(verify_key=None)
+    captured: dict[str, Any] = {}
+
+    def fake_inject(self: GenerateLoadFault, ctx: RunContext, event):
+        captured["env"] = dict(ctx.env)
+        return ChaosResult(success=True, injected_fault=self.type, elapsed_time=0.0)
+
+    with (
+        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
+        patch.object(GenerateLoadFault, "inject", fake_inject),
+    ):
+        ScenarioManager(
+            target_deployment="dep", namespace="ns", skip_port_forward=True
+        ).run_chaos_and_verification(spec, _build_ctx())
+
+    assert _ENV_LOCAL_PORT not in captured["env"]
+
+
+def test_pick_free_port_returns_a_usable_port() -> None:
+    # pick_free_port binds port 0 and releases it, so consecutive calls may reuse
+    # the same port — it guarantees a usable ephemeral port, not distinctness.
+    port = pick_free_port()
+    assert isinstance(port, int)
+    assert 1 <= port <= 65535
+
+
+def test_scenario_resolves_verify_against_mapping() -> None:
+    """The chaos ``verify`` key is looked up in the harness-supplied mapping."""
+    spec = _build_spec(verify_key="planned-verify")
+    verification_node = object()  # opaque stand-in; VerifierAgent is mocked
+
+    fake_result = VerificationResult(success=True, elapsed_time=2.5, reason="all good")
+
+    with (
+        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
+        patch.object(
+            GenerateLoadFault,
+            "inject",
+            lambda self, ctx, event: ChaosResult(
+                success=True, injected_fault=self.type, elapsed_time=0.0
+            ),
+        ),
+        patch.object(VerifierAgent, "wait_for_condition", return_value=fake_result) as mock_wait,
+    ):
+        manager = ScenarioManager(
+            target_deployment="dep",
+            namespace="ns",
+            verification_mapping={"planned-verify": verification_node},
+            skip_port_forward=True,
+        )
+        manager.run_chaos_and_verification(spec, _build_ctx())
+
+    # The mapping value (not a list-scanned dict) flowed straight to the
+    # VerifierAgent — the lookup is O(1) and never imports verification on the
+    # chaos side.
+    mock_wait.assert_called_once_with(verification_node, timeout_sec=120)
+
+    chaos_report, perf_report = manager.get_reports()
+    assert chaos_report["verification"]["success"] is True
+    assert chaos_report["verification"]["reason"] == "all good"
+    # Perf report is derived from the typed VerificationResult.
+    assert perf_report == {
+        "deployment_time_seconds": 2.5,
+        "uptime_percentage": 100.0,
+        "resource_utilization_efficiency": 1.0,
+    }
+
+
+def test_scenario_unknown_verify_key_surfaces_failure_into_report() -> None:
+    """An unmapped ``verify:`` key writes a verification-failure entry, not silence.
+
+    The chaos seam never silently drops a verify reference — a typo'd key
+    must be visible on ``results.json``, not just in the log, so the
+    operator can spot a broken cross-reference without trawling stdout.
+    """
+    spec = _build_spec(verify_key="not-in-mapping")
+
+    with (
+        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
+        patch.object(
+            GenerateLoadFault,
+            "inject",
+            lambda self, ctx, event: ChaosResult(
+                success=True, injected_fault=self.type, elapsed_time=0.0
+            ),
+        ),
+        patch.object(VerifierAgent, "wait_for_condition") as mock_wait,
+    ):
+        manager = ScenarioManager(
+            target_deployment="dep",
+            namespace="ns",
+            verification_mapping={"some-other-key": object()},
+            skip_port_forward=True,
+        )
+        manager.run_chaos_and_verification(spec, _build_ctx())
+
+    # Never called — the unknown key short-circuited before dispatch.
+    mock_wait.assert_not_called()
+    chaos_report, _ = manager.get_reports()
+    assert chaos_report["status"] == "success"
+    verification = chaos_report["verification"]
+    assert verification["success"] is False
+    assert verification["unresolved_reference"] == "not-in-mapping"
+    assert verification["known_references"] == ["some-other-key"]
+    assert "not found" in verification["reason"]
+
+
+def test_chaos_failure_lands_typed_error_into_report() -> None:
+    """A ``ChaosResult(success=False, error=...)`` flows into the chaos report."""
+    spec = _build_spec(verify_key=None)
+
+    def failing_inject(self, ctx, event):
+        return ChaosResult(
+            success=False,
+            injected_fault=self.type,
+            elapsed_time=0.0,
+            error="fortio not found",
+        )
+
+    with (
+        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
+        patch.object(GenerateLoadFault, "inject", failing_inject),
+    ):
+        manager = ScenarioManager(
+            target_deployment="dep",
+            namespace="ns",
+            skip_port_forward=True,
+        )
+        manager.run_chaos_and_verification(spec, _build_ctx())
+
+    chaos_report, _ = manager.get_reports()
+    assert chaos_report["status"] == "failed"
+    assert chaos_report["error"] == "fortio not found"
+
+
+def test_injection_exception_sets_chaos_active_event() -> None:
+    """A raising injection still sets the event so the main thread unblocks.
+
+    The main thread waits on ``chaos_active_event`` to learn the disruption is
+    active; if injection raises and the event is never set, it stalls for the
+    full activation timeout. The failure path must signal the event.
+    """
+    spec = _build_spec(verify_key=None)
+
+    def raising_inject(self, ctx, event):
+        raise RuntimeError("port-forward refused")
+
+    with (
+        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
+        patch.object(GenerateLoadFault, "inject", raising_inject),
+    ):
+        manager = ScenarioManager(
+            target_deployment="dep",
+            namespace="ns",
+            skip_port_forward=True,
+        )
+        manager.run_chaos_and_verification(spec, _build_ctx())
+
+    assert manager.chaos_active_event.is_set()
+    chaos_report, _ = manager.get_reports()
+    assert chaos_report["status"] == "failed"
+
+
+def test_stop_aborts_verification() -> None:
+    """``stop()`` is exception-safe and sets the abort flag once."""
+    manager = ScenarioManager(
+        target_deployment="dep",
+        namespace="ns",
+        skip_port_forward=True,
+    )
+    manager.stop()  # The fault owns the port-forward; stop only sets the flag.
+    assert manager._aborted.is_set()  # noqa: SLF001
+    # Idempotent — the second call must not raise.
+    manager.stop()
+
+
+def test_scenario_resolves_lb_ip_and_points_action_url_at_it() -> None:
+    """Real-cluster path: manager resolves the Service LB IP and rewrites the URL.
+
+    The harness no longer relies on a port-forward to reach the workload — it
+    reads ``status.loadBalancer.ingress[0].ip`` from the target Service and
+    rewrites the action's ``target.service_url`` to ``http://<ip>:8080`` so the
+    fortio spike hits the LB directly. The skip flag is set on ``ctx.env`` so
+    the fault does not also open a redundant tunnel.
+    """
+    from devops_bench.chaos.faults.generate_load import (
+        _ENV_SKIP_PORT_FORWARD,
+        _ENV_TARGET_DEPLOYMENT,
+        _ENV_TARGET_NAMESPACE,
+    )
+
+    spec = _build_spec(verify_key=None)
+    captured: dict[str, Any] = {}
+
+    def fake_inject(self: GenerateLoadFault, ctx: RunContext, event):
+        captured["env"] = dict(ctx.env)
+        captured["service_url"] = self.target.service_url
+        return ChaosResult(success=True, injected_fault=self.type, elapsed_time=0.0)
+
+    fake_svc = {"status": {"loadBalancer": {"ingress": [{"ip": "34.10.20.30"}]}}}
+
+    with (
+        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
+        patch.object(GenerateLoadFault, "inject", fake_inject),
+        patch(
+            "devops_bench.evalharness.scenario.get_resource",
+            return_value=fake_svc,
+        ) as get_resource_mock,
+    ):
+        manager = ScenarioManager(
+            target_deployment="dep",
+            namespace="ns",
+            skip_port_forward=False,
+        )
+        manager.run_chaos_and_verification(spec, _build_ctx())
+
+    # The Service was queried by deployment name in the right namespace.
+    get_resource_mock.assert_called_with("service", "dep", namespace="ns")
+    # The action's URL was rewritten to the LB endpoint, port 8080.
+    assert captured["service_url"] == "http://34.10.20.30:8080"
+    # Skip flag is set so the fault doesn't also open a port-forward.
+    assert captured["env"][_ENV_SKIP_PORT_FORWARD] == "1"
+    # Deployment / namespace are still threaded for the fallback path.
+    assert captured["env"][_ENV_TARGET_DEPLOYMENT] == "dep"
+    assert captured["env"][_ENV_TARGET_NAMESPACE] == "ns"
+
+
+def test_scenario_falls_back_to_port_forward_when_lb_ip_unavailable() -> None:
+    """When LB resolution times out, the manager leaves the skip flag unset.
+
+    The fault then opens its own ``kubectl port-forward`` to the target
+    deployment as the fallback transport — a degraded but functional path so
+    the run still attempts load.
+    """
+    from devops_bench.chaos.faults.generate_load import _ENV_SKIP_PORT_FORWARD
+
+    spec = _build_spec(verify_key=None)
+    captured: dict[str, Any] = {}
+
+    def fake_inject(self: GenerateLoadFault, ctx: RunContext, event):
+        captured["env"] = dict(ctx.env)
+        captured["service_url"] = self.target.service_url
+        return ChaosResult(success=True, injected_fault=self.type, elapsed_time=0.0)
+
+    # Service has no LB ingress assigned yet — every poll returns "not ready",
+    # and the bounded poll eventually gives up.
+    no_ip_svc = {"status": {"loadBalancer": {}}}
+
+    with (
+        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
+        patch.object(GenerateLoadFault, "inject", fake_inject),
+        patch(
+            "devops_bench.evalharness.scenario.get_resource",
+            return_value=no_ip_svc,
+        ),
+        # Make poll_until short-circuit to a single failed check so the test
+        # doesn't actually wait 180s on the wall clock.
+        patch(
+            "devops_bench.evalharness.scenario.poll_until",
+            return_value=False,
+        ) as poll_mock,
+    ):
+        manager = ScenarioManager(
+            target_deployment="dep",
+            namespace="ns",
+            skip_port_forward=False,
+        )
+        manager.run_chaos_and_verification(spec, _build_ctx())
+
+    poll_mock.assert_called_once()
+    # The action URL is untouched (no IP to rewrite to).
+    assert captured["service_url"] == "http://example.svc.cluster.local"
+    # And critically the skip flag is NOT set — the fault falls back to its
+    # port-forward to keep the run functional.
+    assert _ENV_SKIP_PORT_FORWARD not in captured["env"]
+
+
+def test_scenario_skips_lb_resolution_in_smoke_path() -> None:
+    """``skip_port_forward=True`` (smoke) never queries the cluster for an LB IP.
+
+    The smoke harness runs against NoOpDeployer with no real cluster, so
+    asking kubectl for a Service would either fail or accidentally hit the
+    operator's current context. The skip flag short-circuits both the
+    resolution and the port-forward.
+    """
+    from devops_bench.chaos.faults.generate_load import _ENV_SKIP_PORT_FORWARD
+
+    spec = _build_spec(verify_key=None)
+    captured: dict[str, Any] = {}
+
+    def fake_inject(self: GenerateLoadFault, ctx: RunContext, event):
+        captured["env"] = dict(ctx.env)
+        captured["service_url"] = self.target.service_url
+        return ChaosResult(success=True, injected_fault=self.type, elapsed_time=0.0)
+
+    with (
+        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
+        patch.object(GenerateLoadFault, "inject", fake_inject),
+        patch(
+            "devops_bench.evalharness.scenario.get_resource",
+            side_effect=AssertionError("smoke path must not query the cluster"),
+        ),
+        patch(
+            "devops_bench.evalharness.scenario.poll_until",
+            side_effect=AssertionError("smoke path must not poll"),
+        ),
+    ):
+        manager = ScenarioManager(
+            target_deployment="dep",
+            namespace="ns",
+            skip_port_forward=True,
+        )
+        manager.run_chaos_and_verification(spec, _build_ctx())
+
+    # Skip flag set, URL untouched, no kubectl / poll happened (the patches
+    # would have raised AssertionError otherwise).
+    assert captured["env"][_ENV_SKIP_PORT_FORWARD] == "1"
+    assert captured["service_url"] == "http://example.svc.cluster.local"
+
+
+def test_scenario_skips_lb_resolution_for_local_cluster() -> None:
+    """When the cluster is local (location='local'), skip LB resolution but keep port-forward fallback.
+
+    This avoids the 180s LoadBalancer IP resolution timeout on KinD, where
+    the Service type is ClusterIP and will never get an external IP, while
+    still allowing the port-forward tunnel to be opened.
+    """
+    from devops_bench.chaos.faults.generate_load import (
+        _ENV_SKIP_PORT_FORWARD,
+        _ENV_TARGET_DEPLOYMENT,
+        _ENV_TARGET_NAMESPACE,
+    )
+    from devops_bench.core.context import ClusterInfo
+
+    spec = _build_spec(verify_key=None)
+    captured: dict[str, Any] = {}
+
+    def fake_inject(self: GenerateLoadFault, ctx: RunContext, event):
+        captured["env"] = dict(ctx.env)
+        captured["service_url"] = self.target.service_url
+        return ChaosResult(success=True, injected_fault=self.type, elapsed_time=0.0)
+
+    # Local cluster info
+    local_cluster = ClusterInfo(name="my-kind", location="local")
+    ctx = _build_ctx()
+    ctx.cluster = local_cluster
+
+    with (
+        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
+        patch.object(GenerateLoadFault, "inject", fake_inject),
+        patch(
+            "devops_bench.evalharness.scenario.get_resource",
+            side_effect=AssertionError("local path must not query the cluster for LB"),
+        ),
+        patch(
+            "devops_bench.evalharness.scenario.poll_until",
+            side_effect=AssertionError("local path must not poll for LB"),
+        ),
+    ):
+        manager = ScenarioManager(
+            target_deployment="dep",
+            namespace="ns",
+            skip_port_forward=False,
+        )
+        manager.run_chaos_and_verification(spec, ctx)
+
+    assert captured["service_url"] == "http://example.svc.cluster.local"
+    assert _ENV_SKIP_PORT_FORWARD not in captured["env"]
+    assert captured["env"][_ENV_TARGET_DEPLOYMENT] == "dep"
+    assert captured["env"][_ENV_TARGET_NAMESPACE] == "ns"
+
+
+@pytest.fixture(autouse=True)
+def _no_real_kubectl(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Guard against this file accidentally shelling out to ``kubectl``.
+
+    Tests that don't exercise the port-forward path run with
+    ``skip_port_forward=True`` so the load fault never opens a tunnel; this guard
+    patches the ``subprocess.Popen`` the port-forward helper would use so a test
+    that forgets the flag (and isn't deliberately driving the port-forward path)
+    fails loudly instead of attempting a real port-forward.
+    """
+
+    def _boom(*args, **kwargs):  # pragma: no cover - exercised only on regression
+        raise RuntimeError("test attempted to spawn a real kubectl process")
+
+    monkeypatch.setattr("devops_bench.k8s.kubectl.subprocess.Popen", _boom)

--- a/tests/unit/evalharness/test_single_env_read.py
+++ b/tests/unit/evalharness/test_single_env_read.py
@@ -1,0 +1,177 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single ``BENCH_USE_MCP`` read site (CONVENTIONS.md §7 / harness handoff §2.2).
+
+The harness owns the only read of ``BENCH_USE_MCP``; the resolved boolean is
+threaded into both the agent's :class:`AgentConfig` (gates the MCP binding)
+and the metrics scoring call (``MetricContext.use_mcp``). This file pins the
+invariant so a future change cannot silently re-introduce the agent-vs-judge
+disagreement that motivated §7.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from devops_bench.evalharness.default import DefaultEvalHarness
+
+
+@pytest.fixture
+def isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip every ``BENCH_*`` / ``AGENT_*`` knob the harness reads.
+
+    Keeps the test from picking up the developer's shell env (e.g. an
+    ``AGENT_MCP_SERVER`` left over from a manual run) which would muddle the
+    capability assertions.
+    """
+    for var in (
+        "BENCH_USE_MCP",
+        "BENCH_AGENT_TYPE",
+        "BENCH_NO_INFRA",
+        "AGENT_MCP_SERVER",
+        "AGENT_ALLOWED_TOOLS",
+        "AGENT_SKILLS_PATHS",
+        "AGENT_RULES_TEXT",
+        "AGENT_TARGET",
+        "AGENT_MODEL",
+        "AGENT_PROVIDER",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_harness_reads_use_mcp_once_at_construction(
+    monkeypatch: pytest.MonkeyPatch, isolate_env: None
+) -> None:
+    """``BENCH_USE_MCP`` is read once during ``__init__``, not on every method."""
+    monkeypatch.setenv("BENCH_USE_MCP", "true")
+
+    with patch(
+        "devops_bench.evalharness.default.get_bool",
+        wraps=__import__("devops_bench.core", fromlist=["get_bool"]).get_bool,
+    ) as wrapped:
+        harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+
+        bench_use_mcp_reads = [
+            call for call in wrapped.call_args_list if call.args and call.args[0] == "BENCH_USE_MCP"
+        ]
+        # Exactly one harness-driven read of BENCH_USE_MCP at construction.
+        assert len(bench_use_mcp_reads) == 1
+        assert harness.use_mcp is True
+
+
+def test_use_mcp_flows_into_agent_capabilities_and_metrics(
+    monkeypatch: pytest.MonkeyPatch, isolate_env: None
+) -> None:
+    """The same resolved bool reaches the AgentConfig and the metrics call."""
+    monkeypatch.setenv("BENCH_USE_MCP", "false")
+    monkeypatch.setenv("AGENT_MCP_SERVER", "echo hi")
+    monkeypatch.setenv("AGENT_ALLOWED_TOOLS", "run_command")
+
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+
+    # Agent side: a False ``use_mcp`` gates off the MCP binding even when the
+    # env names a server — only the harness decides whether MCP runs.
+    config = harness.build_agent_config()
+    assert config.capabilities.mcp_servers == ()
+    assert config.capabilities.tools_enabled is False
+    assert harness.use_mcp is False
+
+    # Metrics side: the score path threads the same boolean as
+    # ``use_mcp=False`` into ``evaluate_metrics_batch``.
+    captured: dict = {}
+
+    def fake_batch(results: list[dict], judge: object, *, use_mcp: bool) -> None:
+        captured["use_mcp"] = use_mcp
+        captured["count"] = len(results)
+
+    monkeypatch.setattr(
+        "devops_bench.metrics.evaluate_metrics_batch",
+        fake_batch,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "devops_bench.metrics.get_judge_model",
+        lambda: object(),
+        raising=False,
+    )
+
+    harness._score([{"status": "success", "name": "t"}])  # noqa: SLF001
+    assert captured == {"use_mcp": False, "count": 1}
+
+
+def test_use_mcp_true_grants_mcp_binding(
+    monkeypatch: pytest.MonkeyPatch, isolate_env: None
+) -> None:
+    """A True ``use_mcp`` lets the env-declared MCP binding through."""
+    monkeypatch.setenv("BENCH_USE_MCP", "true")
+    monkeypatch.setenv("AGENT_MCP_SERVER", "/path/to/mcp")
+    monkeypatch.setenv("AGENT_ALLOWED_TOOLS", "tool_a,tool_b")
+
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+    config = harness.build_agent_config()
+
+    assert config.capabilities.tools_enabled is True
+    assert config.capabilities.mcp is not None
+    assert config.capabilities.allowed_tools == ("tool_a", "tool_b")
+
+
+def test_only_one_executable_use_mcp_read_in_repo(
+    monkeypatch: pytest.MonkeyPatch, isolate_env: None, tmp_path: Path
+) -> None:
+    """Only one *executable* ``BENCH_USE_MCP`` read site exists in the package.
+
+    Pinned as a test rather than a comment so a refactor that re-introduces a
+    second read site fails CI rather than passes review. Plain docstring
+    mentions ("never reads ``BENCH_USE_MCP``") are intentionally allowed —
+    the assertion is on actual calls into ``get_bool`` / ``os.environ``.
+    """
+    import re
+
+    devops_bench_root = Path(__file__).resolve().parents[3] / "devops_bench"
+    # Match every realistic way a Python module reads BENCH_USE_MCP — the
+    # core helpers (``get_bool``, ``get_env``, ``first_env``), the stdlib
+    # ``os.getenv`` / ``os.environ.get`` / ``os.environ[...]`` paths, and
+    # bare ``environ["..."]`` (e.g. ``from os import environ``). A reviewer
+    # eyeballing §7 compliance would search for any of these; codify the
+    # search so a sneaked-in second read fails CI instead of passing review.
+    read_pattern = re.compile(
+        r"("
+        r"get_bool|get_env|first_env|os\.getenv|"
+        r"os\.environ\.get|os\.environ\[|"
+        r"\bgetenv|\benviron\["
+        r")\s*\(?\s*[\"']BENCH_USE_MCP[\"']"
+    )
+    reads: dict[Path, int] = {}
+    for path in devops_bench_root.rglob("*.py"):
+        text = path.read_text()
+        matches = read_pattern.findall(text)
+        if matches:
+            reads[path.relative_to(devops_bench_root)] = len(matches)
+
+    # Allowed read sites (CONVENTIONS.md §7):
+    # * ``evalharness/default.py`` — the canonical single read site.
+    # * ``metrics/pipeline.py`` — a documented *fallback* the harness never
+    #   triggers (it always passes ``use_mcp=`` explicitly), retained for
+    #   legacy CLI callers running ``evaluate_metrics_batch`` directly.
+    assert set(reads.keys()) <= {
+        Path("evalharness/default.py"),
+        Path("metrics/pipeline.py"),
+    }, f"unexpected BENCH_USE_MCP reads in: {sorted(reads)}"
+    # Pin the harness file to exactly one read so an accidental second read
+    # site (e.g. from a per-task refresh) is caught here.
+    assert reads.get(Path("evalharness/default.py")) == 1


### PR DESCRIPTION
## What this adds

The evaluation harness:

- `evalharness/base.py` — the `Harness` abstract base.
- `evalharness/scenario.py` — the `ScenarioManager` (runs chaos + verification against a cluster, with port-forward helpers).
- `evalharness/artifacts.py` — workspace snapshot + generated-file collection.
- `evalharness/default.py` — `DefaultEvalHarness`: the task loop (provision → run agent → optional chaos/verify → score → teardown).
- `evalharness/__init__.py` — the package's public surface.

## Testing

Unit tests cover the base, scenario manager, and default harness (registry resolution, single-env reads, package-import laziness). `uv sync --frozen`, `ruff check`, `ruff format --check`, and `pytest` all pass. End-to-end and spec-parsing coverage that relies on concrete verifiers and task fixtures will follow as those land.

/kind feature

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end evaluation harness with agent execution, scoring, and JSON report outputs.
  * Introduced a scenario orchestrator for chaos injection and optional verification with aggregated chaos/performance reporting.
  * Added workspace artifact collection for newly generated outputs.
  * Added public package exports for harness and scenario tooling.
* **Bug Fixes**
  * Improved robustness so injection/verification/setup failures are recorded per task without aborting the full run.
  * Enhanced load-balancer URL and port-forward behavior, including graceful fallbacks and clearer unresolved verification reporting.
* **Tests**
  * Added unit coverage for scenario wiring, report handling, package import cleanliness, registry resolution, and single-read env conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->