### PR TITLE
feat(agents): add canonical token buckets shared across harnesses

### DIFF
--- a/devops_bench/agents/cli/gemini_cli/parsing.py
+++ b/devops_bench/agents/cli/gemini_cli/parsing.py
@@ -21,10 +21,11 @@ list and pulls the final text and aggregated token usage from ``result`` events.
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 
 from devops_bench.agents.result import ToolCall, empty_tokens
 
-__all__ = ["parse_stream_json"]
+__all__: list[str] = ["parse_stream_json"]
 
 
 def _int_or_none(value: object) -> int | None:
@@ -32,7 +33,7 @@ def _int_or_none(value: object) -> int | None:
     return value if isinstance(value, int) and not isinstance(value, bool) else None
 
 
-def _canonical_tokens(stats: dict) -> dict:
+def _canonical_tokens(stats: Mapping[str, object]) -> dict[str, int | None]:
     """Map the terminal ``result.stats`` block onto the canonical token buckets.
 
     The CLI reports ``input_tokens`` as the *full* prompt with ``cached`` as a

--- a/devops_bench/agents/cli/gemini_cli/parsing.py
+++ b/devops_bench/agents/cli/gemini_cli/parsing.py
@@ -22,9 +22,37 @@ from __future__ import annotations
 
 import json
 
-from devops_bench.agents.result import ToolCall
+from devops_bench.agents.result import ToolCall, empty_tokens
 
 __all__ = ["parse_stream_json"]
+
+
+def _int_or_none(value: object) -> int | None:
+    """Coerce to ``int``, rejecting ``bool`` (a JSON ``true`` is not a count)."""
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _canonical_tokens(stats: dict) -> dict:
+    """Map the terminal ``result.stats`` block onto the canonical token buckets.
+
+    The CLI reports ``input_tokens`` as the *full* prompt with ``cached`` as a
+    subset, and rolls thinking tokens into ``total_tokens`` only — so canonical
+    ``input`` is the difference, and ``reasoning`` is derived from the total gap
+    (``total - full_input - output``) when every part is reported.
+    """
+    full_input = _int_or_none(stats.get("input_tokens"))
+    output = _int_or_none(stats.get("output_tokens"))
+    total = _int_or_none(stats.get("total_tokens"))
+    cached = _int_or_none(stats.get("cached"))
+    inp = full_input - cached if full_input is not None and cached is not None else full_input
+    reasoning = None
+    if full_input is not None and output is not None and total is not None:
+        gap = total - full_input - output
+        if gap >= 0:
+            reasoning = gap
+    tokens = empty_tokens()
+    tokens.update(input=inp, cached=cached, reasoning=reasoning, output=output, total=total)
+    return tokens
 
 
 def parse_stream_json(stdout: str) -> tuple[str, list[dict], dict, list[str]]:
@@ -127,12 +155,7 @@ def parse_stream_json(stdout: str) -> tuple[str, list[dict], dict, list[str]]:
             stats = event.get("stats")
             usage = event.get("tokens") or event.get("usage")
             if isinstance(stats, dict):
-                tokens = {
-                    "input": stats.get("input_tokens"),
-                    "output": stats.get("output_tokens"),
-                    "total": stats.get("total_tokens"),
-                    "cached": stats.get("cached"),
-                }
+                tokens = _canonical_tokens(stats)
             elif isinstance(usage, dict):
                 tokens = usage
 

--- a/devops_bench/agents/cli/gemini_cli/parsing.py
+++ b/devops_bench/agents/cli/gemini_cli/parsing.py
@@ -39,13 +39,17 @@ def _canonical_tokens(stats: Mapping[str, object]) -> dict[str, int | None]:
     The CLI reports ``input_tokens`` as the *full* prompt with ``cached`` as a
     subset, and rolls thinking tokens into ``total_tokens`` only — so canonical
     ``input`` is the difference, and ``reasoning`` is derived from the total gap
-    (``total - full_input - output``) when every part is reported.
+    (``total - full_input - output``) when every part is reported. Both
+    subtractions are clamped at ``0`` so an over-reported ``cached`` (or a
+    rounding quirk) can never yield a negative bucket.
     """
     full_input = _int_or_none(stats.get("input_tokens"))
     output = _int_or_none(stats.get("output_tokens"))
     total = _int_or_none(stats.get("total_tokens"))
     cached = _int_or_none(stats.get("cached"))
-    inp = full_input - cached if full_input is not None and cached is not None else full_input
+    inp = (
+        max(full_input - cached, 0) if full_input is not None and cached is not None else full_input
+    )
     reasoning = None
     if full_input is not None and output is not None and total is not None:
         gap = total - full_input - output

--- a/devops_bench/agents/result.py
+++ b/devops_bench/agents/result.py
@@ -27,7 +27,7 @@ __all__: list[str] = ["AgentResult", "TOKEN_BUCKETS", "ToolCall", "empty_tokens"
 TOKEN_BUCKETS: tuple[str, ...] = ("input", "cached", "cache_write", "reasoning", "output", "total")
 
 
-def empty_tokens() -> dict[str, Any]:
+def empty_tokens() -> dict[str, int | None]:
     """Return the canonical token dict with every bucket ``None`` (unavailable)."""
     return dict.fromkeys(TOKEN_BUCKETS, None)
 

--- a/devops_bench/agents/result.py
+++ b/devops_bench/agents/result.py
@@ -19,12 +19,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-__all__ = ["ToolCall", "AgentResult", "TOKEN_BUCKETS", "empty_tokens"]
+__all__: list[str] = ["AgentResult", "TOKEN_BUCKETS", "ToolCall", "empty_tokens"]
 
 # Canonical token buckets every harness maps onto: ``input`` is the non-cached
 # prompt, ``cached`` is cache-read only (cache writes go in ``cache_write``),
 # ``output`` excludes ``reasoning``, and ``total`` is the sum of all buckets.
-TOKEN_BUCKETS = ("input", "cached", "cache_write", "reasoning", "output", "total")
+TOKEN_BUCKETS: tuple[str, ...] = ("input", "cached", "cache_write", "reasoning", "output", "total")
 
 
 def empty_tokens() -> dict[str, Any]:

--- a/devops_bench/agents/result.py
+++ b/devops_bench/agents/result.py
@@ -19,7 +19,17 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-__all__ = ["ToolCall", "AgentResult"]
+__all__ = ["ToolCall", "AgentResult", "TOKEN_BUCKETS", "empty_tokens"]
+
+# Canonical token buckets every harness maps onto: ``input`` is the non-cached
+# prompt, ``cached`` is cache-read only (cache writes go in ``cache_write``),
+# ``output`` excludes ``reasoning``, and ``total`` is the sum of all buckets.
+TOKEN_BUCKETS = ("input", "cached", "cache_write", "reasoning", "output", "total")
+
+
+def empty_tokens() -> dict[str, Any]:
+    """Return the canonical token dict with every bucket ``None`` (unavailable)."""
+    return dict.fromkeys(TOKEN_BUCKETS, None)
 
 
 @dataclass

--- a/devops_bench/results/__init__.py
+++ b/devops_bench/results/__init__.py
@@ -22,6 +22,7 @@ from devops_bench.results.aggregate import (
     rebatch_rows,
 )
 from devops_bench.results.normalize import (
+    NormalizedTokens,
     build_rows,
     derive_augmentation,
     extract_score,
@@ -34,6 +35,7 @@ from devops_bench.results.row import SCHEMA_VERSION, Manifest, ResultRow
 __all__ = [
     "SCHEMA_VERSION",
     "Manifest",
+    "NormalizedTokens",
     "ResultRow",
     "aggregate",
     "build_manifests",

--- a/devops_bench/results/normalize.py
+++ b/devops_bench/results/normalize.py
@@ -45,17 +45,22 @@ __all__ = [
 OUTCOME_SCORE_KEY = "OutcomeValidity"
 TOOL_SCORE_KEY = "ToolInvocation"
 
-# Token usage aliases per provider, in lookup priority. Kept in sync with
-# ``devops_bench.agents.api.agent.extract_tokens`` (API providers) and the CLI
-# parsers, which emit ``input`` / ``output``.
-_INPUT_TOKEN_KEYS = ("prompt_tokens", "prompt_token_count", "input_tokens", "input")
+# Token usage aliases per provider, in lookup priority. The canonical keys
+# (``input`` / ``cached`` / ``reasoning`` / ``output``; see
+# ``devops_bench.agents.result.TOKEN_BUCKETS``) come first; the rest keep
+# historical ``results.json`` records readable.
+_INPUT_TOKEN_KEYS = ("input", "prompt_tokens", "prompt_token_count", "input_tokens")
 _OUTPUT_TOKEN_KEYS = (
+    "output",
     "candidates_tokens",
     "candidates_token_count",
     "completion_tokens",
     "output_tokens",
-    "output",
 )
+_CACHED_TOKEN_KEYS = ("cached", "cache_read_input_tokens", "cached_content_token_count")
+_CACHE_WRITE_TOKEN_KEYS = ("cache_write", "cache_creation_input_tokens")
+_REASONING_TOKEN_KEYS = ("reasoning", "thoughts_token_count", "reasoning_tokens")
+_TOTAL_TOKEN_KEYS = ("total", "total_tokens", "total_token_count")
 
 # Runs of characters outside ``[a-z0-9]`` collapse to a single ``-``. Mirrors the
 # dashboard's ``catalog.mjs`` / seeder ``slugify`` so the model component of a
@@ -147,23 +152,33 @@ def _first_token(tokens: Mapping[str, Any], keys: tuple[str, ...]) -> int | None
     return None
 
 
-def normalize_tokens(tokens: Mapping[str, Any] | None) -> tuple[int | None, int | None]:
-    """Flatten a provider-defined token dict to ``(input_tokens, output_tokens)``.
+def normalize_tokens(
+    tokens: Mapping[str, Any] | None,
+) -> tuple[int | None, int | None, int | None, int | None, int | None, int | None]:
+    """Flatten a token dict to per-bucket counts.
 
-    Reads the first present alias for each direction across the known provider
-    shapes; an unreported direction yields ``None`` rather than ``0`` so the
-    dashboard can distinguish "no data" from a genuine zero.
+    Reads the first present alias for each bucket across the canonical shape
+    and the known historical provider shapes; an unreported bucket yields
+    ``None`` rather than ``0`` so the dashboard can distinguish "no data" from
+    a genuine zero. ``total`` semantics vary for pre-canonical records (some
+    eras exclude cached/reasoning); canonical records always report the full
+    footprint.
 
     Args:
         tokens: The record's ``tokens`` mapping, or ``None``.
 
     Returns:
-        An ``(input_tokens, output_tokens)`` pair, each ``int`` or ``None``.
+        An ``(input, output, cached, reasoning, cache_write, total)`` tuple of
+        token counts, each ``int`` or ``None``.
     """
     usage = tokens or {}
     return (
         _first_token(usage, _INPUT_TOKEN_KEYS),
         _first_token(usage, _OUTPUT_TOKEN_KEYS),
+        _first_token(usage, _CACHED_TOKEN_KEYS),
+        _first_token(usage, _REASONING_TOKEN_KEYS),
+        _first_token(usage, _CACHE_WRITE_TOKEN_KEYS),
+        _first_token(usage, _TOTAL_TOKEN_KEYS),
     )
 
 
@@ -208,7 +223,14 @@ def build_rows(records: Iterable[Mapping[str, Any]], manifest: Manifest) -> list
     rows: list[ResultRow] = []
     for record in records:
         scores = record.get("scores")
-        input_tokens, output_tokens = normalize_tokens(record.get("tokens"))
+        (
+            input_tokens,
+            output_tokens,
+            cached_tokens,
+            reasoning_tokens,
+            cache_write_tokens,
+            total_tokens,
+        ) = normalize_tokens(record.get("tokens"))
         rows.append(
             ResultRow(
                 setup_id=manifest.setup_id,
@@ -225,6 +247,10 @@ def build_rows(records: Iterable[Mapping[str, Any]], manifest: Manifest) -> list
                 latency_sec=float(record.get("latency") or 0.0),
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
+                cached_tokens=cached_tokens,
+                reasoning_tokens=reasoning_tokens,
+                cache_write_tokens=cache_write_tokens,
+                total_tokens=total_tokens,
                 status=record.get("status", "") or "",
                 validated=bool(record.get("validated", False)),
             )

--- a/devops_bench/results/normalize.py
+++ b/devops_bench/results/normalize.py
@@ -24,13 +24,14 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable, Mapping
-from typing import Any
+from typing import Any, NamedTuple
 
 from devops_bench.results.row import Manifest, ResultRow
 
 __all__ = [
     "OUTCOME_SCORE_KEY",
     "TOOL_SCORE_KEY",
+    "NormalizedTokens",
     "build_rows",
     "derive_augmentation",
     "extract_score",
@@ -152,9 +153,24 @@ def _first_token(tokens: Mapping[str, Any], keys: tuple[str, ...]) -> int | None
     return None
 
 
-def normalize_tokens(
-    tokens: Mapping[str, Any] | None,
-) -> tuple[int | None, int | None, int | None, int | None, int | None, int | None]:
+class NormalizedTokens(NamedTuple):
+    """Per-bucket token counts flattened from a provider ``tokens`` dict.
+
+    Each field is an ``int`` count or ``None`` when the bucket was unreported
+    (distinct from a genuine ``0``). Being a :class:`~typing.NamedTuple`, it
+    still unpacks and compares as a plain 6-tuple, so existing positional
+    callers keep working.
+    """
+
+    input: int | None
+    output: int | None
+    cached: int | None
+    reasoning: int | None
+    cache_write: int | None
+    total: int | None
+
+
+def normalize_tokens(tokens: Mapping[str, Any] | None) -> NormalizedTokens:
     """Flatten a token dict to per-bucket counts.
 
     Reads the first present alias for each bucket across the canonical shape
@@ -168,17 +184,17 @@ def normalize_tokens(
         tokens: The record's ``tokens`` mapping, or ``None``.
 
     Returns:
-        An ``(input, output, cached, reasoning, cache_write, total)`` tuple of
-        token counts, each ``int`` or ``None``.
+        A :class:`NormalizedTokens` of ``(input, output, cached, reasoning,
+        cache_write, total)`` counts, each ``int`` or ``None``.
     """
     usage = tokens or {}
-    return (
-        _first_token(usage, _INPUT_TOKEN_KEYS),
-        _first_token(usage, _OUTPUT_TOKEN_KEYS),
-        _first_token(usage, _CACHED_TOKEN_KEYS),
-        _first_token(usage, _REASONING_TOKEN_KEYS),
-        _first_token(usage, _CACHE_WRITE_TOKEN_KEYS),
-        _first_token(usage, _TOTAL_TOKEN_KEYS),
+    return NormalizedTokens(
+        input=_first_token(usage, _INPUT_TOKEN_KEYS),
+        output=_first_token(usage, _OUTPUT_TOKEN_KEYS),
+        cached=_first_token(usage, _CACHED_TOKEN_KEYS),
+        reasoning=_first_token(usage, _REASONING_TOKEN_KEYS),
+        cache_write=_first_token(usage, _CACHE_WRITE_TOKEN_KEYS),
+        total=_first_token(usage, _TOTAL_TOKEN_KEYS),
     )
 
 
@@ -223,14 +239,7 @@ def build_rows(records: Iterable[Mapping[str, Any]], manifest: Manifest) -> list
     rows: list[ResultRow] = []
     for record in records:
         scores = record.get("scores")
-        (
-            input_tokens,
-            output_tokens,
-            cached_tokens,
-            reasoning_tokens,
-            cache_write_tokens,
-            total_tokens,
-        ) = normalize_tokens(record.get("tokens"))
+        tokens = normalize_tokens(record.get("tokens"))
         rows.append(
             ResultRow(
                 setup_id=manifest.setup_id,
@@ -245,12 +254,12 @@ def build_rows(records: Iterable[Mapping[str, Any]], manifest: Manifest) -> list
                 outcome_score=extract_score(scores, OUTCOME_SCORE_KEY),
                 tool_score=extract_score(scores, TOOL_SCORE_KEY),
                 latency_sec=float(record.get("latency") or 0.0),
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                cached_tokens=cached_tokens,
-                reasoning_tokens=reasoning_tokens,
-                cache_write_tokens=cache_write_tokens,
-                total_tokens=total_tokens,
+                input_tokens=tokens.input,
+                output_tokens=tokens.output,
+                cached_tokens=tokens.cached,
+                reasoning_tokens=tokens.reasoning,
+                cache_write_tokens=tokens.cache_write,
+                total_tokens=tokens.total,
                 status=record.get("status", "") or "",
                 validated=bool(record.get("validated", False)),
             )

--- a/devops_bench/results/row.py
+++ b/devops_bench/results/row.py
@@ -102,8 +102,19 @@ class ResultRow(BaseModel):
             when the metric did not run (e.g. a failed task).
         tool_score: Tool-invocation judge score in ``[0, 1]``, or ``None``.
         latency_sec: Agent wall-clock seconds for the iteration.
-        input_tokens: Prompt token count, or ``None`` when unreported.
-        output_tokens: Completion token count, or ``None`` when unreported.
+        input_tokens: Non-cached prompt token count, or ``None`` when
+            unreported. (Historical records that predate the canonical token
+            schema may include cached tokens here.)
+        output_tokens: Visible completion token count (excludes reasoning
+            where the harness reports it), or ``None`` when unreported.
+        cached_tokens: Cache-read token count, or ``None`` when the harness
+            reports no cache telemetry.
+        reasoning_tokens: Thinking-token count, or ``None`` when unreported
+            (some providers bill thinking inside ``output_tokens``).
+        cache_write_tokens: Cache-creation token count (billed at a premium by
+            providers that report it), or ``None`` when unreported.
+        total_tokens: Provider-reported or bucket-sum total, or ``None`` when
+            unreported. Semantics vary for pre-canonical records.
         status: Terminal record status, ``"success"`` or ``"failed"``.
         validated: Whether the task is vetted as correct and eligible for the
             leaderboard; ingest gates promotion on this (default ``False``).
@@ -125,6 +136,10 @@ class ResultRow(BaseModel):
     latency_sec: float
     input_tokens: int | None
     output_tokens: int | None
+    cached_tokens: int | None = None
+    reasoning_tokens: int | None = None
+    cache_write_tokens: int | None = None
+    total_tokens: int | None = None
     status: str
     validated: bool = False
 

--- a/tests/unit/agents/test_agents_cli_gemini.py
+++ b/tests/unit/agents/test_agents_cli_gemini.py
@@ -363,6 +363,22 @@ def test_parse_stream_json_real_cli_schema() -> None:
     }
 
 
+def test_parse_stream_json_clamps_input_when_cached_exceeds_full_input() -> None:
+    """A ``cached`` count larger than ``input_tokens`` must not push canonical
+    ``input`` negative — the difference clamps at 0."""
+    blob = _stream(
+        {
+            "type": "result",
+            "status": "success",
+            "stats": {"input_tokens": 100, "cached": 250, "output_tokens": 10},
+        },
+    )
+    _, _, tokens, errors = parse_stream_json(blob)
+    assert errors == []
+    assert tokens["input"] == 0
+    assert tokens["cached"] == 250
+
+
 def test_parse_stream_json_marks_failed_tool_result_status_field() -> None:
     """A tool_result with ``status="error"`` (and no is_error flag) is failed."""
     blob = _stream(

--- a/tests/unit/agents/test_agents_cli_gemini.py
+++ b/tests/unit/agents/test_agents_cli_gemini.py
@@ -351,7 +351,16 @@ def test_parse_stream_json_real_cli_schema() -> None:
             "status": "completed",
         },
     ]
-    assert tokens == {"input": 31225, "output": 35, "total": 31489, "cached": 12173}
+    # Canonical buckets: input excludes the cached subset, and reasoning is
+    # derived from the total gap (total - full_input - output = thinking).
+    assert tokens == {
+        "input": 31225 - 12173,
+        "cached": 12173,
+        "cache_write": None,
+        "reasoning": 31489 - 31225 - 35,
+        "output": 35,
+        "total": 31489,
+    }
 
 
 def test_parse_stream_json_marks_failed_tool_result_status_field() -> None:

--- a/tests/unit/results/test_results_normalize.py
+++ b/tests/unit/results/test_results_normalize.py
@@ -87,27 +87,47 @@ def test_setup_id_matches_catalog_slug_for_dotted_model():
 # -- normalize_tokens --------------------------------------------------------
 
 
-def test_normalize_tokens_api_shape():
+def test_normalize_tokens_legacy_api_shape():
     tokens = {"prompt_tokens": 10, "candidates_tokens": 5, "total_tokens": 15}
-    assert normalize_tokens(tokens) == (10, 5)
+    assert normalize_tokens(tokens) == (10, 5, None, None, None, 15)
 
 
-def test_normalize_tokens_cli_shape():
-    assert normalize_tokens({"input": 7, "output": 3}) == (7, 3)
+def test_normalize_tokens_canonical_shape():
+    tokens = {
+        "input": 7,
+        "cached": 100,
+        "cache_write": None,
+        "reasoning": 4,
+        "output": 3,
+        "total": 114,
+    }
+    assert normalize_tokens(tokens) == (7, 3, 100, 4, None, 114)
 
 
 def test_normalize_tokens_google_metadata_shape():
     tokens = {"prompt_token_count": 8, "candidates_token_count": 4}
-    assert normalize_tokens(tokens) == (8, 4)
+    assert normalize_tokens(tokens) == (8, 4, None, None, None, None)
 
 
 def test_normalize_tokens_missing_yields_none():
-    assert normalize_tokens({}) == (None, None)
-    assert normalize_tokens(None) == (None, None)
+    assert normalize_tokens({}) == (None, None, None, None, None, None)
+    assert normalize_tokens(None) == (None, None, None, None, None, None)
+
+
+def test_normalize_tokens_none_valued_canonical_keys_fall_through():
+    # A canonical dict with None buckets must not mask values under legacy keys.
+    assert normalize_tokens({"input": None, "prompt_tokens": 9, "output": 2}) == (
+        9,
+        2,
+        None,
+        None,
+        None,
+        None,
+    )
 
 
 def test_normalize_tokens_float_coerced_to_int():
-    assert normalize_tokens({"input": 12.0, "output": 3.9}) == (12, 3)
+    assert normalize_tokens({"input": 12.0, "output": 3.9}) == (12, 3, None, None, None, None)
 
 
 # -- extract_score -----------------------------------------------------------
@@ -172,6 +192,10 @@ def test_build_rows_success_record():
         "latencySec": 42.5,
         "inputTokens": 100,
         "outputTokens": 20,
+        "cachedTokens": None,
+        "reasoningTokens": None,
+        "cacheWriteTokens": None,
+        "totalTokens": None,
         "status": "success",
         "validated": False,
     }
@@ -194,6 +218,10 @@ def test_build_rows_failed_record_has_null_scores_and_tokens():
     assert row.tool_score is None
     assert row.input_tokens is None
     assert row.output_tokens is None
+    assert row.cached_tokens is None
+    assert row.reasoning_tokens is None
+    assert row.cache_write_tokens is None
+    assert row.total_tokens is None
     assert row.iteration == 0
 
 
@@ -233,6 +261,10 @@ def test_result_row_keys_match_typescript_interface():
         "latencySec",
         "inputTokens",
         "outputTokens",
+        "cachedTokens",
+        "reasoningTokens",
+        "cacheWriteTokens",
+        "totalTokens",
         "validated",
     }
     row = build_rows(
@@ -263,3 +295,45 @@ def test_build_rows_propagates_validated():
     # Absent key defaults to False (unvetted tasks don't promote).
     default_row = build_rows([{"name": "t", "folder": "f", "status": "success"}], manifest)[0]
     assert default_row.to_dict()["validated"] is False
+
+
+def test_build_rows_carries_cached_and_reasoning():
+    record = {
+        "name": "t",
+        "folder": "f",
+        "status": "success",
+        "tokens": {
+            "input": 19052,
+            "cached": 12173,
+            "cache_write": None,
+            "reasoning": 229,
+            "output": 35,
+            "total": 31489,
+        },
+    }
+    row = build_rows([record], _manifest())[0]
+    assert row.input_tokens == 19052
+    assert row.cached_tokens == 12173
+    assert row.reasoning_tokens == 229
+    assert row.output_tokens == 35
+    assert row.total_tokens == 31489
+    assert row.cache_write_tokens is None
+
+
+def test_build_rows_carries_cache_write():
+    record = {
+        "name": "t",
+        "folder": "f",
+        "status": "success",
+        "tokens": {
+            "input": 5,
+            "cached": 1000,
+            "cache_write": 200,
+            "reasoning": None,
+            "output": 40,
+            "total": 1245,
+        },
+    }
+    row = build_rows([record], _manifest())[0]
+    assert row.cache_write_tokens == 200
+    assert row.total_tokens == 1245

--- a/tests/unit/results/test_results_normalize.py
+++ b/tests/unit/results/test_results_normalize.py
@@ -87,12 +87,12 @@ def test_setup_id_matches_catalog_slug_for_dotted_model():
 # -- normalize_tokens --------------------------------------------------------
 
 
-def test_normalize_tokens_legacy_api_shape():
+def test_normalize_tokens_legacy_api_shape() -> None:
     tokens = {"prompt_tokens": 10, "candidates_tokens": 5, "total_tokens": 15}
     assert normalize_tokens(tokens) == (10, 5, None, None, None, 15)
 
 
-def test_normalize_tokens_canonical_shape():
+def test_normalize_tokens_canonical_shape() -> None:
     tokens = {
         "input": 7,
         "cached": 100,
@@ -114,7 +114,7 @@ def test_normalize_tokens_missing_yields_none():
     assert normalize_tokens(None) == (None, None, None, None, None, None)
 
 
-def test_normalize_tokens_none_valued_canonical_keys_fall_through():
+def test_normalize_tokens_none_valued_canonical_keys_fall_through() -> None:
     # A canonical dict with None buckets must not mask values under legacy keys.
     assert normalize_tokens({"input": None, "prompt_tokens": 9, "output": 2}) == (
         9,
@@ -297,7 +297,7 @@ def test_build_rows_propagates_validated():
     assert default_row.to_dict()["validated"] is False
 
 
-def test_build_rows_carries_cached_and_reasoning():
+def test_build_rows_carries_cached_and_reasoning() -> None:
     record = {
         "name": "t",
         "folder": "f",
@@ -320,7 +320,7 @@ def test_build_rows_carries_cached_and_reasoning():
     assert row.cache_write_tokens is None
 
 
-def test_build_rows_carries_cache_write():
+def test_build_rows_carries_cache_write() -> None:
     record = {
         "name": "t",
         "folder": "f",


### PR DESCRIPTION
Adds one canonical token schema that agent harnesses map onto, and carries
the new buckets through to the result row.

    {"input", "cached", "cache_write", "reasoning", "output", "total"}   # None = unreported, never a fabricated 0

## Why

`input` means different things across providers today — some report the
uncached prompt, others the full prompt including cache hits — so raw
cross-harness token/cost comparisons are systematically skewed, and with
prompt caching on, cached tokens dominate a multi-turn run's prompt.
Reasoning tokens are also inconsistently bucketed. The anchor rule:
**`input` excludes cached tokens** (the convention usage leaderboards report).

## What's included

- **Shared schema** — `agents/result.py`: `TOKEN_BUCKETS` + `empty_tokens()`.
- **gemini CLI harness** — the terminal `result.stats` block maps to the
  canonical dict (`input = full input − cached`; `reasoning` derived from the
  total gap).
- **Row layer** — `ResultRow` gains `cachedTokens` / `reasoningTokens` /
  `cacheWriteTokens` / `totalTokens` (additive nullable fields, no
  `SCHEMA_VERSION` bump; historical rows stay valid). `normalize_tokens` reads
  the canonical keys first, with legacy aliases kept for older records.

## Verification

- Unit tests green (canonical + legacy + fall-through normalizer cases, the
  gemini `result.stats` mapping, and row round-trip with the new fields).
- `ruff check` and `ruff format --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded dashboard/token reporting to include cached, reasoning, cache-write, and total token counts alongside input/output.
  * Standardized canonical token breakdown for Gemini CLI stream results.
* **Bug Fixes**
  * Corrected token normalization to exclude cached prompt tokens from input and derive reasoning from token totals; clamps edge cases where cached exceeds full input.
  * Preserves “unreported vs zero” semantics by leaving missing buckets unset.
* **Tests**
  * Updated and extended unit tests to validate the new canonical 6-bucket token structure and the expanded dashboard row contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->