### PR TITLE
feat(antigravity): add the agy CLI agent harness

### DIFF
--- a/devops_bench/agents/cli/antigravity/__init__.py
+++ b/devops_bench/agents/cli/antigravity/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Antigravity CLI agent package."""
+
+from devops_bench.agents.cli.antigravity.agent import AgyCliAgent
+from devops_bench.agents.cli.antigravity.parsing import parse_session_jsonl
+
+__all__ = ["AgyCliAgent", "parse_session_jsonl"]

--- a/devops_bench/agents/cli/antigravity/agent.py
+++ b/devops_bench/agents/cli/antigravity/agent.py
@@ -1,0 +1,405 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Antigravity CLI agent harness driving the ``agy`` binary."""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import shutil
+import time
+from typing import TYPE_CHECKING
+
+from devops_bench import core
+from devops_bench.agents import base
+from devops_bench.agents import config as agents_config
+from devops_bench.agents import result as agents_result
+from devops_bench.agents.cli.antigravity import parsing
+from devops_bench.agents.shared import cli_capabilities
+from devops_bench.core import subprocess as devops_subprocess
+
+if TYPE_CHECKING:
+    from devops_bench.agents import capabilities
+
+__all__ = ["AgyCliAgent"]
+
+_log = core.get_logger("agents.cli.antigravity")
+
+_GCLOUD_LOOKUP_TIMEOUT_SEC = 10
+
+# agy flushes usage to the conversation DB asynchronously after process exit;
+# poll briefly for the rows before giving up.
+_DB_FLUSH_POLL_ATTEMPTS = 10
+_DB_FLUSH_POLL_INTERVAL_SEC = 0.25
+# Rows that decode to nothing mean schema drift, not an in-flight flush: allow
+# one recheck, then stop instead of burning the full poll budget.
+_UNDECODABLE_MAX_ATTEMPTS = 2
+
+
+def _read_db_tokens(db_path: pathlib.Path) -> dict | None:
+    """Read canonical token usage from the conversation DB.
+
+    Polls for the async flush while the DB reports ``pending``.
+
+    Args:
+        db_path: Path to the ``conversations/<uuid>.db`` file.
+
+    Returns:
+        The canonical token dict, or ``None`` when usage never materializes
+        (missing DB, or schema drift making the blobs undecodable).
+    """
+    undecodable_seen = 0
+    for attempt in range(_DB_FLUSH_POLL_ATTEMPTS):
+        state, tokens = parsing.db_token_state(db_path)
+        if state == "ready":
+            return tokens
+        if state == "absent":
+            return None
+        if state == "undecodable":
+            undecodable_seen += 1
+            if undecodable_seen >= _UNDECODABLE_MAX_ATTEMPTS:
+                return None
+        if attempt < _DB_FLUSH_POLL_ATTEMPTS - 1:
+            time.sleep(_DB_FLUSH_POLL_INTERVAL_SEC)
+    return None
+
+
+def _resolve_model_name(model: str) -> str:
+    """Resolve a provider-qualified model id to the bare name ``agy`` expects.
+
+    e.g. ``"google/gemini-3.5-flash"`` -> ``"gemini-3.5-flash"``.
+    """
+    return model.split("/")[-1]
+
+
+def _build_settings(
+    mcp_servers: tuple[capabilities.McpBinding, ...],
+    model: str | None,
+    project: str | None = None,
+    location: str | None = None,
+    *,
+    skills_enabled: bool = False,
+) -> dict:
+    """Assemble the Antigravity ``settings.json`` payload for a run."""
+    settings: dict = {}
+    servers = cli_capabilities.build_mcp_servers(mcp_servers)
+    if servers:
+        settings["mcpServers"] = servers
+    if skills_enabled:
+        settings["experimental"] = {"skills": True}
+    if model:
+        settings["modelConfigs"] = {"defaultModel": _resolve_model_name(model)}
+
+    # Add GCP block if project/location are provided (needed for GCA/GKE tools)
+    if project or location:
+        settings["gcp"] = {}
+        if project:
+            settings["gcp"]["project"] = project
+        if location:
+            settings["gcp"]["location"] = location
+
+    return settings
+
+
+def _build_env(config: agents_config.AgentConfig) -> dict[str, str]:
+    """Build the env overlay for the Antigravity CLI subprocess.
+
+    HOME must NOT be overridden to leverage cached OAuth/ADC credentials.
+    """
+    overlay: dict[str, str] = {
+        # Trust workspace so it doesn't block on untrusted folder warnings
+        "GEMINI_CLI_TRUST_WORKSPACE": "true",
+        # Disable OTLP exporters to avoid hangs in headless environments
+        "OTEL_TRACES_EXPORTER": "none",
+        "OTEL_METRICS_EXPORTER": "none",
+        "OTEL_LOGS_EXPORTER": "none",
+        "OTEL_SDK_DISABLED": "true",
+    }
+
+    if config.api_key:
+        overlay["GEMINI_API_KEY"] = config.api_key
+        overlay["GOOGLE_API_KEY"] = config.api_key
+    if config.model:
+        overlay["GEMINI_MODEL"] = _resolve_model_name(config.model)
+
+    if config.extra_env:
+        overlay.update(config.extra_env)
+
+    return overlay
+
+
+def _get_gcloud_project() -> str | None:
+    """Retrieve the default project from gcloud config if available."""
+    try:
+        result = devops_subprocess.run(
+            ["gcloud", "config", "get-value", "project"],
+            check=False,
+            timeout=_GCLOUD_LOOKUP_TIMEOUT_SEC,
+        )
+    except (OSError, core.SubprocessError) as exc:
+        _log.debug("gcloud project lookup failed: %s", exc)
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _get_gcloud_location() -> str | None:
+    """Retrieve the default region from gcloud config if available."""
+    try:
+        result = devops_subprocess.run(
+            ["gcloud", "config", "get-value", "compute/region"],
+            check=False,
+            timeout=_GCLOUD_LOOKUP_TIMEOUT_SEC,
+        )
+    except (OSError, core.SubprocessError) as exc:
+        _log.debug("gcloud location lookup failed: %s", exc)
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+@base.AGENTS.register("antigravity")
+class AgyCliAgent(base.AgentHarness):
+    """Antigravity CLI agent harness driving the ``agy`` binary.
+
+    Lays down capabilities (rules, MCP, skills) in the workspace
+    directory and spawns the ``agy`` binary. It preserves the user's real
+    HOME to leverage cached OAuth/ADC credentials. The trajectory is
+    extracted by parsing the generated transcript JSONL log file.
+    """
+
+    def __init__(self, config: agents_config.AgentConfig | None = None) -> None:
+        super().__init__(config)
+        caps = self.config.capabilities
+        self.mcp_servers = caps.mcp_servers
+        self.skills = caps.skills
+        self.rules = caps.rules
+
+    def _resolve_binary(self) -> str:
+        """Resolve the absolute path to the ``agy`` binary."""
+        if self.config.target:
+            return os.path.expanduser(self.config.target)
+        # Default installation path for antigravity-cli
+        candidate = os.path.expanduser("~/.local/bin/agy")
+        if os.path.exists(candidate):
+            return candidate
+        return "agy"
+
+    def _execute(
+        self, prompt: str, workspace_path: pathlib.Path | None = None
+    ) -> agents_result.AgentResult:
+        caps = self.config.capabilities
+        binary = self._resolve_binary()
+
+        env_overlay = _build_env(self.config)
+
+        with cli_capabilities.agent_workdir(workspace_path, prefix="agy-run-") as workdir:
+            gemini_dir = workdir / ".gemini"
+            # <gemini_dir>/antigravity-cli/ is the single directory agy reads
+            # its config from and writes its state to (see the OAuth token,
+            # conversations, and transcript paths below, and the global
+            # default documented in
+            # .agents/references/permission-configs/README.md).
+            agy_config_dir = gemini_dir / "antigravity-cli"
+            agy_config_dir.mkdir(parents=True, exist_ok=True)
+
+            # Resolve project and location
+            project = (
+                os.environ.get("GOOGLE_CLOUD_PROJECT")
+                or os.environ.get("GCP_PROJECT")
+                or _get_gcloud_project()
+            )
+            if project:
+                env_overlay["GOOGLE_CLOUD_PROJECT"] = project
+                env_overlay["GCP_PROJECT"] = project
+
+            location = (
+                os.environ.get("GOOGLE_CLOUD_LOCATION")
+                or os.environ.get("GCP_LOCATION")
+                or _get_gcloud_location()
+                or "us-central1"
+            )
+            if location:
+                env_overlay["GOOGLE_CLOUD_LOCATION"] = location
+                env_overlay["GCP_LOCATION"] = location
+
+            # Explicit gemini_dir keeps agy on the workspace settings, not real HOME.
+            argv = [
+                binary,
+                "--dangerously-skip-permissions",
+                f"--gemini_dir={gemini_dir}",
+            ]
+            if project:
+                argv.append(f"--project={project}")
+            if self.config.model:
+                argv.append(f"--model={_resolve_model_name(self.config.model)}")
+            argv.append(f"--prompt={prompt}")
+
+            # Write to both GEMINI.md (legacy) and .agents/AGENTS.md (modern)
+            if caps.rules.text:
+                (workdir / "GEMINI.md").write_text(caps.rules.text, encoding="utf-8")
+                agents_dir = workdir / ".agents"
+                agents_dir.mkdir(parents=True, exist_ok=True)
+                (agents_dir / "AGENTS.md").write_text(caps.rules.text, encoding="utf-8")
+
+            skill_names: list[str] = []
+            if caps.skills.paths:
+                skill_names = cli_capabilities.materialize_skills(
+                    agy_config_dir / "skills", caps.skills.paths
+                )
+
+            settings = _build_settings(
+                caps.mcp_servers,
+                self.config.model,
+                project,
+                location,
+                skills_enabled=bool(skill_names),
+            )
+            if settings:
+                (agy_config_dir / "settings.json").write_text(
+                    json.dumps(settings, indent=2), encoding="utf-8"
+                )
+
+            # Copy (not symlink) the OAuth token into the workspace: agy may
+            # refresh it in place during a run, and a symlink shared across
+            # concurrent runs would race on the one real file.
+            real_home = pathlib.Path.home()
+            real_token = real_home / ".gemini" / "antigravity-cli" / "antigravity-oauth-token"
+            copied_token: pathlib.Path | None = None
+            if real_token.exists():
+                target_token = agy_config_dir / "antigravity-oauth-token"
+                try:
+                    shutil.copy2(real_token, target_token)
+                    copied_token = target_token
+                    _log.info("Copied OAuth token from %s to %s", real_token, target_token)
+                except OSError as exc:
+                    _log.warning("Failed to copy OAuth token: %s", exc)
+            else:
+                _log.warning("Real OAuth token not found at %s", real_token)
+
+            completed: devops_subprocess.CompletedProcess | None = None
+            timeout_exc: core.SubprocessError | None = None
+            try:
+                completed = devops_subprocess.run(
+                    argv,
+                    extra_env=env_overlay,
+                    cwd=workdir,
+                    check=False,
+                    timeout=self.config.timeout_sec,
+                )
+            except core.SubprocessError as exc:
+                # check=False means this can only be a timeout. agy may have
+                # already written a partial transcript before being killed,
+                # so fall through to recover it instead of returning early
+                # and losing the workspace to the `with` block's cleanup.
+                timeout_exc = exc
+            except OSError as exc:
+                return agents_result.AgentResult.errored(
+                    f"antigravity-cli binary unavailable: {exc}"
+                )
+            finally:
+                # agy only needs the token while running. Remove the copy once it
+                # exits so the live credential never lingers in a workspace that
+                # is deliberately retained for artifact collection.
+                if copied_token is not None:
+                    copied_token.unlink(missing_ok=True)
+
+            # All logs and conversations land under agy_config_dir since we
+            # passed --gemini_dir.
+            conv_dir = agy_config_dir / "conversations"
+
+            session_text = ""
+            # Tokens live in the conversation DB, not the transcript; read them
+            # here while the per-run workdir still exists.
+            db_tokens: dict | None = None
+            if conv_dir.exists():
+                db_files = list(conv_dir.glob("*.db"))
+                if db_files:
+                    # Sort by modification time, newest first
+                    db_files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+                    latest_uuid = db_files[0].stem
+                    transcript_path = (
+                        agy_config_dir
+                        / "brain"
+                        / latest_uuid
+                        / ".system_generated"
+                        / "logs"
+                        / "transcript.jsonl"
+                    )
+                    if transcript_path.exists():
+                        session_text = transcript_path.read_text(encoding="utf-8")
+                    else:
+                        _log.warning("Transcript file not found: %s", transcript_path)
+                    db_tokens = _read_db_tokens(db_files[0])
+                else:
+                    _log.warning("No .db files found in %s", conv_dir)
+            else:
+                _log.warning("Conversations directory not found: %s", conv_dir)
+
+            if not session_text:
+                _log.warning("Failed to retrieve session log, falling back to empty")
+
+        # Output + trajectory come from the transcript; tokens prefer the DB,
+        # falling back to transcript-aggregated counts (old agy formats), else
+        # all-None so the row reads "unavailable" rather than a fake 0.
+        output, trajectory, transcript_tokens, parse_errors = parsing.parse_session_jsonl(
+            session_text
+        )
+        metadata: dict = {}
+        if db_tokens is not None:
+            tokens = db_tokens
+            metadata["token_source"] = "db"
+        elif any(transcript_tokens.get(k) for k in ("input", "output", "cached")):
+            # Old transcript shape: reasoning is folded into output and there is
+            # no cache_write; map onto the canonical buckets.
+            tokens = parsing.empty_tokens()
+            tokens.update(
+                input=transcript_tokens.get("input"),
+                cached=transcript_tokens.get("cached"),
+                output=transcript_tokens.get("output"),
+                total=transcript_tokens.get("total"),
+            )
+            metadata["token_source"] = "transcript"
+        else:
+            tokens = parsing.empty_tokens()
+            metadata["token_source"] = "unavailable"
+            _log.warning("No token usage recovered from conversation DB or transcript")
+
+        errors: list[str] = list(parse_errors)
+        if timeout_exc is not None:
+            errors.append(f"antigravity-cli subprocess error: {timeout_exc}")
+            if not output:
+                output = (timeout_exc.stdout or "").strip() or f"Error: {timeout_exc}"
+        elif completed.returncode != 0:
+            stderr = (completed.stderr or "").strip()
+            errors.append(f"agy exited {completed.returncode}: {stderr or '<no stderr>'}")
+            metadata["returncode"] = completed.returncode
+            if not output:
+                output = f"Error: agy exited {completed.returncode}"
+
+        # Fall back to raw stdout when the transcript yielded no output.
+        if not output and completed is not None and completed.stdout:
+            output = completed.stdout.strip()
+
+        return agents_result.AgentResult(
+            output=output,
+            trajectory=trajectory,
+            tokens=tokens,
+            errors=errors,
+            metadata=metadata,
+        )

--- a/devops_bench/agents/cli/antigravity/parsing.py
+++ b/devops_bench/agents/cli/antigravity/parsing.py
@@ -1,0 +1,479 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parser for Antigravity CLI session JSONL logs.
+
+Reconstructs the final message history by respecting ``$rewindTo`` and ``$set``
+control records, then extracts the canonical tool call trajectory, final output,
+and aggregated token usage.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sqlite3
+
+from devops_bench import core
+from devops_bench.agents import result as agents_result
+
+__all__ = ["parse_session_jsonl", "empty_tokens", "db_token_state"]
+
+_log = core.get_logger("agents.cli.antigravity.parsing")
+
+
+def _extract_text(content: object) -> str:
+    """Extract plain text from a message content field."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, dict) and isinstance(part.get("text"), str):
+                parts.append(part["text"])
+            elif isinstance(part, str):
+                parts.append(part)
+        return "".join(parts)
+    return ""
+
+
+def _parse_tool_result(result_list: list) -> tuple[str, str]:
+    """Parse a tool result list into a (result_text, status) tuple."""
+    text_parts = []
+    status = "completed"
+
+    for item in result_list:
+        if not isinstance(item, dict):
+            continue
+
+        # Check for functionResponse structure
+        func_resp = item.get("functionResponse")
+        if isinstance(func_resp, dict):
+            response = func_resp.get("response")
+            if isinstance(response, dict):
+                # Look for explicit output
+                output = response.get("output")
+                if output is not None:
+                    text_parts.append(output if isinstance(output, str) else json.dumps(output))
+
+                # Check for error indicators
+                if response.get("error") or response.get("is_error") or response.get("failed"):
+                    status = "error"
+            else:
+                text_parts.append(json.dumps(func_resp))
+        else:
+            # Fallback for other result shapes
+            text_parts.append(json.dumps(item))
+
+    return "\n".join(text_parts), status
+
+
+def parse_transcript_jsonl(jsonl_text: str) -> tuple[str, list[dict], dict, list[str]]:
+    """Parse Antigravity CLI transcript.jsonl into the canonical shape."""
+    errors: list[str] = []
+    trajectory: list[agents_result.ToolCall] = []
+    output_parts: list[str] = []
+    aggregated_tokens = {"input": 0, "output": 0, "total": 0, "cached": 0}
+
+    pending_tool_calls: list[agents_result.ToolCall] = []
+
+    for lineno, raw in enumerate(jsonl_text.splitlines(), start=1):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            errors.append(f"transcript line {lineno} parse error: {exc}")
+            continue
+        if not isinstance(record, dict):
+            continue
+
+        stype = record.get("type")
+        source = record.get("source")
+
+        # Aggregate tokens if present
+        if "tokens" in record and isinstance(record["tokens"], dict):
+            t = record["tokens"]
+            aggregated_tokens["input"] += t.get("input", 0)
+            aggregated_tokens["output"] += t.get("output", 0)
+            aggregated_tokens["cached"] += t.get("cached", 0)
+
+        if source == "MODEL":
+            if stype == "PLANNER_RESPONSE":
+                # If it has content, it's a text response
+                if "content" in record and record["content"]:
+                    output_parts.append(record["content"])
+
+                # If it has tool calls, queue them
+                if "tool_calls" in record and isinstance(record["tool_calls"], list):
+                    for tc in record["tool_calls"]:
+                        if isinstance(tc, dict):
+                            pending_tool_calls.append(
+                                agents_result.ToolCall(
+                                    name=tc.get("name", ""),
+                                    args=tc.get("args") or {},
+                                )
+                            )
+            else:
+                # This is a tool execution result! Match it with the first pending call.
+                if pending_tool_calls:
+                    call = pending_tool_calls.pop(0)
+                    call.result = record.get("content") or record.get("error") or ""
+                    call.status = "completed" if record.get("status") == "DONE" else "error"
+                    trajectory.append(call)
+                # else: ignore tool results that don't match any pending call
+        elif stype == "ERROR_MESSAGE" and record.get("content"):
+            errors.append(f"System error: {record['content']}")
+
+    # If there are still pending tool calls at the end, they were probably interrupted
+    for call in pending_tool_calls:
+        call.status = "interrupted"
+        trajectory.append(call)
+
+    aggregated_tokens["total"] = (
+        aggregated_tokens["input"] + aggregated_tokens["output"] + aggregated_tokens["cached"]
+    )
+    output = "".join(output_parts)
+    return output, [call.to_dict() for call in trajectory], aggregated_tokens, errors
+
+
+def parse_session_jsonl(jsonl_text: str) -> tuple[str, list[dict], dict, list[str]]:
+    """Parse Antigravity CLI session JSONL into the canonical shape.
+
+    Automatically detects if the format is the old session log or the new
+    transcript log and delegates accordingly.
+    """
+    if not jsonl_text:
+        return "", [], {"input": 0, "output": 0, "total": 0, "cached": 0}, ["Empty session log"]
+
+    # Detect format from the first non-empty line's parsed keys, not a raw
+    # substring match (a user message that merely contains the text
+    # "step_index" would otherwise be misrouted).
+    first_record: dict | None = None
+    for line in io.StringIO(jsonl_text):  # lazy: only the first non-empty line is read
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            break
+        if isinstance(parsed, dict):
+            first_record = parsed
+        break
+
+    if first_record is not None and "step_index" in first_record:
+        return parse_transcript_jsonl(jsonl_text)
+
+    # Fallback to old parser
+    return _parse_old_session_jsonl(jsonl_text)
+
+
+def _parse_old_session_jsonl(jsonl_text: str) -> tuple[str, list[dict], dict, list[str]]:
+    """Old parser for Antigravity CLI session JSONL logs."""
+    errors: list[str] = []
+    message_ids: list[str] = []
+    messages_by_id: dict[str, dict] = {}
+
+    # 1. Reconstruct final history by applying rewinds
+    for lineno, raw in enumerate(jsonl_text.splitlines(), start=1):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            errors.append(f"session line {lineno} parse error: {exc}")
+            continue
+        if not isinstance(record, dict):
+            continue
+
+        if "$rewindTo" in record:
+            rewind_id = str(record["$rewindTo"])
+            if rewind_id in message_ids:
+                idx = message_ids.index(rewind_id)
+                # Keep everything up to the rewind target, discard the rest
+                for removed in message_ids[idx + 1 :]:
+                    messages_by_id.pop(removed, None)
+                del message_ids[idx + 1 :]
+            else:
+                # If target not found, clear everything (defensive)
+                message_ids.clear()
+                messages_by_id.clear()
+        elif "$set" in record and isinstance(record["$set"], dict):
+            continue  # control record, not a chat message
+        elif "id" in record and "type" in record:
+            mid = str(record["id"])
+            if mid not in messages_by_id:
+                message_ids.append(mid)
+            messages_by_id[mid] = record
+        elif "sessionId" in record:
+            continue  # session header, not a chat message
+
+    # 2. Extract trajectory, output, and tokens from the reconstructed messages
+    trajectory: list[agents_result.ToolCall] = []
+    output_parts: list[str] = []
+    aggregated_tokens = {"input": 0, "output": 0, "total": 0, "cached": 0}
+
+    for mid in message_ids:
+        msg = messages_by_id[mid]
+        mtype = msg.get("type")
+
+        if mtype in ("gemini", "agent", "assistant"):
+            # Extract text output
+            content_text = _extract_text(msg.get("content", ""))
+            if content_text:
+                output_parts.append(content_text)
+
+            # Extract tool calls
+            tool_calls_data = msg.get("toolCalls")
+            if isinstance(tool_calls_data, list):
+                for tc in tool_calls_data:
+                    if not isinstance(tc, dict):
+                        continue
+
+                    name = tc.get("name", "")
+                    args = tc.get("args") or tc.get("arguments") or {}
+
+                    # Parse result and status
+                    result_text = None
+                    status = "called"
+                    result_data = tc.get("result")
+
+                    if isinstance(result_data, list):
+                        result_text, status = _parse_tool_result(result_data)
+                    elif result_data is not None:
+                        result_text = (
+                            result_data if isinstance(result_data, str) else json.dumps(result_data)
+                        )
+                        status = "completed"
+
+                    call = agents_result.ToolCall(
+                        name=name,
+                        args=args if isinstance(args, dict) else {},
+                        result=result_text,
+                        status=status,
+                    )
+                    trajectory.append(call)
+
+            # Aggregate tokens
+            msg_tokens = msg.get("tokens")
+            if isinstance(msg_tokens, dict):
+                aggregated_tokens["input"] += msg_tokens.get("input", 0)
+                output_cnt = msg_tokens.get("output", 0)
+                thoughts_cnt = msg_tokens.get("thoughts", 0)
+                tool_cnt = msg_tokens.get("tool", 0)
+                aggregated_tokens["output"] += output_cnt + thoughts_cnt + tool_cnt
+                aggregated_tokens["cached"] += msg_tokens.get("cached", 0)
+
+    aggregated_tokens["total"] = (
+        aggregated_tokens["input"] + aggregated_tokens["output"] + aggregated_tokens["cached"]
+    )
+
+    output = "".join(output_parts)
+    return output, [call.to_dict() for call in trajectory], aggregated_tokens, errors
+
+
+# Harness-local until the unified token schema lands: input = non-cached prompt,
+# cached = cache reads, output excludes reasoning, total = sum of all buckets.
+_TOKEN_BUCKETS = ("input", "cached", "cache_write", "reasoning", "output", "total")
+
+
+def empty_tokens() -> dict:
+    """Return the canonical token dict with every bucket ``None`` (unavailable)."""
+    return dict.fromkeys(_TOKEN_BUCKETS, None)
+
+
+# --- Token usage from the conversation DB ----------------------------------
+#
+# agy persists a per-turn usage record in the conversation DB
+# (``gen_metadata.data`` blob) at protobuf wire path ``.1.4``:
+#
+#   f2 -> input (non-cached), f5 -> cached, f9 -> reasoning, f10 -> output,
+#   f3 == f9 + f10 (integrity guard; there is no cache-write field).
+#
+# The format is private and version-sensitive: reads are guarded by the f3
+# invariant and yield all-``None`` on mismatch (never a fake 0). Side-call usage
+# (e.g. title generation) is not stored here, so totals cover the main
+# trajectory only (~0.2% low observed).
+
+# Tables agy creates before the usage flush lands; their presence distinguishes
+# "flush pending, retry" from "not an agy DB / nothing to wait for".
+_AGY_DB_TABLES = frozenset({"trajectory_meta", "steps"})
+
+
+def _read_varint(buf: bytes, i: int) -> tuple[int, int]:
+    """Decode a base-128 varint at ``buf[i:]``; return ``(value, next_index)``."""
+    shift = 0
+    result = 0
+    while i < len(buf):
+        byte = buf[i]
+        result |= (byte & 0x7F) << shift
+        i += 1
+        if not byte & 0x80:
+            return result, i
+        shift += 7
+        if shift >= 64:
+            raise ValueError("varint too long")
+    raise ValueError("truncated varint")
+
+
+def _parse_message(buf: bytes) -> list[tuple[int, int, object]] | None:
+    """Parse protobuf wire bytes into ``(field_num, wire_type, value)`` triples.
+
+    Returns ``None`` when ``buf`` is not a clean protobuf message (e.g. it is a
+    UTF-8 string rather than a sub-message), so callers can safely probe any
+    length-delimited field without misparsing text.
+    """
+    fields: list[tuple[int, int, object]] = []
+    i, n = 0, len(buf)
+    try:
+        while i < n:
+            key, i = _read_varint(buf, i)
+            field_num, wire = key >> 3, key & 7
+            if wire == 0:  # varint
+                val, i = _read_varint(buf, i)
+                fields.append((field_num, 0, val))
+            elif wire == 2:  # length-delimited
+                ln, i = _read_varint(buf, i)
+                if i + ln > n:
+                    return None
+                fields.append((field_num, 2, buf[i : i + ln]))
+                i += ln
+            elif wire == 5:  # 32-bit: bounds-check and skip (no consumer)
+                if i + 4 > n:
+                    return None
+                i += 4
+            elif wire == 1:  # 64-bit: bounds-check and skip (no consumer)
+                if i + 8 > n:
+                    return None
+                i += 8
+            else:  # groups (3/4) / unknown: not a message we understand
+                return None
+    except ValueError:
+        return None
+    return fields
+
+
+def _collect_usage(buf: bytes, out: list[dict], depth: int = 0) -> None:
+    """Recursively collect usage records (``f3 == f9 + f10``)."""
+    if depth > 12:
+        return
+    fields = _parse_message(buf)
+    if fields is None:
+        return
+    v = {fn: val for fn, wt, val in fields if wt == 0}
+    # proto3 omits zero-valued scalars: a fully-cached turn omits f2 and a
+    # thinking-only turn omits f10, so require f3 plus at least one of f9/f10.
+    # f3 > 0 keeps config-shaped noise records (f3=0, no f9/f10) from matching.
+    if 3 in v and v[3] > 0 and (9 in v or 10 in v) and v[3] == v.get(9, 0) + v.get(10, 0):
+        out.append(
+            {
+                "input": v.get(2, 0),
+                "cached": v.get(5, 0),
+                "reasoning": v.get(9, 0),
+                "output": v.get(10, 0),
+            }
+        )
+    for _fn, wire, val in fields:
+        if wire == 2 and isinstance(val, bytes | bytearray) and len(val) >= 2:
+            _collect_usage(val, out, depth + 1)
+
+
+def _turn_usage(blob: bytes) -> dict | None:
+    """Return the main-generation usage record for one blob.
+
+    The record is mirrored at two wire paths with identical values; picking the
+    largest-total record dedups the mirrors and keeps any smaller side-call
+    record from shadowing the real turn.
+    """
+    records: list[dict] = []
+    _collect_usage(bytes(blob), records)
+    if not records:
+        return None
+    return max(records, key=lambda r: r["input"] + r["cached"] + r["reasoning"] + r["output"])
+
+
+def db_token_state(db_path: str | os.PathLike[str]) -> tuple[str, dict | None]:
+    """Read canonical token usage from an ``agy`` conversation DB.
+
+    Returns:
+        A ``(state, tokens)`` tuple so the caller can handle the async flush:
+
+        * ``("ready", tokens)`` — usage decoded; ``tokens`` is the canonical dict.
+        * ``("pending", None)`` — an ``agy`` DB whose usage rows have not flushed
+          yet (retry after a short wait).
+        * ``("undecodable", None)`` — usage rows exist but none matches the
+          expected layout (schema drift; retrying will not help).
+        * ``("absent", None)`` — no DB, not an ``agy`` DB, or unreadable.
+
+    Buckets are summed per-turn across ``gen_metadata``. ``cached`` is a genuine
+    ``0`` when no turn hit the cache (protobuf omits the field when zero);
+    ``cache_write`` is always ``None``. ``total`` is the full footprint
+    (input + cached + reasoning + output), the same quantity as Gemini's
+    provider ``total_tokens``.
+    """
+    if not db_path or not os.path.exists(db_path):
+        return "absent", None
+    # The DB is read during agy's post-exit flush window, so a read can hit a
+    # locked/half-written image (OperationalError/DatabaseError). Those are
+    # transient -> "pending" so the poll retries; only genuinely unusable DBs
+    # (e.g. InterfaceError) are terminal "absent".
+    try:
+        con = sqlite3.connect(f"file:{os.fspath(db_path)}?mode=ro", uri=True)
+    except (sqlite3.OperationalError, sqlite3.DatabaseError):
+        return "pending", None
+    except sqlite3.Error:
+        return "absent", None
+
+    totals = {"input": 0, "cached": 0, "reasoning": 0, "output": 0}
+    saw_row = False
+    seen_turn = False
+    try:
+        tables = {r[0] for r in con.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        if "gen_metadata" not in tables:
+            return ("pending", None) if tables & _AGY_DB_TABLES else ("absent", None)
+        # Stream the cursor: peak memory is one blob, not the whole turn history.
+        for (blob,) in con.execute("SELECT data FROM gen_metadata ORDER BY idx"):
+            saw_row = True
+            if not isinstance(blob, bytes | bytearray):
+                continue
+            usage = _turn_usage(blob)
+            if usage is None:
+                continue
+            seen_turn = True
+            for key in totals:
+                totals[key] += usage[key]
+    except (sqlite3.OperationalError, sqlite3.DatabaseError):
+        return "pending", None
+    except sqlite3.Error:
+        return "absent", None
+    finally:
+        con.close()
+
+    if not saw_row:
+        return "pending", None  # table created but rows not flushed yet
+    if not seen_turn:
+        return "undecodable", None  # rows flushed, but no usage record matched
+    tokens = empty_tokens()
+    tokens.update(
+        input=totals["input"],
+        cached=totals["cached"],
+        reasoning=totals["reasoning"],
+        output=totals["output"],
+        total=totals["input"] + totals["cached"] + totals["reasoning"] + totals["output"],
+    )
+    return "ready", tokens

--- a/tests/unit/agents/test_agents_cli_antigravity.py
+++ b/tests/unit/agents/test_agents_cli_antigravity.py
@@ -1,0 +1,776 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.agents.cli.antigravity."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sqlite3
+from types import SimpleNamespace
+from unittest import mock
+
+from devops_bench.agents import capabilities
+from devops_bench.agents import config as agents_config
+from devops_bench.agents.cli.antigravity import agent as agy_mod
+from devops_bench.agents.cli.antigravity import parsing
+from devops_bench.core import subprocess as devops_subprocess
+from devops_bench.core.errors import SubprocessError
+
+
+def _jsonl(*records: dict) -> str:
+    """Render a list of records as a JSONL blob."""
+    return "\n".join(json.dumps(record) for record in records) + "\n"
+
+
+SAMPLE_SESSION = _jsonl(
+    {"sessionId": "session-123"},
+    {
+        "id": "msg-1",
+        "type": "user",
+        "content": "List GKE clusters and get details of cluster-a",
+    },
+    {
+        "id": "msg-2",
+        "type": "gemini",
+        "content": "",
+        "toolCalls": [
+            {
+                "name": "mcp_gke_list_clusters",
+                "args": {"project": "p1"},
+                "result": [
+                    {
+                        "functionResponse": {
+                            "name": "mcp_gke_list_clusters",
+                            "response": {"output": "cluster-a, cluster-b"},
+                        }
+                    }
+                ],
+            }
+        ],
+        "tokens": {"input": 10, "output": 5},
+    },
+    {
+        "id": "msg-3",
+        "type": "gemini",
+        "content": "I found cluster-a. Let me get its details.",
+        "toolCalls": [
+            {
+                "name": "mcp_gke_get_cluster",
+                "args": {"cluster": "cluster-a"},
+                "result": [
+                    {
+                        "functionResponse": {
+                            "name": "mcp_gke_get_cluster",
+                            "response": {"output": "v1.30", "is_error": False},
+                        }
+                    }
+                ],
+            }
+        ],
+        "tokens": {"input": 15, "output": 8},
+    },
+    {
+        "id": "msg-4",
+        "type": "gemini",
+        "content": "Done. Cluster-a is running v1.30.",
+        "tokens": {"input": 20, "output": 10},
+    },
+)
+
+SAMPLE_TRANSCRIPT = _jsonl(
+    {
+        "step_index": 0,
+        "source": "USER_EXPLICIT",
+        "type": "USER_INPUT",
+        "status": "DONE",
+        "content": "Configure redirect",
+    },
+    {
+        "step_index": 2,
+        "source": "MODEL",
+        "type": "PLANNER_RESPONSE",
+        "status": "DONE",
+        "tool_calls": [
+            {
+                "name": "run_command",
+                "args": {"CommandLine": "pwd"},
+            }
+        ],
+    },
+    {
+        "step_index": 3,
+        "source": "MODEL",
+        "type": "RUN_COMMAND",
+        "status": "DONE",
+        "content": "/workspace",
+    },
+    {
+        "step_index": 5,
+        "source": "MODEL",
+        "type": "PLANNER_RESPONSE",
+        "status": "DONE",
+        "content": "Done configuring redirect",
+    },
+)
+
+
+def test_parse_session_jsonl_emits_canonical_trajectory():
+    output, trajectory, tokens, errors = parsing.parse_session_jsonl(SAMPLE_SESSION)
+    assert output == "I found cluster-a. Let me get its details.Done. Cluster-a is running v1.30."
+    assert tokens == {"input": 45, "output": 23, "total": 68, "cached": 0}
+    assert errors == []
+    assert trajectory == [
+        {
+            "name": "mcp_gke_list_clusters",
+            "args": {"project": "p1"},
+            "result": "cluster-a, cluster-b",
+            "status": "completed",
+        },
+        {
+            "name": "mcp_gke_get_cluster",
+            "args": {"cluster": "cluster-a"},
+            "result": "v1.30",
+            "status": "completed",
+        },
+    ]
+
+
+def test_parse_old_session_total_includes_cached_tokens():
+    # Regression: total must include cached (input + output + cached), matching
+    # the DB-path convention, not input + output alone.
+    session = _jsonl(
+        {"sessionId": "s"},
+        {
+            "id": "m1",
+            "type": "gemini",
+            "content": "done",
+            "tokens": {"input": 10, "output": 5, "cached": 100},
+        },
+    )
+    _output, _trajectory, tokens, _errors = parsing.parse_session_jsonl(session)
+    assert tokens == {"input": 10, "output": 5, "cached": 100, "total": 115}
+
+
+def test_parse_transcript_total_includes_cached_tokens():
+    # Same convention for the newer step_index transcript format.
+    transcript = _jsonl(
+        {"step_index": 0, "source": "USER_EXPLICIT", "type": "USER_INPUT", "content": "hi"},
+        {
+            "step_index": 1,
+            "source": "MODEL",
+            "type": "PLANNER_RESPONSE",
+            "status": "DONE",
+            "content": "done",
+            "tokens": {"input": 10, "output": 5, "cached": 100},
+        },
+    )
+    _output, _trajectory, tokens, _errors = parsing.parse_session_jsonl(transcript)
+    assert tokens == {"input": 10, "output": 5, "cached": 100, "total": 115}
+
+
+def test_parse_session_jsonl_handles_rewinds():
+    session_with_rewind = _jsonl(
+        {"sessionId": "session-123"},
+        {"id": "msg-1", "type": "user", "content": "hello"},
+        {
+            "id": "msg-2",
+            "type": "gemini",
+            "content": "thought 1",
+            "toolCalls": [{"name": "tool1", "args": {}}],
+        },
+        # Rewind back to msg-1 (effectively discarding msg-2)
+        {"$rewindTo": "msg-1"},
+        {
+            "id": "msg-3",
+            "type": "gemini",
+            "content": "thought 2",
+            "toolCalls": [{"name": "tool2", "args": {}, "result": "ok"}],
+        },
+    )
+    output, trajectory, _tokens, errors = parsing.parse_session_jsonl(session_with_rewind)
+    assert output == "thought 2"
+    assert errors == []
+    assert len(trajectory) == 1
+    assert trajectory[0]["name"] == "tool2"
+
+
+def test_parse_session_jsonl_handles_tool_errors():
+    session_with_error = _jsonl(
+        {
+            "id": "msg-1",
+            "type": "gemini",
+            "toolCalls": [
+                {
+                    "name": "fail_tool",
+                    "args": {},
+                    "result": [
+                        {
+                            "functionResponse": {
+                                "name": "fail_tool",
+                                "response": {"output": "permission denied", "is_error": True},
+                            }
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    _, trajectory, _, _ = parsing.parse_session_jsonl(session_with_error)
+    assert trajectory[0]["status"] == "error"
+    assert trajectory[0]["result"] == "permission denied"
+
+
+def test_parse_transcript_jsonl():
+    output, trajectory, tokens, errors = parsing.parse_session_jsonl(SAMPLE_TRANSCRIPT)
+    assert output == "Done configuring redirect"
+    assert errors == []
+    assert trajectory == [
+        {
+            "name": "run_command",
+            "args": {"CommandLine": "pwd"},
+            "result": "/workspace",
+            "status": "completed",
+        }
+    ]
+
+
+def test_parse_transcript_jsonl_marks_non_done_result_as_error():
+    transcript = _jsonl(
+        {"step_index": 0, "source": "USER_EXPLICIT", "type": "USER_INPUT", "content": "go"},
+        {
+            "step_index": 1,
+            "source": "MODEL",
+            "type": "PLANNER_RESPONSE",
+            "tool_calls": [{"name": "run_command", "args": {"CommandLine": "false"}}],
+        },
+        {
+            "step_index": 2,
+            "source": "MODEL",
+            "type": "RUN_COMMAND",
+            "status": "FAILED",
+            "content": "command not found",
+        },
+    )
+    _, trajectory, _, _ = parsing.parse_session_jsonl(transcript)
+    assert trajectory == [
+        {
+            "name": "run_command",
+            "args": {"CommandLine": "false"},
+            "result": "command not found",
+            "status": "error",
+        }
+    ]
+
+
+def test_parse_transcript_jsonl_marks_trailing_pending_calls_as_interrupted():
+    transcript = _jsonl(
+        {"step_index": 0, "source": "USER_EXPLICIT", "type": "USER_INPUT", "content": "go"},
+        {
+            "step_index": 1,
+            "source": "MODEL",
+            "type": "PLANNER_RESPONSE",
+            "tool_calls": [{"name": "long_running_tool", "args": {}}],
+        },
+        # No matching result record follows: the run ended mid-tool-call.
+    )
+    _, trajectory, _, _ = parsing.parse_session_jsonl(transcript)
+    assert trajectory == [
+        {
+            "name": "long_running_tool",
+            "args": {},
+            "result": None,
+            "status": "interrupted",
+        }
+    ]
+
+
+def test_build_settings_renders_mcp_and_model():
+    mcp = capabilities.McpBinding(name="gke", command=("gke-mcp", "run"))
+    settings = agy_mod._build_settings(
+        (mcp,), "google/gemini-3.5-flash", "my-project", "us-east1", skills_enabled=True
+    )
+
+    assert settings["experimental"]["skills"] is True
+    assert settings["modelConfigs"]["defaultModel"] == "gemini-3.5-flash"
+    assert settings["mcpServers"]["gke"] == {
+        "command": "gke-mcp",
+        "args": ["run"],
+    }
+    assert settings["gcp"] == {
+        "project": "my-project",
+        "location": "us-east1",
+    }
+
+
+def test_build_settings_omits_skills_block_when_disabled():
+    settings = agy_mod._build_settings((), "google/gemini-3.5-flash")
+
+    assert "experimental" not in settings
+    # No mcp servers, project, or location either: only modelConfigs remains.
+    assert settings == {"modelConfigs": {"defaultModel": "gemini-3.5-flash"}}
+
+
+def test_build_env_sets_auth_and_presets():
+    config = agents_config.AgentConfig(
+        model="gemini-3.5-flash",
+        api_key="secret-key",
+    )
+    env = agy_mod._build_env(config)
+
+    assert "HOME" not in env  # HOME must not be overridden
+    assert env["GEMINI_CLI_TRUST_WORKSPACE"] == "true"
+    assert env["GEMINI_API_KEY"] == "secret-key"
+    assert env["GOOGLE_API_KEY"] == "secret-key"
+    assert env["GEMINI_MODEL"] == "gemini-3.5-flash"
+    assert env["OTEL_SDK_DISABLED"] == "true"
+
+
+def test_build_env_resolves_provider_qualified_model_name():
+    # GEMINI_MODEL must match the bare id used by --model= and modelConfigs,
+    # not the raw "provider/model" form.
+    config = agents_config.AgentConfig(model="google/gemini-3.5-flash")
+    env = agy_mod._build_env(config)
+
+    assert env["GEMINI_MODEL"] == "gemini-3.5-flash"
+
+
+@mock.patch.object(pathlib.Path, "home")
+@mock.patch.object(devops_subprocess, "run")
+def test_agy_cli_agent_execute_flow(mock_run, mock_home, tmp_path):
+    # Mock Path.home() to return a temp directory to avoid polluting real HOME
+    mock_home.return_value = tmp_path
+
+    mock_run.return_value = SimpleNamespace(
+        args=["agy"],
+        returncode=0,
+        stdout="Success",
+        stderr="",
+    )
+
+    # Mock the session file writing that agy would do in the mocked HOME
+    def side_effect(*args, **kwargs):
+        cwd = kwargs.get("cwd") or tmp_path
+        root_dir = cwd / ".gemini" / "antigravity-cli"
+        conv_dir = root_dir / "conversations"
+        conv_dir.mkdir(parents=True, exist_ok=True)
+        uuid = "test-uuid-123"
+        (conv_dir / f"{uuid}.db").write_text("", encoding="utf-8")
+
+        transcript_dir = root_dir / "brain" / uuid / ".system_generated" / "logs"
+        transcript_dir.mkdir(parents=True, exist_ok=True)
+        (transcript_dir / "transcript.jsonl").write_text(SAMPLE_SESSION, encoding="utf-8")
+        return mock_run.return_value
+
+    mock_run.side_effect = side_effect
+
+    config = agents_config.AgentConfig(
+        target="/bin/agy",
+        model="gemini-3.5-flash",
+        capabilities=capabilities.AllCapabilities(),
+    )
+    agent = agy_mod.AgyCliAgent(config)
+
+    result = agent._execute("run task")
+
+    assert (
+        result.output
+        == "I found cluster-a. Let me get its details.Done. Cluster-a is running v1.30."
+    )
+    assert len(result.trajectory) == 2
+    assert result.errors == []
+    assert mock_run.called
+
+    # Verify argv
+    args = mock_run.call_args[0][0]
+    assert args[0] == "/bin/agy"
+    assert "--dangerously-skip-permissions" in args
+    assert "--prompt=run task" in args
+    assert any(a.startswith("--gemini_dir=") for a in args)
+
+
+def _write_sample_transcript(
+    cwd: pathlib.Path, *, db_turns: list[bytes] | None = None, transcript: str | None = None
+) -> None:
+    """Lay down agy's on-disk session layout: transcript + conversation DB.
+
+    ``db_turns`` populates a conversation DB with usage records; ``None`` writes
+    an empty file (no usage). ``transcript`` defaults to ``SAMPLE_SESSION``.
+    """
+    root_dir = cwd / ".gemini" / "antigravity-cli"
+    conv_dir = root_dir / "conversations"
+    conv_dir.mkdir(parents=True, exist_ok=True)
+    uuid = "test-uuid-123"
+    if db_turns is None:
+        (conv_dir / f"{uuid}.db").write_text("", encoding="utf-8")
+    else:
+        _make_conv_db(conv_dir / f"{uuid}.db", db_turns)
+    transcript_dir = root_dir / "brain" / uuid / ".system_generated" / "logs"
+    transcript_dir.mkdir(parents=True, exist_ok=True)
+    (transcript_dir / "transcript.jsonl").write_text(
+        SAMPLE_SESSION if transcript is None else transcript, encoding="utf-8"
+    )
+
+
+@mock.patch.object(pathlib.Path, "home")
+@mock.patch.object(devops_subprocess, "run")
+def test_agy_cli_agent_execute_flow_nonzero_exit_records_error_and_metadata(
+    mock_run, mock_home, tmp_path
+):
+    mock_home.return_value = tmp_path
+    mock_run.return_value = SimpleNamespace(args=["agy"], returncode=1, stdout="", stderr="boom")
+
+    def side_effect(*args, **kwargs):
+        _write_sample_transcript(kwargs.get("cwd") or tmp_path)
+        return mock_run.return_value
+
+    mock_run.side_effect = side_effect
+
+    config = agents_config.AgentConfig(
+        target="/bin/agy",
+        model="gemini-3.5-flash",
+        capabilities=capabilities.AllCapabilities(),
+    )
+    result = agy_mod.AgyCliAgent(config)._execute("run task")
+
+    assert result.errors == ["agy exited 1: boom"]
+    assert result.metadata["returncode"] == 1
+    # The transcript was still recovered even though the run failed.
+    assert "Cluster-a is running v1.30" in result.output
+
+
+@mock.patch.object(pathlib.Path, "home")
+@mock.patch.object(devops_subprocess, "run")
+def test_agy_cli_agent_execute_flow_missing_transcript_falls_back_to_stdout(
+    mock_run, mock_home, tmp_path
+):
+    mock_home.return_value = tmp_path
+    # No side_effect: agy writes no conversations/transcript this run.
+    mock_run.return_value = SimpleNamespace(
+        args=["agy"], returncode=0, stdout="raw agy stdout", stderr=""
+    )
+
+    config = agents_config.AgentConfig(
+        target="/bin/agy",
+        model="gemini-3.5-flash",
+        capabilities=capabilities.AllCapabilities(),
+    )
+    result = agy_mod.AgyCliAgent(config)._execute("run task")
+
+    assert result.output == "raw agy stdout"
+    assert result.trajectory == []
+    assert "Empty session log" in result.errors
+
+
+def test_empty_tokens_all_none():
+    assert parsing.empty_tokens() == {
+        "input": None,
+        "cached": None,
+        "cache_write": None,
+        "reasoning": None,
+        "output": None,
+        "total": None,
+    }
+
+
+# --- token usage from the conversation DB ----------------------------------
+
+
+def _pb_varint(n: int) -> bytes:
+    out = bytearray()
+    while True:
+        b = n & 0x7F
+        n >>= 7
+        out.append(b | 0x80 if n else b)
+        if not n:
+            return bytes(out)
+
+
+def _pb_vfield(field_num: int, val: int) -> bytes:
+    return _pb_varint(field_num << 3) + _pb_varint(val)  # wire type 0
+
+
+def _pb_lfield(field_num: int, payload: bytes) -> bytes:
+    return _pb_varint(field_num << 3 | 2) + _pb_varint(len(payload)) + payload  # wire type 2
+
+
+def _usage_blob(inp, cached, reasoning, output, *, f3=None):
+    """Build a gen_metadata blob with a usage record at wire path .1.4.
+
+    Fields: f2=input, f5=cached, f9=reasoning, f10=output, f3=f9+f10.
+    Zero-valued scalars are omitted, mirroring proto3 wire encoding.
+    """
+    stats = b""
+    if inp:
+        stats += _pb_vfield(2, inp)
+    if cached:
+        stats += _pb_vfield(5, cached)
+    if reasoning:
+        stats += _pb_vfield(9, reasoning)
+    if output:
+        stats += _pb_vfield(10, output)
+    stats += _pb_vfield(3, reasoning + output if f3 is None else f3)
+    return _pb_lfield(1, _pb_lfield(4, stats))  # outer{1: mid{4: stats}} -> .1.4
+
+
+def _make_conv_db(path, turns, *, with_gen_metadata=True):
+    con = sqlite3.connect(path)
+    con.execute("CREATE TABLE trajectory_meta (trajectory_id text)")
+    con.execute("INSERT INTO trajectory_meta VALUES ('t')")
+    if with_gen_metadata:
+        con.execute("CREATE TABLE gen_metadata (idx integer, data blob, size integer)")
+        for i, blob in enumerate(turns):
+            con.execute("INSERT INTO gen_metadata VALUES (?, ?, ?)", (i, blob, len(blob)))
+    con.commit()
+    con.close()
+
+
+def test_db_token_state_ready_single_turn(tmp_path):
+    db = tmp_path / "conv.db"
+    _make_conv_db(db, [_usage_blob(14882, 0, 0, 7)])
+    state, tokens = parsing.db_token_state(db)
+    assert state == "ready"
+    assert tokens == {
+        "input": 14882,
+        "cached": 0,
+        "cache_write": None,
+        "reasoning": 0,
+        "output": 7,
+        "total": 14889,
+    }
+
+
+def test_db_token_state_sums_turns_with_cache_read(tmp_path):
+    db = tmp_path / "conv.db"
+    _make_conv_db(db, [_usage_blob(16592, 0, 234, 51), _usage_blob(4752, 12200, 352, 50)])
+    state, tokens = parsing.db_token_state(db)
+    assert state == "ready"
+    assert tokens["input"] == 16592 + 4752
+    assert tokens["cached"] == 12200  # f5
+    assert tokens["reasoning"] == 234 + 352
+    assert tokens["output"] == 51 + 50
+    assert tokens["cache_write"] is None
+    assert (
+        tokens["total"]
+        == tokens["input"] + tokens["cached"] + tokens["reasoning"] + tokens["output"]
+    )
+
+
+def test_db_token_state_counts_fully_cached_turn(tmp_path):
+    # A turn served entirely from cache omits input_tokens (proto3 drops zero
+    # fields); it must still be counted, not dropped.
+    db = tmp_path / "conv.db"
+    _make_conv_db(db, [_usage_blob(0, 12000, 30, 20)])
+    state, tokens = parsing.db_token_state(db)
+    assert state == "ready"
+    assert tokens["input"] == 0
+    assert tokens["cached"] == 12000
+    assert tokens["reasoning"] == 30
+    assert tokens["output"] == 20
+    assert tokens["total"] == 12050
+
+
+def test_db_token_state_counts_thinking_only_turn(tmp_path):
+    # A turn with zero response tokens omits f10 (proto3); it must still be
+    # counted via f3 == f9.
+    db = tmp_path / "conv.db"
+    _make_conv_db(db, [_usage_blob(8000, 0, 500, 0)])
+    state, tokens = parsing.db_token_state(db)
+    assert state == "ready"
+    assert tokens["input"] == 8000
+    assert tokens["reasoning"] == 500
+    assert tokens["output"] == 0
+
+
+def test_db_token_state_rejects_noise_record_with_zero_f3(tmp_path):
+    # Config-shaped noise (f3 present but 0, no f9/f10) must not match.
+    noise = _pb_lfield(1, _pb_lfield(4, _pb_vfield(1, 50) + _pb_vfield(3, 0) + _pb_vfield(5, 1)))
+    db = tmp_path / "conv.db"
+    _make_conv_db(db, [noise])
+    assert parsing.db_token_state(db) == ("undecodable", None)
+
+
+def test_db_token_state_undecodable_when_invariant_fails(tmp_path):
+    # f3 != f9 + f10 -> schema drift, terminal.
+    db = tmp_path / "conv.db"
+    _make_conv_db(db, [_usage_blob(100, 0, 9, 5, f3=999)])
+    assert parsing.db_token_state(db) == ("undecodable", None)
+
+
+def test_db_token_state_pending_when_usage_not_flushed(tmp_path):
+    # No gen_metadata table yet, or table exists with zero rows: flush pending.
+    db1 = tmp_path / "conv1.db"
+    _make_conv_db(db1, [], with_gen_metadata=False)
+    assert parsing.db_token_state(db1) == ("pending", None)
+    db2 = tmp_path / "conv2.db"
+    _make_conv_db(db2, [])
+    assert parsing.db_token_state(db2) == ("pending", None)
+
+
+def test_db_token_state_pending_on_transient_read_error(tmp_path, monkeypatch):
+    # A locked/half-written DB during agy's async post-exit flush raises a
+    # transient sqlite error; it must be retryable ("pending"), not terminal
+    # ("absent"), so the poll loop waits for the flush to finish.
+    db = tmp_path / "conv.db"
+    _make_conv_db(db, [_usage_blob(100, 0, 9, 5)])
+
+    class _LockedCon:
+        def execute(self, *_args, **_kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(parsing.sqlite3, "connect", lambda *a, **k: _LockedCon())
+    assert parsing.db_token_state(db) == ("pending", None)
+
+
+def test_db_token_state_absent_for_missing_or_nonconversation_db(tmp_path):
+    assert parsing.db_token_state(tmp_path / "nope.db") == ("absent", None)
+    empty = tmp_path / "empty.db"
+    empty.write_bytes(b"")  # 0-byte file -> valid empty sqlite, no agy tables
+    assert parsing.db_token_state(empty) == ("absent", None)
+
+
+@mock.patch.object(pathlib.Path, "home")
+@mock.patch.object(devops_subprocess, "run")
+def test_agy_cli_agent_execute_flow_timeout_recovers_partial_transcript(
+    mock_run, mock_home, tmp_path
+):
+    # Regression test: core.subprocess.run raises SubprocessError on a timeout
+    # even with check=False. The transcript agy wrote before being killed
+    # must still be recovered instead of being lost with the tempdir.
+    mock_home.return_value = tmp_path
+
+    def side_effect(*args, **kwargs):
+        cwd = kwargs.get("cwd")
+        if cwd is None:
+            return SimpleNamespace(args=["gcloud"], returncode=1, stdout="", stderr="")
+        _write_sample_transcript(cwd)
+        raise SubprocessError(["agy"], returncode=-1, stdout="", stderr="")
+
+    mock_run.side_effect = side_effect
+
+    config = agents_config.AgentConfig(
+        target="/bin/agy",
+        model="gemini-3.5-flash",
+        capabilities=capabilities.AllCapabilities(),
+        timeout_sec=1,
+    )
+    result = agy_mod.AgyCliAgent(config)._execute("run task")
+
+    assert len(result.trajectory) == 2
+    assert any("subprocess error" in e for e in result.errors)
+
+
+@mock.patch.object(pathlib.Path, "home")
+@mock.patch.object(devops_subprocess, "run")
+def test_agy_cli_agent_execute_reads_tokens_from_db(mock_run, mock_home, tmp_path):
+    # Tokens (incl. cached) come from the conversation DB; output + trajectory
+    # from the transcript.
+    mock_home.return_value = tmp_path
+    result_ns = SimpleNamespace(args=["agy"], returncode=0, stdout="done", stderr="")
+
+    def side_effect(*args, **kwargs):
+        cwd = kwargs.get("cwd")
+        if cwd is None:
+            return SimpleNamespace(args=["gcloud"], returncode=1, stdout="", stderr="")
+        _write_sample_transcript(cwd, db_turns=[_usage_blob(4752, 12200, 30, 20)])
+        return result_ns
+
+    mock_run.side_effect = side_effect
+
+    config = agents_config.AgentConfig(
+        target="/bin/agy",
+        model="gemini-3.5-flash",
+        capabilities=capabilities.AllCapabilities(),
+    )
+    result = agy_mod.AgyCliAgent(config)._execute("run task")
+
+    assert result.tokens == {
+        "input": 4752,
+        "cached": 12200,
+        "cache_write": None,
+        "reasoning": 30,
+        "output": 20,
+        "total": 4752 + 12200 + 30 + 20,
+    }
+    assert result.metadata["token_source"] == "db"
+    assert len(result.trajectory) == 2
+
+
+@mock.patch.object(pathlib.Path, "home")
+@mock.patch.object(devops_subprocess, "run")
+def test_agy_cli_agent_execute_falls_back_to_transcript_tokens(mock_run, mock_home, tmp_path):
+    # DB has no usage but the (old-format) transcript carries per-record tokens:
+    # fall back to those instead of reporting all-None.
+    mock_home.return_value = tmp_path
+    plain = SimpleNamespace(args=["agy"], returncode=0, stdout="plain text output", stderr="")
+
+    def side_effect(*args, **kwargs):
+        cwd = kwargs.get("cwd")
+        if cwd is None:
+            return SimpleNamespace(args=["gcloud"], returncode=1, stdout="", stderr="")
+        _write_sample_transcript(cwd)  # empty .db; SAMPLE_SESSION has tokens
+        return plain
+
+    mock_run.side_effect = side_effect
+
+    config = agents_config.AgentConfig(
+        target="/bin/agy",
+        model="gemini-3.5-flash",
+        capabilities=capabilities.AllCapabilities(),
+    )
+    result = agy_mod.AgyCliAgent(config)._execute("run task")
+
+    # SAMPLE_SESSION sums: input 45, output 23, total 68, cached 0; reasoning and
+    # cache_write are unknowable from the old shape.
+    assert result.tokens == {
+        "input": 45,
+        "cached": 0,
+        "cache_write": None,
+        "reasoning": None,
+        "output": 23,
+        "total": 68,
+    }
+    assert result.metadata["token_source"] == "transcript"
+
+
+@mock.patch.object(pathlib.Path, "home")
+@mock.patch.object(devops_subprocess, "run")
+def test_agy_cli_agent_execute_emits_none_tokens_when_no_source(mock_run, mock_home, tmp_path):
+    # No usage in the DB and a token-less (new-format) transcript -> all-None
+    # (never a fabricated zero), flagged as unavailable.
+    mock_home.return_value = tmp_path
+    plain = SimpleNamespace(args=["agy"], returncode=0, stdout="plain text output", stderr="")
+
+    def side_effect(*args, **kwargs):
+        cwd = kwargs.get("cwd")
+        if cwd is None:
+            return SimpleNamespace(args=["gcloud"], returncode=1, stdout="", stderr="")
+        _write_sample_transcript(cwd, transcript=SAMPLE_TRANSCRIPT)  # no tokens anywhere
+        return plain
+
+    mock_run.side_effect = side_effect
+
+    config = agents_config.AgentConfig(
+        target="/bin/agy",
+        model="gemini-3.5-flash",
+        capabilities=capabilities.AllCapabilities(),
+    )
+    result = agy_mod.AgyCliAgent(config)._execute("run task")
+
+    assert result.tokens == parsing.empty_tokens()
+    assert result.metadata["token_source"] == "unavailable"


### PR DESCRIPTION
Adds the Antigravity (`agy`) CLI agent harness, alongside the existing `gemini`
and `oc` harnesses. It stages the task working directory, spawns the `agy`
binary, parses the transcript into the canonical trajectory, and reports token
usage read from `agy`'s conversation DB.

## Token accounting

`agy` does not expose usage on the transcript. It persists a per-turn usage
record in the conversation DB (`conversations/<uuid>.db`, `gen_metadata`
protobuf blob) at wire path `.1.4`:

`f2`=input (non-cached), `f5`=cached, `f9`=reasoning, `f10`=output, `f3`=f9+f10.

- Decode that as the primary token source → `{input, cached, cache_write: None,
  reasoning, output, total}`, summed per turn; poll for `agy`'s async DB flush
  (transient reads during the flush window are retried, not treated as terminal).
- Guarded: the `f3 == f9 + f10` invariant rejects non-matching records;
  undecodable rows (schema drift) stop the poll early; anything unrecoverable
  yields all-`None`, never a fabricated 0.
- Fall back to transcript-aggregated counts for formats that carry per-record tokens.
- `metadata.token_source` records which source fed the run (`db` / `transcript` / `unavailable`).

## Notes / limitations

- The DB format is private and version-sensitive (re-verify on `agy` upgrade);
  the decoder can be dropped once `agy` exposes usage headlessly.
- Side-call usage (e.g. title generation) is not stored in `gen_metadata`;
  totals cover the main trajectory (~0.2% low observed).
- The copied OAuth token is removed once `agy` exits, so the credential does not
  linger in a workspace retained for artifact collection.

## Verification

- 29 unit tests for the decoder, poll/state machine, and fallback paths.
- `ruff check` / `ruff format --check` clean; full `tests/unit/agents` suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running tasks through the Antigravity CLI agent.
  * Added workspace-isolated configuration for skills, models, MCP servers, authentication, and optional cloud settings.
  * Added parsing for session and transcript logs, including tool activity, rewinds, errors, output, and token usage.
  * Added reliable token reporting with database and transcript fallbacks.
* **Bug Fixes**
  * Improved recovery of output and partial transcripts after failures, missing logs, or timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->