### PR TITLE
feat(agents): add the API agent with MCP and skills support

### DIFF
--- a/devops_bench/agents/api/__init__.py
+++ b/devops_bench/agents/api/__init__.py
@@ -1,0 +1,29 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""API/MCP agent harness driving the shared :func:`run_tool_loop` primitive.
+
+The concrete harness lives in :mod:`devops_bench.agents.api.agent` and
+self-registers under ``"api"`` via ``@AGENTS.register`` — importing this
+package triggers that registration (matching the CLI harness packages), so
+``AGENTS.get("api")`` works after ``import devops_bench.agents.api``. Heavy
+optional dependencies (the ``mcp`` SDK, ``deepeval``, provider SDKs) still
+load only at call time.
+"""
+
+from __future__ import annotations
+
+from devops_bench.agents.api.agent import ApiAgent
+
+__all__ = ["ApiAgent"]

--- a/devops_bench/agents/api/agent.py
+++ b/devops_bench/agents/api/agent.py
@@ -1,0 +1,497 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""API/MCP agent harness driving the shared :func:`run_tool_loop` primitive.
+
+:class:`ApiAgent` drives a model-agnostic MCP/skills tool-use loop and folds the
+resulting conversation history into canonical :class:`ToolCall` trajectory
+entries.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shlex
+import time
+from collections import deque
+from pathlib import Path
+from typing import Any
+
+from devops_bench.agents.api.mcp import MCPClient, extract_tool_text
+from devops_bench.agents.api.skills import (
+    SkillToolInfo,
+    discover_skill_tools,
+)
+from devops_bench.agents.base import AGENTS, AgentHarness
+from devops_bench.agents.config import AgentConfig
+from devops_bench.agents.result import AgentResult, ToolCall
+from devops_bench.core import get_logger
+from devops_bench.models import LLMClient, get_model
+from devops_bench.models.utils.loop import LoopResult, ToolDispatcher, run_tool_loop
+
+__all__ = ["ApiAgent", "fold_trajectory", "extract_tokens"]
+
+_log = get_logger("agents.api.agent")
+
+# Safety cap on agent turns; overridable via ``AgentConfig.max_turns``. Set high
+# because API agents legitimately take many tool-use turns — it only guards
+# against a model that never stops requesting tools.
+_DEFAULT_MAX_TURNS = 50
+
+
+def fold_trajectory(contents: list[dict]) -> list[dict]:
+    """Fold a :class:`LoopResult.contents` history into canonical trajectory entries.
+
+    Each assistant tool call is paired by ``tool_call_id`` with its tool result
+    and emitted as one :class:`ToolCall`. Calls with no id — Gemini emits every
+    function call with ``id=None`` — are paired FIFO with the id-less results,
+    which is exact under :func:`run_tool_loop`'s contract of appending one
+    result per dispatched call in call order.
+
+    Args:
+        contents: The conversation history produced by :func:`run_tool_loop`.
+
+    Returns:
+        A list of ``ToolCall.to_dict()`` mappings, one per tool call the model
+        issued, in the order issued.
+
+    Note:
+        Tool results matching no assistant-issued call are dropped from the
+        trajectory rather than synthesized into free-floating entries.
+    """
+    folded, _orphans = _fold_with_extraction_errors(contents)
+    return folded
+
+
+def _fold_with_extraction_errors(
+    contents: list[dict],
+) -> tuple[list[dict], list[str]]:
+    """Same as :func:`fold_trajectory` but also returns orphan-result diagnostics.
+
+    Args:
+        contents: As :func:`fold_trajectory`.
+
+    Returns:
+        A ``(trajectory, orphan_errors)`` tuple. ``orphan_errors`` lists one
+        message per unpaired ``role: tool`` entry; empty on a clean fold.
+    """
+    # Index assistant call ids first so we can detect orphans on the result
+    # pass; id-less calls (Gemini emits every function call with ``id=None``)
+    # are counted so their results can be paired FIFO instead of dropped.
+    assistant_call_ids: set[str] = set()
+    unkeyed_call_count = 0
+    for msg in contents:
+        if msg.get("role") != "assistant":
+            continue
+        for call in msg.get("tool_calls") or []:
+            cid = call.get("id")
+            if cid is None:
+                unkeyed_call_count += 1
+            else:
+                assistant_call_ids.add(str(cid))
+
+    # Pre-build call-id → (text, is_error) map so an out-of-order or absent
+    # result still leaves the call as ``status="called"``/``result=None`` rather
+    # than crashing on a lookup. Id-less results queue up FIFO — exact pairing
+    # under run_tool_loop's append-one-result-per-call-in-order contract.
+    results_by_id: dict[str, tuple[str, bool]] = {}
+    unkeyed_results: deque[tuple[str, bool]] = deque()
+    orphan_errors: list[str] = []
+    for msg in contents:
+        if msg.get("role") != "tool":
+            continue
+        call_id = msg.get("tool_call_id")
+        text = msg.get("content")
+        text_str = text if isinstance(text, str) else "" if text is None else str(text)
+        is_error = isinstance(text, str) and text.startswith("Error: ")
+        if call_id is None and len(unkeyed_results) < unkeyed_call_count:
+            unkeyed_results.append((text_str, is_error))
+            continue
+        if call_id is None or str(call_id) not in assistant_call_ids:
+            # Drop the orphan from the trajectory but surface it for diagnostics.
+            preview = text_str[:80].replace("\n", " ")
+            msg_text = (
+                "fold_trajectory dropped tool result with no matching call "
+                f"(id={call_id!r}, content={preview!r})"
+            )
+            _log.debug(msg_text)
+            orphan_errors.append(msg_text)
+            continue
+        results_by_id[str(call_id)] = (text_str, is_error)
+
+    trajectory: list[ToolCall] = []
+    for msg in contents:
+        if msg.get("role") != "assistant":
+            continue
+        tool_calls = msg.get("tool_calls") or []
+        for call in tool_calls:
+            name = call.get("name", "")
+            args = call.get("args")
+            call_id = call.get("id")
+            entry = ToolCall(
+                name=name,
+                args=args if isinstance(args, dict) else {},
+                status="called",
+            )
+            if call_id is not None:
+                hit = results_by_id.get(str(call_id))
+            else:
+                hit = unkeyed_results.popleft() if unkeyed_results else None
+            if hit is not None:
+                text, is_error = hit
+                entry.result = text
+                entry.status = "error" if is_error else "completed"
+            trajectory.append(entry)
+
+    return [entry.to_dict() for entry in trajectory], orphan_errors
+
+
+def extract_tokens(response: Any) -> dict:
+    """Pull provider token usage off the final raw response.
+
+    Detects which provider's usage shape is present and maps each onto a stable
+    key scheme (``prompt_tokens`` / ``candidates_tokens`` / ``total_tokens``) so
+    ``results.json`` stays consistent across providers.
+
+    Supported shapes:
+
+    * **Google** — ``response.usage_metadata`` with ``prompt_token_count`` /
+      ``candidates_token_count`` / ``total_token_count``.
+    * **Anthropic** — ``response.usage`` with ``input_tokens`` /
+      ``output_tokens`` (no aggregated total; the sum is used).
+    * **OpenAI / Ollama** — ``response.usage`` with ``prompt_tokens`` /
+      ``completion_tokens`` / ``total_tokens``.
+
+    The "output" field (``candidates_tokens``) absorbs whichever provider name
+    is present (``candidates_token_count`` / ``output_tokens`` /
+    ``completion_tokens``). When ``total`` is absent it is computed from the
+    other two so metrics never see ``0`` for a non-empty run.
+
+    Args:
+        response: The last raw provider response from
+            :attr:`LoopResult.response`, or ``None``.
+
+    Returns:
+        A ``{"prompt_tokens", "candidates_tokens", "total_tokens"}`` dict, or
+        ``{}`` when no usage is reported.
+    """
+    if response is None:
+        return {}
+    usage = getattr(response, "usage_metadata", None) or getattr(response, "usage", None)
+    if usage is None:
+        return {}
+
+    # Try the Google attr first, then the OpenAI-style attr, then the Anthropic
+    # alias.
+    prompt = _first_int_attr(usage, "prompt_token_count", "prompt_tokens", "input_tokens")
+    candidates = _first_int_attr(
+        usage, "candidates_token_count", "completion_tokens", "output_tokens"
+    )
+    total = _first_int_attr(usage, "total_token_count", "total_tokens")
+    # Anthropic emits no aggregated total; compute it so non-zero usage never
+    # surfaces as ``total_tokens: 0`` in results.json.
+    if total == 0 and (prompt or candidates):
+        total = prompt + candidates
+
+    return {
+        "prompt_tokens": prompt,
+        "candidates_tokens": candidates,
+        "total_tokens": total,
+    }
+
+
+def _first_int_attr(obj: Any, *names: str) -> int:
+    """Return the first ``names`` attribute on ``obj`` that holds a non-``None`` int.
+
+    Provider usage objects are typed namespaces / pydantic models with the
+    counts as plain ints; an unset field is either absent or ``None``. The
+    helper falls through both cases and returns ``0`` when no name matches so
+    the caller never has to ``None``-guard the arithmetic.
+    """
+    for name in names:
+        value = getattr(obj, name, None)
+        if value is not None:
+            return int(value)
+    return 0
+
+
+def _build_dispatch(
+    mcp_client: MCPClient | None,
+    skill_resources: dict[str, str],
+    errors: list[str],
+) -> ToolDispatcher:
+    """Build the dispatcher passed to :func:`run_tool_loop`.
+
+    Wraps each tool call in its own ``try/except`` because ``run_tool_loop``
+    propagates dispatch errors by design — letting a single tool failure abort
+    the whole run would be wrong for a benchmark agent. Failures are recorded
+    on ``errors`` and returned as the tool result text so the model can react
+    on the next turn.
+
+    Args:
+        mcp_client: Active :class:`MCPClient`, or ``None`` when MCP is off.
+        skill_resources: Map of skill tool name to the skill file's content
+            (captured at discovery); populated by
+            :func:`devops_bench.agents.api.skills.discover_skill_tools`.
+        errors: Errors list to mutate when a dispatch raises.
+
+    Returns:
+        An async ``(name, args, call_id) -> str`` callable matching
+        :data:`devops_bench.models.utils.loop.ToolDispatcher`.
+    """
+
+    async def dispatch(name: str, args: Any, call_id: str | None) -> str:
+        try:
+            # Skill tools take priority — they are advertised in the same tool
+            # list but are served locally from the content captured at
+            # discovery, without round-tripping the MCP server or the disk.
+            if name in skill_resources:
+                _log.info("Serving skill tool %s from discovery-time content", name)
+                return skill_resources[name]
+            if mcp_client is None:
+                msg = (
+                    f"Error: tool {name!r} requested but no MCP server is "
+                    "configured for this agent."
+                )
+                errors.append(msg)
+                return msg
+            arg_dict = args if isinstance(args, dict) else {}
+            tool_result = await mcp_client.call_tool(name, arg_dict)
+            text = extract_tool_text(tool_result)
+            # MCP servers report tool failure via ``isError`` rather than
+            # raising; surface it through the same error protocol as a raised
+            # dispatch so the fold and metrics see the failure mode.
+            if getattr(tool_result, "isError", False):
+                msg = f"Error calling tool {name}: {text}"
+                _log.warning(msg)
+                errors.append(msg)
+                return text if text.startswith("Error: ") else f"Error: {text}"
+            return text
+        except Exception as exc:  # noqa: BLE001 - one tool failure must not abort the run
+            msg = f"Error calling tool {name}: {exc}"
+            _log.warning(msg)
+            errors.append(msg)
+            return f"Error: {exc}"
+
+    return dispatch
+
+
+async def _gather_tools(
+    mcp_client: MCPClient | None,
+    skill_tools: list[SkillToolInfo],
+) -> list[Any]:
+    """Return the combined MCP + skill tool list passed to ``format_tools``.
+
+    Args:
+        mcp_client: Active MCP client, or ``None`` when MCP is off.
+        skill_tools: Skill tool descriptors from
+            :func:`discover_skill_tools`.
+
+    Returns:
+        A list of tool objects (MCP-native or :class:`SkillToolInfo`) in MCP
+        order followed by skill order. Both are duck-typed (``name``,
+        ``description``, ``inputSchema``) so adapters' ``format_tools`` handles
+        them uniformly.
+    """
+    tools: list[Any] = []
+    if mcp_client is not None:
+        tools_result = await mcp_client.list_tools()
+        tools.extend(tools_result.tools)
+    tools.extend(skill_tools)
+    return tools
+
+
+async def _run_async(
+    client: LLMClient,
+    prompt: str,
+    mcp_server_path: str | None,
+    skills_paths: tuple[str, ...],
+    rules_text: str | None,
+    max_turns: int,
+) -> tuple[LoopResult, list[str], list[str]]:
+    """Drive the tool-use loop and return its ``(LoopResult, errors, skills)``.
+
+    Opens an MCP session when ``mcp_server_path`` is set and discovers local
+    skills when ``skills_paths`` is non-empty — the two are independent. The
+    tool list is formatted by the caller and passed to :func:`run_tool_loop`
+    pre-formatted.
+
+    Args:
+        client: Neutral LLM client.
+        prompt: Task prompt seeding the loop.
+        mcp_server_path: Command launching the MCP server, or ``None`` to skip
+            MCP entirely.
+        skills_paths: Filesystem locations to discover local skills under.
+        rules_text: Operator-brief text (the ``AgentRules.text`` payload)
+            handed to the provider as the ``system_instruction``; ``None`` /
+            empty means "no preamble".
+        max_turns: Safety cap on turns.
+
+    Returns:
+        A ``(loop_result, errors, skill_names)`` tuple. ``errors`` carries any
+        per-tool dispatch failures recorded by the dispatcher.
+    """
+    errors: list[str] = []
+    skill_tools, skill_resources, skill_names = await asyncio.to_thread(
+        discover_skill_tools, skills_paths
+    )
+    system_instruction = rules_text or None
+
+    if not mcp_server_path:
+        formatted = client.format_tools(skill_tools)
+        dispatch = _build_dispatch(None, skill_resources, errors)
+        loop_result = await run_tool_loop(
+            client=client,
+            goal=prompt,
+            tools=formatted,
+            system_instruction=system_instruction,
+            dispatch=dispatch,
+            max_turns=max_turns,
+        )
+        return loop_result, errors, skill_names
+
+    async with MCPClient(mcp_server_path) as mcp_client:
+        tools = await _gather_tools(mcp_client, skill_tools)
+        formatted = client.format_tools(tools)
+        dispatch = _build_dispatch(mcp_client, skill_resources, errors)
+        loop_result = await run_tool_loop(
+            client=client,
+            goal=prompt,
+            tools=formatted,
+            system_instruction=system_instruction,
+            dispatch=dispatch,
+            max_turns=max_turns,
+        )
+        return loop_result, errors, skill_names
+
+
+@AGENTS.register("api")
+class ApiAgent(AgentHarness):
+    """API agent harness driving a model-agnostic MCP tool-use loop.
+
+    Provider, model, and capability bindings all flow from
+    :class:`~devops_bench.agents.config.AgentConfig` — no environment reads
+    happen inside this class. Capability gates:
+
+    * **MCP on/off** is driven by ``config.capabilities.mcp`` (presence of an
+      :class:`~devops_bench.agents.capabilities.McpBinding` with a non-empty
+      ``command``).
+    * **Skills on/off** is driven by ``config.capabilities.skills.paths``
+      independently of MCP — an agent may run with skills only, MCP only,
+      both, or neither.
+    * **Rules** flow from ``config.capabilities.rules.text`` and ride on the
+      provider's ``system_instruction`` parameter (empty text → no preamble).
+
+    ``__init__`` assigns ``self.mcp_servers`` / ``self.skills`` /
+    ``self.rules`` from the config bindings, which makes
+    ``isinstance(agent, SupportsMcp/SupportsSkills/SupportsRules)`` return
+    ``True`` for orchestrator-side capability negotiation (the Protocols are
+    structural — no mixin required).
+
+    The execute path opens the MCP session (when configured), discovers
+    skills, hands the *pre-formatted* tool list to :func:`run_tool_loop`, and
+    folds the resulting conversation history into canonical
+    :class:`~devops_bench.agents.result.ToolCall` trajectory entries via
+    :func:`fold_trajectory`.
+    """
+
+    def __init__(self, config: AgentConfig | None = None) -> None:
+        # Assign the capability bindings as attributes so the structural
+        # Protocols see the granted bindings.
+        AgentHarness.__init__(self, config)
+        caps = self.config.capabilities
+        self.mcp_servers = caps.mcp_servers
+        self.skills = caps.skills
+        self.rules = caps.rules
+
+    def _execute(self, prompt: str, workspace_path: Path | None = None) -> AgentResult:
+        """Build the LLM client, drive the loop, and assemble an AgentResult.
+
+        Args:
+            prompt: Task prompt handed to the agent.
+            workspace_path: Unused — the API agent drives a remote tool-use
+                loop over MCP/skills with no local filesystem workspace.
+
+        Returns:
+            An :class:`AgentResult` whose ``trajectory`` is a list of canonical
+            :class:`ToolCall` entries, ``output`` is :attr:`LoopResult.final_text`,
+            and ``latency`` carries the loop's accumulated wall-clock.
+            ``tokens`` reflects the final provider turn only — per-turn
+            accumulation is a pending ``run_tool_loop`` follow-up.
+        """
+        llm_client = get_model(self.config.provider, self.config.model)
+        max_turns = (
+            self.config.max_turns if self.config.max_turns is not None else _DEFAULT_MAX_TURNS
+        )
+        mcp_servers = self.config.capabilities.mcp_servers
+        if len(mcp_servers) > 1:
+            _log.warning(
+                "API agent honors only the first MCP binding; ignoring %d additional server(s)",
+                len(mcp_servers) - 1,
+            )
+        mcp_binding = self.config.capabilities.mcp
+        # Only open an MCPClient when an MCP binding carries a launch command;
+        # an empty-command binding is treated as "no MCP". ``shlex.join``
+        # round-trips ``MCPClient``'s ``shlex.split`` so a spaced argv token
+        # (``("uv run", "mcp-server")``) is rebuilt as a single quoted word.
+        mcp_server_path = (
+            shlex.join(mcp_binding.command) if mcp_binding and mcp_binding.command else None
+        )
+        skills_paths = self.config.capabilities.skills.paths
+        rules_text = self.config.capabilities.rules.text
+
+        run_coro = _run_async(
+            llm_client,
+            prompt,
+            mcp_server_path,
+            skills_paths,
+            rules_text,
+            max_turns,
+        )
+        # Honor the config's wall-clock budget over the whole run (MCP session
+        # + every provider turn), matching the CLI harnesses' whole-call
+        # timeout semantics. ``wait_for`` with ``timeout=None`` imposes none.
+        timeout = self.config.timeout_sec
+        start = time.monotonic()
+        try:
+            loop_result, dispatch_errors, skill_names = asyncio.run(
+                asyncio.wait_for(run_coro, timeout=timeout)
+            )
+        except TimeoutError:
+            # ``wait_for``'s TimeoutError can only fire once the deadline has
+            # elapsed (and never with ``timeout=None``) — anything earlier came
+            # from inside the run (e.g. a provider socket timeout;
+            # socket.timeout is TimeoutError since 3.10). Re-raise those so the
+            # base safety net logs the traceback instead of relabeling them.
+            elapsed = time.monotonic() - start
+            if timeout is None or elapsed < timeout:
+                raise
+            return AgentResult.errored(f"API agent timed out after {timeout}s", latency=elapsed)
+
+        trajectory, orphan_errors = _fold_with_extraction_errors(loop_result.contents)
+        tokens = extract_tokens(loop_result.response)
+        metadata: dict[str, Any] = {
+            "tools_used": sorted(loop_result.tools_used),
+        }
+        if skill_names:
+            metadata["skills_loaded"] = list(skill_names)
+
+        return AgentResult(
+            output=loop_result.final_text,
+            trajectory=trajectory,
+            tokens=tokens,
+            latency=loop_result.latency,
+            errors=list(dispatch_errors) + orphan_errors,
+            metadata=metadata,
+        )

--- a/devops_bench/agents/api/mcp.py
+++ b/devops_bench/agents/api/mcp.py
@@ -1,0 +1,147 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Async MCP client wrapping the ``mcp`` SDK over a stdio server transport."""
+
+from __future__ import annotations
+
+import shlex
+from contextlib import AsyncExitStack
+from types import TracebackType
+from typing import Any
+
+from devops_bench.core import get_logger
+
+__all__ = ["MCPClient", "extract_tool_text"]
+
+_log = get_logger("agents.api.mcp")
+
+
+class MCPClient:
+    """Async context manager over an MCP stdio server.
+
+    Spawns the MCP server given by ``server_path``, initializes a session, and
+    exposes tool discovery and invocation. The ``mcp`` SDK is imported lazily on
+    ``__aenter__`` so merely importing this module never requires the SDK.
+
+    Attributes:
+        server_path: Command used to launch the MCP server over stdio.
+        session: The active ``ClientSession`` once entered, else ``None``.
+
+    Raises:
+        ImportError: If the ``mcp`` package is missing (a broken install —
+            ``mcp`` is a required dependency; on enter).
+        ValueError: If ``server_path`` is empty or whitespace-only (on enter).
+    """
+
+    def __init__(self, server_path: str) -> None:
+        self.server_path = server_path
+        self.exit_stack = AsyncExitStack()
+        self.session: Any = None
+
+    async def __aenter__(self) -> MCPClient:
+        try:
+            from mcp.client.session import ClientSession
+            from mcp.client.stdio import StdioServerParameters, stdio_client
+        except ImportError as exc:  # pragma: no cover - broken install only
+            raise ImportError(
+                "The API agent's MCP client needs the 'mcp' package, a required "
+                "dependency of devops-bench; reinstall the package to restore it."
+            ) from exc
+
+        # Split the command so a multi-word server_path (e.g. "uv run mcp-server")
+        # is spawned as program + args rather than a single executable name; the
+        # stdio transport spawns without a shell, so an unsplit command would fail
+        # with FileNotFoundError.
+        parts = shlex.split(self.server_path or "")
+        if not parts:
+            raise ValueError(
+                "MCP server_path is empty; set AGENT_TARGET/MCP_SERVER_PATH to the "
+                "MCP server command."
+            )
+        server_params = StdioServerParameters(command=parts[0], args=parts[1:])
+        # Unwind anything already entered (e.g. the spawned server subprocess)
+        # when a later setup step fails — __aexit__ never runs if __aenter__
+        # raises, so cleanup must happen here.
+        try:
+            stdio_transport = await self.exit_stack.enter_async_context(stdio_client(server_params))
+            self.read_stream, self.write_stream = stdio_transport
+            self.session = await self.exit_stack.enter_async_context(
+                ClientSession(self.read_stream, self.write_stream)
+            )
+            await self.session.initialize()
+        except BaseException:
+            await self.exit_stack.aclose()
+            raise
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        await self.exit_stack.aclose()
+
+    async def list_tools(self) -> Any:
+        """List the tools advertised by the connected MCP server.
+
+        Returns:
+            The raw ``list_tools`` result whose ``.tools`` is the tool list.
+        """
+        return await self.session.list_tools()
+
+    async def call_tool(self, name: str, arguments: dict) -> Any:
+        """Invoke an MCP tool by name.
+
+        DeepEval's ``@observe`` wrapper is applied when available so MCP calls
+        appear in traces; the import is best-effort and a missing ``deepeval``
+        degrades gracefully to an untraced call.
+
+        Args:
+            name: Tool name as advertised by the server.
+            arguments: Keyword arguments for the tool.
+
+        Returns:
+            The raw tool-call result from the MCP session.
+        """
+        try:
+            from deepeval.tracing import observe
+        except ImportError:
+            return await self.session.call_tool(name, arguments=arguments)
+
+        @observe(span_type="TOOL")
+        async def _call() -> Any:
+            return await self.session.call_tool(name, arguments=arguments)
+
+        return await _call()
+
+
+def extract_tool_text(tool_result: Any) -> str:
+    """Aggregate the text of every content block in an MCP tool result.
+
+    Args:
+        tool_result: The raw result returned by :meth:`MCPClient.call_tool`.
+
+    Returns:
+        The newline-joined text of all blocks exposing a ``text`` attribute. If
+        the result has no ``content`` blocks (or none carry text), the result is
+        stringified instead.
+    """
+    content = getattr(tool_result, "content", None)
+    if content:
+        texts = [block.text for block in content if hasattr(block, "text")]
+        if texts:
+            return "\n".join(texts)
+    return str(tool_result)

--- a/devops_bench/agents/api/skills.py
+++ b/devops_bench/agents/api/skills.py
@@ -75,9 +75,11 @@ def discover_skill_tools(
     Discovery goes through the shared
     :func:`~devops_bench.agents.shared.skills.iter_skills` walk, so semantics
     (expanduser, sorted order, first-wins dedupe, missing paths warned) are
-    identical across harnesses. The file content is captured at discovery time
-    so invoking a skill tool later serves the exact text that was advertised —
-    no re-read, no window for the file to change or vanish mid-run.
+    identical across harnesses; names that collide after tool-name
+    normalization are additionally deduped here, first-wins with a warning.
+    The file content is captured at discovery time so invoking a skill tool
+    later serves the exact text that was advertised — no re-read, no window
+    for the file to change or vanish mid-run.
 
     Performs blocking filesystem I/O; callers in async contexts should run this
     via :func:`asyncio.to_thread` to keep the event loop responsive.
@@ -99,9 +101,23 @@ def discover_skill_tools(
     tools: list[SkillToolInfo] = []
     resources: dict[str, str] = {}
     names: list[str] = []
+    seen_normalized: set[str] = set()
 
     for skill in iter_skills(paths):
         normalized = "skill_" + skill.name.replace("-", "_")
+        # iter_skills dedupes raw names, but distinct raw names can still
+        # normalize to the same tool name (``my-skill`` vs ``my_skill``) —
+        # first wins, so the advertised tool list never carries duplicates and
+        # ``resources`` is never silently overwritten.
+        if normalized in seen_normalized:
+            _log.warning(
+                "Skipping skill %r from %s: normalized tool name %r collides with an earlier skill",
+                skill.name,
+                skill.path,
+                normalized,
+            )
+            continue
+        seen_normalized.add(normalized)
         tools.append(
             SkillToolInfo(
                 name=normalized,

--- a/devops_bench/agents/api/skills.py
+++ b/devops_bench/agents/api/skills.py
@@ -1,0 +1,115 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Local skill discovery for the API agent (decoupled from MCP).
+
+A *skill* is a ``SKILL.md`` file under one of the configured paths whose
+frontmatter declares a ``name`` and ``description``. Each discovered skill is
+advertised to the model as a synthetic tool — invoking the tool returns the
+file's contents. Skills are independent of MCP: an agent may have skills
+without an MCP server (and vice versa); the API agent gates each on its own
+config field.
+
+This module performs only blocking filesystem I/O; importing it pulls no
+provider SDK, ``mcp``, or ``deepeval``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from devops_bench.agents.shared.skills import iter_skills, parse_skill_md
+from devops_bench.core import get_logger
+
+__all__ = [
+    "SkillToolInfo",
+    "parse_skill_md",
+    "discover_skill_tools",
+]
+
+_log = get_logger("agents.api.skills")
+
+
+class SkillToolInfo:
+    """Duck-typed stand-in for an MCP tool used to advertise a local skill.
+
+    Mirrors the attribute surface (``name``, ``description``, ``inputSchema``)
+    the provider adapters' ``format_tools`` reads from an MCP tool object, so a
+    skill can be added to the same tool list as MCP tools without a separate
+    formatting path.
+
+    Attributes:
+        name: Tool name as exposed to the model (prefixed ``skill_``).
+        description: Free-form description shown to the model.
+        inputSchema: JSON schema for arguments. Defaults to an empty object
+            schema (skills take no arguments today) — never ``None``, because
+            the Anthropic/OpenAI-style adapters forward the attribute verbatim
+            and those APIs reject a null schema.
+    """
+
+    def __init__(self, name: str, description: str, inputSchema: Any = None) -> None:  # noqa: N803 - matches MCP tool attr
+        self.name = name
+        self.description = description
+        self.inputSchema = (
+            inputSchema if inputSchema is not None else {"type": "object", "properties": {}}
+        )
+
+
+def discover_skill_tools(
+    paths: Iterable[str],
+) -> tuple[list[SkillToolInfo], dict[str, str], list[str]]:
+    """Discover skills under ``paths`` and build tool descriptors.
+
+    Discovery goes through the shared
+    :func:`~devops_bench.agents.shared.skills.iter_skills` walk, so semantics
+    (expanduser, sorted order, first-wins dedupe, missing paths warned) are
+    identical across harnesses. The file content is captured at discovery time
+    so invoking a skill tool later serves the exact text that was advertised —
+    no re-read, no window for the file to change or vanish mid-run.
+
+    Performs blocking filesystem I/O; callers in async contexts should run this
+    via :func:`asyncio.to_thread` to keep the event loop responsive.
+
+    Args:
+        paths: Filesystem locations to search (each is walked recursively for
+            ``SKILL.md`` files).
+
+    Returns:
+        A ``(tools, resources, names)`` tuple:
+
+        * ``tools`` — :class:`SkillToolInfo` descriptors ready to merge into the
+          MCP tool list before formatting.
+        * ``resources`` — map of normalized tool name to the skill file's full
+          content, consumed by the agent's dispatch closure.
+        * ``names`` — discovered skill names (the unnormalized values from each
+          file's frontmatter); useful for diagnostics.
+    """
+    tools: list[SkillToolInfo] = []
+    resources: dict[str, str] = {}
+    names: list[str] = []
+
+    for skill in iter_skills(paths):
+        normalized = "skill_" + skill.name.replace("-", "_")
+        tools.append(
+            SkillToolInfo(
+                name=normalized,
+                description=skill.description or f"Exposes skill: {skill.name}",
+            )
+        )
+        resources[normalized] = skill.content
+        names.append(skill.name)
+        _log.info("Loaded local skill as tool: %s -> %s", normalized, skill.path)
+
+    return tools, resources, names

--- a/devops_bench/agents/shared/cli_capabilities.py
+++ b/devops_bench/agents/shared/cli_capabilities.py
@@ -28,7 +28,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from devops_bench.agents.shared.skills import parse_skill_md
+from devops_bench.agents.shared.skills import iter_skills
 from devops_bench.core import get_logger
 
 if TYPE_CHECKING:
@@ -113,52 +113,21 @@ def materialize_skills(skills_root: Path, paths: tuple[str, ...]) -> list[str]:
     agent performs), the file is written to ``skills_root/<name>/SKILL.md`` using
     the ``name`` from its frontmatter.
 
-    The frontmatter ``name`` must be a bare directory name: anything carrying a
-    path separator, ``..``, or an absolute prefix would escape ``skills_root``,
-    so such skills are warned and skipped rather than written. When two skill
-    files share a name, the first discovered wins and later ones are warned
-    and skipped rather than silently overwriting it.
-
     Args:
         skills_root: The destination skills directory to populate.
-        paths: Skill source directories to walk recursively. Missing paths are
-            warned and skipped (matching the API agent's discovery semantic).
+        paths: Skill source directories, discovered via the shared
+            :func:`~devops_bench.agents.shared.skills.iter_skills` walk
+            (expanduser, sorted order, escaping/duplicate names warned and
+            skipped, missing paths warned).
 
     Returns:
         The names of the skills materialized, in discovery order.
     """
     written: list[str] = []
-    for raw_path in paths:
-        if not raw_path:
-            continue
-        source = Path(os.path.expanduser(raw_path))
-        if not source.exists():
-            _log.warning("Skills directory not found: %s", source)
-            continue
-        for skill_file in sorted(source.rglob(_SKILL_FILE)):
-            name, _description, content = parse_skill_md(str(skill_file))
-            if not name or content is None:
-                continue
-            # Path("..").name is ".." itself, so ".." needs its own rejection.
-            if name == ".." or name != Path(name).name:
-                _log.warning(
-                    "Skipping skill %r from %s: name must not contain path separators, "
-                    "'..', or an absolute prefix",
-                    name,
-                    skill_file,
-                )
-                continue
-            if name in written:
-                _log.warning(
-                    "Skipping duplicate skill %r from %s: already materialized from an "
-                    "earlier source",
-                    name,
-                    skill_file,
-                )
-                continue
-            dest_dir = skills_root / name
-            dest_dir.mkdir(parents=True, exist_ok=True)
-            (dest_dir / _SKILL_FILE).write_text(content, encoding="utf-8")
-            written.append(name)
-            _log.info("Linked skill %s -> %s", name, dest_dir)
+    for skill in iter_skills(paths):
+        dest_dir = skills_root / skill.name
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / _SKILL_FILE).write_text(skill.content, encoding="utf-8")
+        written.append(skill.name)
+        _log.info("Linked skill %s -> %s", skill.name, dest_dir)
     return written

--- a/devops_bench/agents/shared/skills.py
+++ b/devops_bench/agents/shared/skills.py
@@ -22,22 +22,101 @@ into the other's package. Importing this module pulls no provider SDK.
 
 from __future__ import annotations
 
+import os
 import re
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+from typing import NamedTuple
 
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
 from devops_bench.core import get_logger
 
-__all__ = ["parse_skill_md"]
+__all__ = ["SkillFile", "iter_skills", "parse_skill_md"]
 
 _log = get_logger("agents.shared.skills")
 
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL | re.MULTILINE)
 
+_SKILL_FILE = "SKILL.md"
+
 # YAML 1.2 semantics (matching tasks/loader.py): only ``true``/``false`` are
 # booleans, so a description like ``yes`` stays a plain string.
 _yaml = YAML(typ="safe")
+
+
+class SkillFile(NamedTuple):
+    """One discovered skill: its frontmatter fields plus source location.
+
+    Attributes:
+        name: The ``name`` declared in the file's frontmatter.
+        description: The ``description`` declared in the frontmatter, or ``None``.
+        content: The full file text (frontmatter + body).
+        path: Absolute or as-given path to the source ``SKILL.md``.
+    """
+
+    name: str
+    description: str | None
+    content: str
+    path: str
+
+
+def iter_skills(paths: Iterable[str]) -> Iterator[SkillFile]:
+    """Discover ``SKILL.md`` files beneath ``paths`` with the shared semantics.
+
+    Every harness discovers skills through this single walk so behavior cannot
+    diverge per agent flavor:
+
+    * each path is ``os.path.expanduser``-expanded (``~/skills`` works),
+    * empty path strings are skipped, missing directories are warned and
+      skipped,
+    * files are visited in ``sorted(rglob)`` order for determinism,
+    * names carrying a path separator, ``..``, or an absolute prefix are
+      warned and skipped — consumers use the name as a directory or tool
+      name, and such a name would escape the destination root,
+    * duplicate skill names are first-wins with a warning,
+    * files with no parseable ``name`` are skipped.
+
+    Args:
+        paths: Skill source directories to walk recursively.
+
+    Yields:
+        A :class:`SkillFile` per unique, parseable skill, in discovery order.
+    """
+    seen: set[str] = set()
+    for raw_path in paths:
+        if not raw_path:
+            continue
+        source = Path(os.path.expanduser(raw_path))
+        if not source.exists():
+            _log.warning("Skills directory not found: %s", source)
+            continue
+        for skill_file in sorted(source.rglob(_SKILL_FILE)):
+            name, description, content = parse_skill_md(str(skill_file))
+            if not name or content is None:
+                continue
+            # Path("..").name is ".." itself, so ".." needs its own rejection.
+            if name == ".." or name != Path(name).name:
+                _log.warning(
+                    "Skipping skill %r from %s: name must not contain path separators, "
+                    "'..', or an absolute prefix",
+                    name,
+                    skill_file,
+                )
+                continue
+            if name in seen:
+                _log.warning(
+                    "Skipping duplicate skill %r from %s: already discovered from an "
+                    "earlier source",
+                    name,
+                    skill_file,
+                )
+                continue
+            seen.add(name)
+            yield SkillFile(
+                name=name, description=description, content=content, path=str(skill_file)
+            )
 
 
 def parse_skill_md(file_path: str) -> tuple[str | None, str | None, str | None]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 dependencies = [
     "deepeval>=4.0.3",
     "google-genai>=2.8.0",
+    "mcp>=1.27.1",
     "pydantic>=2.0",
     "ruamel.yaml>=0.18.0",
 ]

--- a/tests/unit/agents/api/__init__.py
+++ b/tests/unit/agents/api/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit/agents/api/test_agents_api_agent.py
+++ b/tests/unit/agents/api/test_agents_api_agent.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -154,11 +155,11 @@ class _FakeMCPClient:
 # ---------------------------------------------------------------------------
 
 
-def test_api_agent_registered_under_canonical_key():
+def test_api_agent_registered_under_canonical_key() -> None:
     assert AGENTS.get("api") is ApiAgent
 
 
-def test_package_import_alone_registers_api_agent():
+def test_package_import_alone_registers_api_agent() -> None:
     """``import devops_bench.agents.api`` (no ``.agent`` submodule import) must
     register the harness — the documented consumer convention resolves via
     ``AGENTS.get`` after a package import. Runs in a fresh interpreter because
@@ -187,7 +188,7 @@ def test_package_import_alone_registers_api_agent():
 # ---------------------------------------------------------------------------
 
 
-def test_fold_trajectory_pairs_assistant_calls_with_tool_results():
+def test_fold_trajectory_pairs_assistant_calls_with_tool_results() -> None:
     contents = [
         {"role": "user", "content": "g"},
         {
@@ -208,7 +209,7 @@ def test_fold_trajectory_pairs_assistant_calls_with_tool_results():
     ]
 
 
-def test_fold_trajectory_marks_dispatcher_errors_as_error_status():
+def test_fold_trajectory_marks_dispatcher_errors_as_error_status() -> None:
     # The dispatcher returns ``"Error: ..."`` for a failed tool call (matching
     # the agent's _build_dispatch contract) — folding must surface that as the
     # ``"error"`` status so metrics see the failure mode, not a clean call.
@@ -228,7 +229,7 @@ def test_fold_trajectory_marks_dispatcher_errors_as_error_status():
     ]
 
 
-def test_fold_trajectory_leaves_unmatched_call_as_called_status():
+def test_fold_trajectory_leaves_unmatched_call_as_called_status() -> None:
     # If a result never lands (e.g. dispatch raised before appending), the call
     # entry survives with ``status="called"`` and ``result=None`` rather than
     # being silently dropped.
@@ -245,7 +246,7 @@ def test_fold_trajectory_leaves_unmatched_call_as_called_status():
     ]
 
 
-def test_fold_trajectory_skips_text_only_turns():
+def test_fold_trajectory_skips_text_only_turns() -> None:
     contents = [
         {"role": "user", "content": "hi"},
         {"role": "assistant", "content": "hello"},
@@ -254,7 +255,7 @@ def test_fold_trajectory_skips_text_only_turns():
     assert fold_trajectory(contents) == []
 
 
-def test_fold_trajectory_handles_none_args_and_none_call_id():
+def test_fold_trajectory_handles_none_args_and_none_call_id() -> None:
     # Defensive: missing ``args`` becomes ``{}``; an entry with no ``id`` is
     # emitted as ``status="called"`` (no result to pair with).
     contents = [
@@ -269,7 +270,7 @@ def test_fold_trajectory_handles_none_args_and_none_call_id():
     ]
 
 
-def test_fold_trajectory_pairs_unkeyed_gemini_style_calls_fifo():
+def test_fold_trajectory_pairs_unkeyed_gemini_style_calls_fifo() -> None:
     """Gemini emits every function call with ``id=None`` and ``run_tool_loop``
     appends one result per call in order — the fold must pair them FIFO
     instead of dropping every result as an orphan (review finding: the default
@@ -298,7 +299,7 @@ def test_fold_trajectory_pairs_unkeyed_gemini_style_calls_fifo():
     ]
 
 
-def test_fold_trajectory_extra_unkeyed_result_is_still_an_orphan():
+def test_fold_trajectory_extra_unkeyed_result_is_still_an_orphan() -> None:
     """Id-less results beyond the number of id-less calls stay orphans —
     FIFO pairing must not absorb genuinely unmatched results."""
     contents = [
@@ -318,7 +319,7 @@ def test_fold_trajectory_extra_unkeyed_result_is_still_an_orphan():
     assert "stray" in orphans[0]
 
 
-def test_fold_trajectory_drops_unpaired_tool_results_silently_from_trajectory():
+def test_fold_trajectory_drops_unpaired_tool_results_silently_from_trajectory() -> None:
     """An orphan ``role: tool`` (no matching assistant call_id) is dropped from
     the canonical trajectory — synthesizing a free-floating entry would break
     the "every trajectory item is a real ToolCall the model issued" invariant
@@ -333,7 +334,7 @@ def test_fold_trajectory_drops_unpaired_tool_results_silently_from_trajectory():
     assert fold_trajectory(contents) == []
 
 
-def test_fold_with_extraction_errors_surfaces_orphan_results():
+def test_fold_with_extraction_errors_surfaces_orphan_results() -> None:
     from devops_bench.agents.api.agent import _fold_with_extraction_errors
 
     contents = [
@@ -352,7 +353,7 @@ def test_fold_with_extraction_errors_surfaces_orphan_results():
 # ---------------------------------------------------------------------------
 
 
-def test_extract_tokens_reads_usage_metadata():
+def test_extract_tokens_reads_usage_metadata() -> None:
     usage = SimpleNamespace(prompt_token_count=3, candidates_token_count=5, total_token_count=8)
     response = SimpleNamespace(usage_metadata=usage)
     assert extract_tokens(response) == {
@@ -362,7 +363,7 @@ def test_extract_tokens_reads_usage_metadata():
     }
 
 
-def test_extract_tokens_falls_back_to_usage_attribute():
+def test_extract_tokens_falls_back_to_usage_attribute() -> None:
     usage = SimpleNamespace(prompt_token_count=1, candidates_token_count=2, total_token_count=3)
     # No ``usage_metadata``; the function should still find ``usage``.
     response = SimpleNamespace(usage=usage)
@@ -373,12 +374,12 @@ def test_extract_tokens_falls_back_to_usage_attribute():
     }
 
 
-def test_extract_tokens_returns_empty_dict_when_no_usage():
+def test_extract_tokens_returns_empty_dict_when_no_usage() -> None:
     assert extract_tokens(SimpleNamespace()) == {}
     assert extract_tokens(None) == {}
 
 
-def test_extract_tokens_defaults_missing_counts_to_zero():
+def test_extract_tokens_defaults_missing_counts_to_zero() -> None:
     """Missing counts default to 0; if the source provided no total but the
     other two fields are non-zero, the helper computes prompt+candidates so a
     non-empty run never shows ``total_tokens: 0`` in results.json."""
@@ -392,7 +393,7 @@ def test_extract_tokens_defaults_missing_counts_to_zero():
     }
 
 
-def test_extract_tokens_reads_anthropic_input_output_shape():
+def test_extract_tokens_reads_anthropic_input_output_shape() -> None:
     """Anthropic emits ``usage.input_tokens`` / ``usage.output_tokens`` and **no**
     aggregated total. The helper must map both onto the legacy keys and compute
     the total so non-Google providers do not silently drop tokens.
@@ -410,7 +411,7 @@ def test_extract_tokens_reads_anthropic_input_output_shape():
     }
 
 
-def test_extract_tokens_reads_openai_ollama_shape():
+def test_extract_tokens_reads_openai_ollama_shape() -> None:
     """OpenAI / Ollama emit ``usage.prompt_tokens`` / ``completion_tokens`` /
     ``total_tokens``. The helper must map ``completion_tokens`` → the legacy
     ``candidates_tokens`` slot and pass ``total_tokens`` through verbatim.
@@ -427,7 +428,7 @@ def test_extract_tokens_reads_openai_ollama_shape():
     }
 
 
-def test_extract_tokens_google_total_passes_through_when_present():
+def test_extract_tokens_google_total_passes_through_when_present() -> None:
     """When the provider supplies its own total it wins over the computed sum."""
     usage = SimpleNamespace(prompt_token_count=5, candidates_token_count=7, total_token_count=99)
     response = SimpleNamespace(usage_metadata=usage)
@@ -437,7 +438,7 @@ def test_extract_tokens_google_total_passes_through_when_present():
     assert extract_tokens(response)["total_tokens"] == 99
 
 
-def test_extract_tokens_preserves_legacy_on_disk_key_scheme():
+def test_extract_tokens_preserves_legacy_on_disk_key_scheme() -> None:
     """The on-disk dict shape must stay ``{prompt_tokens, candidates_tokens,
     total_tokens}`` for D3 (results.json stability) — three keys, exactly.
     """
@@ -451,7 +452,9 @@ def test_extract_tokens_preserves_legacy_on_disk_key_scheme():
 # ---------------------------------------------------------------------------
 
 
-def test_execute_runs_with_no_tools_when_capabilities_default(monkeypatch):
+def test_execute_runs_with_no_tools_when_capabilities_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Default capabilities (no MCP binding, no skills) → loop runs tool-less.
 
     Renamed from ``..._when_target_unset`` because the MCP gate is no longer
@@ -490,7 +493,9 @@ def test_execute_runs_with_no_tools_when_capabilities_default(monkeypatch):
     assert fake.calls[0]["tools"] == ("formatted", ())
 
 
-def test_execute_passes_explicit_provider_and_model_to_get_model(monkeypatch):
+def test_execute_passes_explicit_provider_and_model_to_get_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     captured: dict[str, Any] = {}
 
     def fake_get_model(provider, model):
@@ -504,7 +509,9 @@ def test_execute_passes_explicit_provider_and_model_to_get_model(monkeypatch):
     assert captured == {"provider": "anthropic", "model": "claude-3-5"}
 
 
-def test_execute_records_anthropic_tokens_through_to_agentresult(monkeypatch):
+def test_execute_records_anthropic_tokens_through_to_agentresult(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """End-to-end: an Anthropic-shaped usage object surfaces on
     ``AgentResult.tokens`` under the legacy key scheme — regression for the
     blocking bug where non-Google providers silently logged zero tokens."""
@@ -526,7 +533,9 @@ def test_execute_records_anthropic_tokens_through_to_agentresult(monkeypatch):
     }
 
 
-def test_execute_records_openai_tokens_through_to_agentresult(monkeypatch):
+def test_execute_records_openai_tokens_through_to_agentresult(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """End-to-end: an OpenAI/Ollama-shaped usage object surfaces under the
     legacy key scheme."""
     fake = _FakeLLMClient(
@@ -552,7 +561,9 @@ def test_execute_records_openai_tokens_through_to_agentresult(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_execute_folds_assistant_tool_pairs_into_canonical_trajectory(monkeypatch):
+def test_execute_folds_assistant_tool_pairs_into_canonical_trajectory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """End-to-end: an MCP tool turn followed by a finishing turn → one ToolCall."""
     fc = [{"name": "do_thing", "args": {"a": 1}, "id": "call-1"}]
     fake = _FakeLLMClient(
@@ -603,7 +614,9 @@ def test_execute_folds_assistant_tool_pairs_into_canonical_trajectory(monkeypatc
 # ---------------------------------------------------------------------------
 
 
-def test_execute_dispatch_error_lands_in_errors_and_continues(monkeypatch):
+def test_execute_dispatch_error_lands_in_errors_and_continues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A tool call that raises must surface on errors, not crash the agent."""
 
     class _ExplodingMCP(_FakeMCPClient):
@@ -632,7 +645,7 @@ def test_execute_dispatch_error_lands_in_errors_and_continues(monkeypatch):
     ]
 
 
-def test_execute_marks_mcp_iserror_result_as_error(monkeypatch):
+def test_execute_marks_mcp_iserror_result_as_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """An MCP server reporting failure via ``CallToolResult.isError`` (rather
     than raising) must fold as ``status="error"`` and land on ``errors`` —
     previously the flag was ignored and failures scored as completed (review
@@ -662,7 +675,9 @@ def test_execute_marks_mcp_iserror_result_as_error(monkeypatch):
     ]
 
 
-def test_execute_records_missing_mcp_when_tool_requested_without_server(monkeypatch):
+def test_execute_records_missing_mcp_when_tool_requested_without_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """No MCP server, but the model still requests a tool → recorded, not crashed."""
     fc = [{"name": "ghost", "args": {}, "id": "c2"}]
     fake = _FakeLLMClient(
@@ -692,7 +707,9 @@ def test_execute_records_missing_mcp_when_tool_requested_without_server(monkeypa
 # ---------------------------------------------------------------------------
 
 
-def test_execute_skills_discover_without_mcp(monkeypatch, tmp_path):
+def test_execute_skills_discover_without_mcp(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Skills must be loadable on the MCP-off path, not gated on MCP being on."""
     skill_dir = tmp_path / "skills"
     skill = skill_dir / "demo" / "SKILL.md"
@@ -731,7 +748,7 @@ def test_execute_skills_discover_without_mcp(monkeypatch, tmp_path):
     assert fake.format_tools_calls[0][0].name == "skill_demo_skill"
 
 
-def test_execute_no_skills_no_mcp_runs_tool_less(monkeypatch):
+def test_execute_no_skills_no_mcp_runs_tool_less(monkeypatch: pytest.MonkeyPatch) -> None:
     """Empty skills + no target → loop seen no tools, no metadata noise."""
     fake = _FakeLLMClient([_Turn(text="hi")])
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
@@ -746,7 +763,7 @@ def test_execute_no_skills_no_mcp_runs_tool_less(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_execute_lets_value_error_reach_base_safety_net(monkeypatch):
+def test_execute_lets_value_error_reach_base_safety_net(monkeypatch: pytest.MonkeyPatch) -> None:
     """A ``ValueError`` raised inside the run (MCP setup, provider adapter,
     anywhere) must bubble to :meth:`AgentHarness.run`'s safety net, which logs
     the full traceback and converts to an errored result tagged with the
@@ -780,7 +797,7 @@ def test_execute_lets_value_error_reach_base_safety_net(monkeypatch):
     assert result.output.startswith("Error: ")
 
 
-def test_execute_times_out_via_config_timeout_sec(monkeypatch):
+def test_execute_times_out_via_config_timeout_sec(monkeypatch: pytest.MonkeyPatch) -> None:
     """``AgentConfig.timeout_sec`` must bound the whole run — a hanging MCP
     server or provider call converts to an errored result at the deadline
     instead of wedging the benchmark (review finding: the field was ignored)."""
@@ -796,7 +813,7 @@ def test_execute_times_out_via_config_timeout_sec(monkeypatch):
     assert "timed out after 0.05s" in result.errors[0]
 
 
-def test_execute_reraises_internal_timeout_before_deadline(monkeypatch):
+def test_execute_reraises_internal_timeout_before_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
     """A ``TimeoutError`` from inside the run (e.g. a provider socket timeout —
     ``socket.timeout`` is ``TimeoutError`` since 3.10) raised well before the
     configured deadline must not be relabeled as the agent-level timeout: it
@@ -814,7 +831,7 @@ def test_execute_reraises_internal_timeout_before_deadline(monkeypatch):
     assert result.errors[0] == "TimeoutError: socket read timed out"
 
 
-def test_execute_honors_max_turns_zero(monkeypatch):
+def test_execute_honors_max_turns_zero(monkeypatch: pytest.MonkeyPatch) -> None:
     """``max_turns=0`` means zero model turns — it must not be silently
     replaced by the 50-turn default via a falsy-``or`` (review finding)."""
     fake = _FakeLLMClient([_Turn(text="never called")])
@@ -825,7 +842,9 @@ def test_execute_honors_max_turns_zero(monkeypatch):
     assert result.output == ""
 
 
-def test_execute_warns_when_extra_mcp_servers_dropped(monkeypatch, caplog):
+def test_execute_warns_when_extra_mcp_servers_dropped(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     """Only the first MCP binding is honored (documented aggregate behavior);
     dropping servers 2..N must at least be visible in the logs."""
     fake = _FakeLLMClient([_Turn(text="ok")])
@@ -848,7 +867,7 @@ def test_execute_warns_when_extra_mcp_servers_dropped(monkeypatch, caplog):
 # ---------------------------------------------------------------------------
 
 
-def test_execute_ignores_bench_use_mcp_env(monkeypatch):
+def test_execute_ignores_bench_use_mcp_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Setting BENCH_USE_MCP must not change the agent's behavior.
 
     The MCP on/off gate is ``config.capabilities.mcp`` (a binding with a
@@ -862,7 +881,7 @@ def test_execute_ignores_bench_use_mcp_env(monkeypatch):
     assert result.output == "ok"
 
 
-def test_agent_source_has_no_bench_use_mcp_or_environ_reads():
+def test_agent_source_has_no_bench_use_mcp_or_environ_reads() -> None:
     """Statically verify the agents/api source carries no env-smuggling.
 
     The conventions doc forbids agents from reading ``BENCH_USE_MCP`` (the
@@ -951,7 +970,7 @@ def test_agent_source_has_no_bench_use_mcp_or_environ_reads():
                 )
 
 
-def test_api_package_does_not_expose_legacy_context_or_system_instruction():
+def test_api_package_does_not_expose_legacy_context_or_system_instruction() -> None:
     """The PR2 contract drops the ``context``/``system_instruction`` grab-bag.
 
     No symbol or kwarg with that name should remain in the public surface.
@@ -971,7 +990,7 @@ def test_api_package_does_not_expose_legacy_context_or_system_instruction():
 
 
 @pytest.mark.parametrize("method_name", ["_execute"])
-def test_execute_is_synchronous_and_safe_for_harness_invocation(method_name):
+def test_execute_is_synchronous_and_safe_for_harness_invocation(method_name: str) -> None:
     """The harness calls ``run(prompt)`` synchronously; ``_execute`` must be sync too."""
     import inspect
 
@@ -987,7 +1006,7 @@ def test_execute_is_synchronous_and_safe_for_harness_invocation(method_name):
 # ---------------------------------------------------------------------------
 
 
-def test_api_agent_satisfies_all_three_capability_protocols():
+def test_api_agent_satisfies_all_three_capability_protocols() -> None:
     """``isinstance`` against each Protocol is how the harness negotiates
     capabilities before granting a binding (handoff §6). ApiAgent declares
     every capability it can drive — MCP, skills, rules — so an instance must
@@ -998,7 +1017,7 @@ def test_api_agent_satisfies_all_three_capability_protocols():
     assert isinstance(agent, SupportsRules)
 
 
-def test_api_agent_mirrors_capability_bindings_onto_mixin_attributes():
+def test_api_agent_mirrors_capability_bindings_onto_mixin_attributes() -> None:
     """The structural-Protocol attributes (``mcp_servers``/``skills``/``rules``)
     must reflect the bindings the orchestrator granted; otherwise capability
     negotiation would see the mixin defaults instead of the live config."""
@@ -1019,7 +1038,7 @@ def test_api_agent_mirrors_capability_bindings_onto_mixin_attributes():
 # ---------------------------------------------------------------------------
 
 
-def test_execute_runs_with_mcp_only_no_skills(monkeypatch):
+def test_execute_runs_with_mcp_only_no_skills(monkeypatch: pytest.MonkeyPatch) -> None:
     """MCP binding present, skills binding empty → MCP path opens, no skills loaded."""
     fc = [{"name": "do_thing", "args": {}, "id": "c1"}]
     fake = _FakeLLMClient([_Turn(text="working", calls=fc), _Turn(text="done")])
@@ -1034,7 +1053,9 @@ def test_execute_runs_with_mcp_only_no_skills(monkeypatch):
     assert "skills_loaded" not in result.metadata  # SkillBinding stayed empty
 
 
-def test_execute_runs_with_both_mcp_and_skills(monkeypatch, tmp_path):
+def test_execute_runs_with_both_mcp_and_skills(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Both bindings populated → MCP session is opened *and* skills are discovered."""
     skill_dir = tmp_path / "skills"
     (skill_dir / "demo").mkdir(parents=True)
@@ -1058,7 +1079,7 @@ def test_execute_runs_with_both_mcp_and_skills(monkeypatch, tmp_path):
     assert result.metadata["skills_loaded"] == ["demo"]
 
 
-def test_execute_runs_with_neither_mcp_nor_skills(monkeypatch):
+def test_execute_runs_with_neither_mcp_nor_skills(monkeypatch: pytest.MonkeyPatch) -> None:
     """Default capabilities → tool-less run, no MCP session, no skills loaded."""
     fake = _FakeLLMClient([_Turn(text="bare")])
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
@@ -1077,7 +1098,9 @@ def test_execute_runs_with_neither_mcp_nor_skills(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_execute_threads_rules_text_into_system_instruction(monkeypatch):
+def test_execute_threads_rules_text_into_system_instruction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Non-empty rules text must ride on the provider's ``system_instruction``."""
     fake = _FakeLLMClient([_Turn(text="ok")])
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
@@ -1086,7 +1109,9 @@ def test_execute_threads_rules_text_into_system_instruction(monkeypatch):
     assert fake.calls[0]["system_instruction"] == "be careful"
 
 
-def test_execute_empty_rules_text_yields_none_system_instruction(monkeypatch):
+def test_execute_empty_rules_text_yields_none_system_instruction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Empty rules text → ``system_instruction=None`` (the loop's "no preamble")."""
     fake = _FakeLLMClient([_Turn(text="ok")])
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
@@ -1100,7 +1125,7 @@ def test_execute_empty_rules_text_yields_none_system_instruction(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_execute_skips_mcp_when_binding_has_no_command(monkeypatch):
+def test_execute_skips_mcp_when_binding_has_no_command(monkeypatch: pytest.MonkeyPatch) -> None:
     """A binding with no launch command (CLI-agent shape) → API agent runs MCP-off."""
     fake = _FakeLLMClient([_Turn(text="ok")])
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
@@ -1114,7 +1139,9 @@ def test_execute_skips_mcp_when_binding_has_no_command(monkeypatch):
     assert result.output == "ok"
 
 
-def test_execute_preserves_spaced_command_token_through_shlex_roundtrip(monkeypatch):
+def test_execute_preserves_spaced_command_token_through_shlex_roundtrip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A spaced argv token (``("uv run", "mcp-server")``) must reach MCPClient
     intact: ``shlex.join`` quotes it on the way in, ``MCPClient``'s
     ``shlex.split`` recovers the original parts on the way out.

--- a/tests/unit/agents/api/test_agents_api_agent.py
+++ b/tests/unit/agents/api/test_agents_api_agent.py
@@ -1,0 +1,1148 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for :mod:`devops_bench.agents.api.agent`."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from devops_bench.agents import AGENTS, AgentConfig
+from devops_bench.agents.api import agent as agent_mod
+from devops_bench.agents.api.agent import (
+    ApiAgent,
+    extract_tokens,
+    fold_trajectory,
+)
+from devops_bench.agents.capabilities import (
+    AgentRules,
+    AllCapabilities,
+    McpBinding,
+    SkillBinding,
+    SupportsMcp,
+    SupportsRules,
+    SupportsSkills,
+)
+from devops_bench.models.base import LLMClient
+
+
+def _mcp_caps(command: str = "server", *, tools: tuple[str, ...] = ()) -> AllCapabilities:
+    """Helper: build capabilities that turn the API agent's MCP path on."""
+    return AllCapabilities(
+        mcp_servers=(McpBinding(name="test", command=tuple(command.split()), tools=tools),),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Turn:
+    """One scripted response in :class:`_FakeLLMClient`.
+
+    Attributes:
+        text: ``get_text_content`` payload for this turn.
+        calls: Function calls returned by ``extract_function_calls`` (each in
+            the neutral ``{"name", "args", "id"}`` shape).
+        usage: Optional duck-typed usage object surfaced on the raw response.
+        usage_attr: Which attribute name to attach ``usage`` under. Defaults to
+            ``"usage_metadata"`` (Google shape); set ``"usage"`` to exercise
+            Anthropic / OpenAI / Ollama paths.
+    """
+
+    text: str
+    calls: list[dict] = field(default_factory=list)
+    usage: Any = None
+    usage_attr: str = "usage_metadata"
+
+
+class _FakeLLMClient(LLMClient):
+    """Scripted :class:`LLMClient` that returns ``_Turn`` objects in order.
+
+    Records every ``generate_content`` invocation and tracks whether
+    ``format_tools`` was called so the agent's caller-formats-tools contract is
+    asserted.
+    """
+
+    def __init__(self, turns: list[_Turn]) -> None:
+        self._turns = list(turns)
+        self.calls: list[dict] = []
+        self.format_tools_calls: list[Any] = []
+
+    async def generate_content(
+        self,
+        contents: list[dict[str, Any]],
+        tools: Any,
+        system_instruction: str | None,
+    ) -> Any:
+        if not self._turns:
+            raise AssertionError("FakeLLMClient ran out of scripted turns")
+        turn = self._turns.pop(0)
+        self.calls.append(
+            {
+                "contents": [dict(msg) for msg in contents],
+                "tools": tools,
+                "system_instruction": system_instruction,
+            }
+        )
+        response = SimpleNamespace(text=turn.text, calls=turn.calls)
+        if turn.usage is not None:
+            setattr(response, turn.usage_attr, turn.usage)
+        return response
+
+    def format_tools(self, mcp_tools: Any) -> Any:
+        # Snapshot so tests can assert the agent does pre-format tools before
+        # calling the loop.
+        self.format_tools_calls.append(list(mcp_tools))
+        return ("formatted", tuple(getattr(t, "name", "") for t in mcp_tools))
+
+    def extract_function_calls(self, response: Any) -> list[dict]:
+        return list(response.calls)
+
+    def get_text_content(self, response: Any) -> str:
+        return response.text
+
+
+class _FakeMCPClient:
+    """Stand-in for :class:`MCPClient` exposing only what the agent uses.
+
+    Records every call so tests assert dispatch hit MCP (or skipped it).
+    """
+
+    def __init__(self, tools: list[Any] | None = None) -> None:
+        self._tools = list(tools or [])
+        self.calls: list[tuple[str, dict]] = []
+        self.entered = False
+        self.exited = False
+
+    async def __aenter__(self) -> _FakeMCPClient:
+        self.entered = True
+        return self
+
+    async def __aexit__(self, *_a: Any) -> None:
+        self.exited = True
+
+    async def list_tools(self) -> Any:
+        return SimpleNamespace(tools=self._tools)
+
+    async def call_tool(self, name: str, arguments: dict) -> Any:
+        self.calls.append((name, arguments))
+        block = SimpleNamespace(text=f"mcp-result-of-{name}")
+        return SimpleNamespace(content=[block])
+
+
+# ---------------------------------------------------------------------------
+# Registration & registry wiring
+# ---------------------------------------------------------------------------
+
+
+def test_api_agent_registered_under_canonical_key():
+    assert AGENTS.get("api") is ApiAgent
+
+
+def test_package_import_alone_registers_api_agent():
+    """``import devops_bench.agents.api`` (no ``.agent`` submodule import) must
+    register the harness — the documented consumer convention resolves via
+    ``AGENTS.get`` after a package import. Runs in a fresh interpreter because
+    this test module itself imports ``.agent``, which would mask a regression
+    (review finding: the package ``__init__`` didn't import the module, so the
+    registration decorator never ran)."""
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import devops_bench.agents.api
+        from devops_bench.agents.base import AGENTS
+        assert AGENTS.get("api").__name__ == "ApiAgent"
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# fold_trajectory
+# ---------------------------------------------------------------------------
+
+
+def test_fold_trajectory_pairs_assistant_calls_with_tool_results():
+    contents = [
+        {"role": "user", "content": "g"},
+        {
+            "role": "assistant",
+            "content": "thinking",
+            "tool_calls": [
+                {"name": "alpha", "args": {"a": 1}, "id": "1"},
+                {"name": "beta", "args": {"b": 2}, "id": "2"},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "1", "name": "alpha", "content": "A-result"},
+        {"role": "tool", "tool_call_id": "2", "name": "beta", "content": "B-result"},
+        {"role": "assistant", "content": "all done"},
+    ]
+    assert fold_trajectory(contents) == [
+        {"name": "alpha", "args": {"a": 1}, "result": "A-result", "status": "completed"},
+        {"name": "beta", "args": {"b": 2}, "result": "B-result", "status": "completed"},
+    ]
+
+
+def test_fold_trajectory_marks_dispatcher_errors_as_error_status():
+    # The dispatcher returns ``"Error: ..."`` for a failed tool call (matching
+    # the agent's _build_dispatch contract) — folding must surface that as the
+    # ``"error"`` status so metrics see the failure mode, not a clean call.
+    contents = [
+        {"role": "user", "content": "g"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"name": "boom", "args": {}, "id": "x"}],
+        },
+        {"role": "tool", "tool_call_id": "x", "name": "boom", "content": "Error: kaboom"},
+        {"role": "assistant", "content": "abort"},
+    ]
+    folded = fold_trajectory(contents)
+    assert folded == [
+        {"name": "boom", "args": {}, "result": "Error: kaboom", "status": "error"},
+    ]
+
+
+def test_fold_trajectory_leaves_unmatched_call_as_called_status():
+    # If a result never lands (e.g. dispatch raised before appending), the call
+    # entry survives with ``status="called"`` and ``result=None`` rather than
+    # being silently dropped.
+    contents = [
+        {"role": "user", "content": "g"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"name": "lost", "args": {}, "id": "9"}],
+        },
+    ]
+    assert fold_trajectory(contents) == [
+        {"name": "lost", "args": {}, "result": None, "status": "called"},
+    ]
+
+
+def test_fold_trajectory_skips_text_only_turns():
+    contents = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "assistant", "content": "bye"},
+    ]
+    assert fold_trajectory(contents) == []
+
+
+def test_fold_trajectory_handles_none_args_and_none_call_id():
+    # Defensive: missing ``args`` becomes ``{}``; an entry with no ``id`` is
+    # emitted as ``status="called"`` (no result to pair with).
+    contents = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"name": "t", "args": None, "id": None}],
+        },
+    ]
+    assert fold_trajectory(contents) == [
+        {"name": "t", "args": {}, "result": None, "status": "called"},
+    ]
+
+
+def test_fold_trajectory_pairs_unkeyed_gemini_style_calls_fifo():
+    """Gemini emits every function call with ``id=None`` and ``run_tool_loop``
+    appends one result per call in order — the fold must pair them FIFO
+    instead of dropping every result as an orphan (review finding: the default
+    provider produced all-'called' trajectories and errored every clean run)."""
+    contents = [
+        {"role": "user", "content": "g"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"name": "alpha", "args": {"a": 1}, "id": None},
+                {"name": "beta", "args": {"b": 2}, "id": None},
+            ],
+        },
+        {"role": "tool", "tool_call_id": None, "name": "alpha", "content": "A-result"},
+        {"role": "tool", "tool_call_id": None, "name": "beta", "content": "Error: b"},
+        {"role": "assistant", "content": "done"},
+    ]
+    from devops_bench.agents.api.agent import _fold_with_extraction_errors
+
+    folded, orphans = _fold_with_extraction_errors(contents)
+    assert orphans == []
+    assert folded == [
+        {"name": "alpha", "args": {"a": 1}, "result": "A-result", "status": "completed"},
+        {"name": "beta", "args": {"b": 2}, "result": "Error: b", "status": "error"},
+    ]
+
+
+def test_fold_trajectory_extra_unkeyed_result_is_still_an_orphan():
+    """Id-less results beyond the number of id-less calls stay orphans —
+    FIFO pairing must not absorb genuinely unmatched results."""
+    contents = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"name": "t", "args": {}, "id": None}],
+        },
+        {"role": "tool", "tool_call_id": None, "name": "t", "content": "paired"},
+        {"role": "tool", "tool_call_id": None, "name": "ghost", "content": "stray"},
+    ]
+    from devops_bench.agents.api.agent import _fold_with_extraction_errors
+
+    folded, orphans = _fold_with_extraction_errors(contents)
+    assert folded == [{"name": "t", "args": {}, "result": "paired", "status": "completed"}]
+    assert len(orphans) == 1
+    assert "stray" in orphans[0]
+
+
+def test_fold_trajectory_drops_unpaired_tool_results_silently_from_trajectory():
+    """An orphan ``role: tool`` (no matching assistant call_id) is dropped from
+    the canonical trajectory — synthesizing a free-floating entry would break
+    the "every trajectory item is a real ToolCall the model issued" invariant
+    metrics depend on. The diagnostic flows out via ``_fold_with_extraction_errors``
+    instead (asserted in ``test_execute_orphan_tool_result_lands_in_errors``).
+    """
+    contents = [
+        {"role": "user", "content": "g"},
+        # No assistant turn → no matching call_id for the ghost result.
+        {"role": "tool", "tool_call_id": "ghost", "name": "x", "content": "?"},
+    ]
+    assert fold_trajectory(contents) == []
+
+
+def test_fold_with_extraction_errors_surfaces_orphan_results():
+    from devops_bench.agents.api.agent import _fold_with_extraction_errors
+
+    contents = [
+        {"role": "user", "content": "g"},
+        {"role": "tool", "tool_call_id": "ghost", "name": "x", "content": "stray"},
+    ]
+    folded, orphans = _fold_with_extraction_errors(contents)
+    assert folded == []
+    assert len(orphans) == 1
+    assert "no matching call" in orphans[0]
+    assert "ghost" in orphans[0]
+
+
+# ---------------------------------------------------------------------------
+# extract_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_extract_tokens_reads_usage_metadata():
+    usage = SimpleNamespace(prompt_token_count=3, candidates_token_count=5, total_token_count=8)
+    response = SimpleNamespace(usage_metadata=usage)
+    assert extract_tokens(response) == {
+        "prompt_tokens": 3,
+        "candidates_tokens": 5,
+        "total_tokens": 8,
+    }
+
+
+def test_extract_tokens_falls_back_to_usage_attribute():
+    usage = SimpleNamespace(prompt_token_count=1, candidates_token_count=2, total_token_count=3)
+    # No ``usage_metadata``; the function should still find ``usage``.
+    response = SimpleNamespace(usage=usage)
+    assert extract_tokens(response) == {
+        "prompt_tokens": 1,
+        "candidates_tokens": 2,
+        "total_tokens": 3,
+    }
+
+
+def test_extract_tokens_returns_empty_dict_when_no_usage():
+    assert extract_tokens(SimpleNamespace()) == {}
+    assert extract_tokens(None) == {}
+
+
+def test_extract_tokens_defaults_missing_counts_to_zero():
+    """Missing counts default to 0; if the source provided no total but the
+    other two fields are non-zero, the helper computes prompt+candidates so a
+    non-empty run never shows ``total_tokens: 0`` in results.json."""
+    usage = SimpleNamespace(prompt_token_count=4)  # other counts unset
+    response = SimpleNamespace(usage_metadata=usage)
+    assert extract_tokens(response) == {
+        "prompt_tokens": 4,
+        "candidates_tokens": 0,
+        # 4 + 0 (no source total provided, but a non-zero prompt → compute it).
+        "total_tokens": 4,
+    }
+
+
+def test_extract_tokens_reads_anthropic_input_output_shape():
+    """Anthropic emits ``usage.input_tokens`` / ``usage.output_tokens`` and **no**
+    aggregated total. The helper must map both onto the legacy keys and compute
+    the total so non-Google providers do not silently drop tokens.
+
+    Regression test for the blocking bug found in review: the previous
+    extract_tokens only read Google-style fields and returned zeros for any
+    Anthropic response, corrupting token metrics in results.json.
+    """
+    usage = SimpleNamespace(input_tokens=42, output_tokens=17)
+    response = SimpleNamespace(usage=usage)
+    assert extract_tokens(response) == {
+        "prompt_tokens": 42,
+        "candidates_tokens": 17,
+        "total_tokens": 59,
+    }
+
+
+def test_extract_tokens_reads_openai_ollama_shape():
+    """OpenAI / Ollama emit ``usage.prompt_tokens`` / ``completion_tokens`` /
+    ``total_tokens``. The helper must map ``completion_tokens`` → the legacy
+    ``candidates_tokens`` slot and pass ``total_tokens`` through verbatim.
+
+    Regression test for the same blocking bug — Ollama responses returned
+    all-zero tokens before the provider-shape detection landed.
+    """
+    usage = SimpleNamespace(prompt_tokens=10, completion_tokens=20, total_tokens=30)
+    response = SimpleNamespace(usage=usage)
+    assert extract_tokens(response) == {
+        "prompt_tokens": 10,
+        "candidates_tokens": 20,
+        "total_tokens": 30,
+    }
+
+
+def test_extract_tokens_google_total_passes_through_when_present():
+    """When the provider supplies its own total it wins over the computed sum."""
+    usage = SimpleNamespace(prompt_token_count=5, candidates_token_count=7, total_token_count=99)
+    response = SimpleNamespace(usage_metadata=usage)
+    # The helper does not second-guess a provider-supplied total even when it
+    # disagrees with prompt+candidates (some providers include reasoning/cached
+    # tokens in the total).
+    assert extract_tokens(response)["total_tokens"] == 99
+
+
+def test_extract_tokens_preserves_legacy_on_disk_key_scheme():
+    """The on-disk dict shape must stay ``{prompt_tokens, candidates_tokens,
+    total_tokens}`` for D3 (results.json stability) — three keys, exactly.
+    """
+    usage = SimpleNamespace(input_tokens=1, output_tokens=2)
+    keys = set(extract_tokens(SimpleNamespace(usage=usage)).keys())
+    assert keys == {"prompt_tokens", "candidates_tokens", "total_tokens"}
+
+
+# ---------------------------------------------------------------------------
+# ApiAgent._execute — MCP-off path
+# ---------------------------------------------------------------------------
+
+
+def test_execute_runs_with_no_tools_when_capabilities_default(monkeypatch):
+    """Default capabilities (no MCP binding, no skills) → loop runs tool-less.
+
+    Renamed from ``..._when_target_unset`` because the MCP gate is no longer
+    ``config.target`` — it's ``config.capabilities.mcp``. The old name
+    survives in git history but the new one matches the post-PR3 reality.
+    """
+    fake = _FakeLLMClient(
+        [
+            _Turn(
+                text="done",
+                usage=SimpleNamespace(
+                    prompt_token_count=3,
+                    candidates_token_count=5,
+                    total_token_count=8,
+                ),
+            )
+        ]
+    )
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+
+    agent = ApiAgent(AgentConfig())
+    result = agent.run("hello")
+
+    assert result.output == "done"
+    assert result.trajectory == []
+    assert result.tokens == {
+        "prompt_tokens": 3,
+        "candidates_tokens": 5,
+        "total_tokens": 8,
+    }
+    assert result.errors == []
+    # Caller-formats-tools: the agent must call format_tools on the (empty)
+    # skill list before invoking the loop.
+    assert fake.format_tools_calls == [[]]
+    # The loop saw the pre-formatted tools sentinel, not the raw list.
+    assert fake.calls[0]["tools"] == ("formatted", ())
+
+
+def test_execute_passes_explicit_provider_and_model_to_get_model(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_get_model(provider, model):
+        captured["provider"] = provider
+        captured["model"] = model
+        return _FakeLLMClient([_Turn(text="ok")])
+
+    monkeypatch.setattr(agent_mod, "get_model", fake_get_model)
+    cfg = AgentConfig(provider="anthropic", model="claude-3-5")
+    ApiAgent(cfg).run("p")
+    assert captured == {"provider": "anthropic", "model": "claude-3-5"}
+
+
+def test_execute_records_anthropic_tokens_through_to_agentresult(monkeypatch):
+    """End-to-end: an Anthropic-shaped usage object surfaces on
+    ``AgentResult.tokens`` under the legacy key scheme — regression for the
+    blocking bug where non-Google providers silently logged zero tokens."""
+    fake = _FakeLLMClient(
+        [
+            _Turn(
+                text="done",
+                usage=SimpleNamespace(input_tokens=42, output_tokens=17),
+                usage_attr="usage",
+            )
+        ]
+    )
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    result = ApiAgent(AgentConfig()).run("p")
+    assert result.tokens == {
+        "prompt_tokens": 42,
+        "candidates_tokens": 17,
+        "total_tokens": 59,
+    }
+
+
+def test_execute_records_openai_tokens_through_to_agentresult(monkeypatch):
+    """End-to-end: an OpenAI/Ollama-shaped usage object surfaces under the
+    legacy key scheme."""
+    fake = _FakeLLMClient(
+        [
+            _Turn(
+                text="done",
+                usage=SimpleNamespace(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+                usage_attr="usage",
+            )
+        ]
+    )
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    result = ApiAgent(AgentConfig()).run("p")
+    assert result.tokens == {
+        "prompt_tokens": 10,
+        "candidates_tokens": 20,
+        "total_tokens": 30,
+    }
+
+
+# ---------------------------------------------------------------------------
+# ApiAgent._execute — MCP-on, trajectory folding & tools_used metadata
+# ---------------------------------------------------------------------------
+
+
+def test_execute_folds_assistant_tool_pairs_into_canonical_trajectory(monkeypatch):
+    """End-to-end: an MCP tool turn followed by a finishing turn → one ToolCall."""
+    fc = [{"name": "do_thing", "args": {"a": 1}, "id": "call-1"}]
+    fake = _FakeLLMClient(
+        [
+            _Turn(text="working", calls=fc),
+            _Turn(
+                text="done",
+                usage=SimpleNamespace(
+                    prompt_token_count=10,
+                    candidates_token_count=20,
+                    total_token_count=30,
+                ),
+            ),
+        ]
+    )
+    mcp_advertised = [SimpleNamespace(name="do_thing", description="d", inputSchema=None)]
+    mcp = _FakeMCPClient(tools=mcp_advertised)
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+
+    result = ApiAgent(AgentConfig(capabilities=_mcp_caps("server"))).run("ping")
+
+    assert result.output == "done"
+    assert result.trajectory == [
+        {
+            "name": "do_thing",
+            "args": {"a": 1},
+            "result": "mcp-result-of-do_thing",
+            "status": "completed",
+        },
+    ]
+    assert result.tokens == {
+        "prompt_tokens": 10,
+        "candidates_tokens": 20,
+        "total_tokens": 30,
+    }
+    assert result.errors == []
+    assert result.metadata["tools_used"] == ["do_thing"]
+    # MCP session was entered & exited via the async-context-manager protocol.
+    assert mcp.entered and mcp.exited
+    # The agent passed the MCP-advertised tool through format_tools before
+    # invoking the loop (caller-formats-tools contract).
+    assert fake.format_tools_calls == [mcp_advertised]
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher error handling
+# ---------------------------------------------------------------------------
+
+
+def test_execute_dispatch_error_lands_in_errors_and_continues(monkeypatch):
+    """A tool call that raises must surface on errors, not crash the agent."""
+
+    class _ExplodingMCP(_FakeMCPClient):
+        async def call_tool(self, name: str, arguments: dict) -> Any:
+            raise RuntimeError("kaboom")
+
+    fc = [{"name": "boom", "args": {}, "id": "c1"}]
+    fake = _FakeLLMClient(
+        [
+            _Turn(text="trying", calls=fc),
+            _Turn(text="giving up"),
+        ]
+    )
+    mcp = _ExplodingMCP(tools=[SimpleNamespace(name="boom", description="d", inputSchema=None)])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+
+    result = ApiAgent(AgentConfig(capabilities=_mcp_caps("server"))).run("ping")
+
+    assert result.output == "giving up"
+    assert any("Error calling tool boom" in e for e in result.errors)
+    # The trajectory still records the failed call with ``status="error"`` so
+    # the metrics layer can see the failure mode.
+    assert result.trajectory == [
+        {"name": "boom", "args": {}, "result": "Error: kaboom", "status": "error"},
+    ]
+
+
+def test_execute_marks_mcp_iserror_result_as_error(monkeypatch):
+    """An MCP server reporting failure via ``CallToolResult.isError`` (rather
+    than raising) must fold as ``status="error"`` and land on ``errors`` —
+    previously the flag was ignored and failures scored as completed (review
+    finding)."""
+
+    class _IsErrorMCP(_FakeMCPClient):
+        async def call_tool(self, name: str, arguments: dict) -> Any:
+            block = SimpleNamespace(text="unknown pod foo")
+            return SimpleNamespace(content=[block], isError=True)
+
+    fc = [{"name": "get_pod", "args": {}, "id": "c1"}]
+    fake = _FakeLLMClient([_Turn(text="trying", calls=fc), _Turn(text="giving up")])
+    mcp = _IsErrorMCP(tools=[SimpleNamespace(name="get_pod", description="d", inputSchema=None)])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+
+    result = ApiAgent(AgentConfig(capabilities=_mcp_caps("server"))).run("ping")
+
+    assert any("Error calling tool get_pod" in e for e in result.errors)
+    assert result.trajectory == [
+        {
+            "name": "get_pod",
+            "args": {},
+            "result": "Error: unknown pod foo",
+            "status": "error",
+        },
+    ]
+
+
+def test_execute_records_missing_mcp_when_tool_requested_without_server(monkeypatch):
+    """No MCP server, but the model still requests a tool → recorded, not crashed."""
+    fc = [{"name": "ghost", "args": {}, "id": "c2"}]
+    fake = _FakeLLMClient(
+        [
+            _Turn(text="requesting", calls=fc),
+            _Turn(text="abandoned"),
+        ]
+    )
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    result = ApiAgent(AgentConfig()).run("p")  # no target -> no MCP
+
+    assert any("no MCP server is configured" in e for e in result.errors)
+    assert result.trajectory == [
+        {
+            "name": "ghost",
+            "args": {},
+            "result": (
+                "Error: tool 'ghost' requested but no MCP server is configured for this agent."
+            ),
+            "status": "error",
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Skills are independent of MCP
+# ---------------------------------------------------------------------------
+
+
+def test_execute_skills_discover_without_mcp(monkeypatch, tmp_path):
+    """Skills must be loadable on the MCP-off path, not gated on MCP being on."""
+    skill_dir = tmp_path / "skills"
+    skill = skill_dir / "demo" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill_body = '---\nname: "demo-skill"\ndescription: does things\n---\nbody\n'
+    skill.write_text(skill_body)
+
+    fc = [{"name": "skill_demo_skill", "args": {}, "id": "s1"}]
+    fake = _FakeLLMClient(
+        [
+            _Turn(text="using skill", calls=fc),
+            _Turn(text="done"),
+        ]
+    )
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    cfg = AgentConfig(
+        capabilities=AllCapabilities(skills=SkillBinding(paths=(str(skill_dir),))),
+    )  # NB: no mcp binding → MCP path disabled
+    result = ApiAgent(cfg).run("p")
+
+    assert result.errors == []  # skill dispatch hit the file, not the MCP error
+    # Dispatch serves the whole file (frontmatter + body) captured at
+    # discovery so the
+    # model can read either as it sees fit — matches the legacy semantic.
+    assert result.trajectory == [
+        {
+            "name": "skill_demo_skill",
+            "args": {},
+            "result": skill_body,
+            "status": "completed",
+        },
+    ]
+    assert result.metadata["skills_loaded"] == ["demo-skill"]
+    # format_tools received the synthetic skill descriptor — one entry.
+    assert len(fake.format_tools_calls[0]) == 1
+    assert fake.format_tools_calls[0][0].name == "skill_demo_skill"
+
+
+def test_execute_no_skills_no_mcp_runs_tool_less(monkeypatch):
+    """Empty skills + no target → loop seen no tools, no metadata noise."""
+    fake = _FakeLLMClient([_Turn(text="hi")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    result = ApiAgent(AgentConfig()).run("p")
+    assert result.output == "hi"
+    assert "skills_loaded" not in result.metadata
+    assert result.metadata["tools_used"] == []
+
+
+# ---------------------------------------------------------------------------
+# Surfaced model-construction errors / empty MCP target
+# ---------------------------------------------------------------------------
+
+
+def test_execute_lets_value_error_reach_base_safety_net(monkeypatch):
+    """A ``ValueError`` raised inside the run (MCP setup, provider adapter,
+    anywhere) must bubble to :meth:`AgentHarness.run`'s safety net, which logs
+    the full traceback and converts to an errored result tagged with the
+    exception type.
+
+    The agent previously intercepted ``ValueError`` itself "for empty MCP
+    commands" — a case its own pre-guard makes unreachable — thereby swallowing
+    unrelated ValueErrors without a traceback (review finding); the catch is
+    gone.
+    """
+
+    class _BoomMCP:
+        def __init__(self, _path: str) -> None: ...
+
+        async def __aenter__(self) -> _BoomMCP:
+            raise ValueError("bad provider argument")
+
+        async def __aexit__(self, *_a: Any) -> None: ...
+
+    fake = _FakeLLMClient([_Turn(text="never reached")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", _BoomMCP)
+
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="bad", command=("/never-spawned",)),),
+    )
+    result = ApiAgent(AgentConfig(capabilities=caps)).run("p")
+    assert result.has_errors()
+    # The base safety net formats as "<ExcType>: <msg>" — proof it was used.
+    assert result.errors[0] == "ValueError: bad provider argument"
+    assert result.output.startswith("Error: ")
+
+
+def test_execute_times_out_via_config_timeout_sec(monkeypatch):
+    """``AgentConfig.timeout_sec`` must bound the whole run — a hanging MCP
+    server or provider call converts to an errored result at the deadline
+    instead of wedging the benchmark (review finding: the field was ignored)."""
+
+    async def _hang(*_a: Any, **_kw: Any):
+        await asyncio.sleep(30)
+
+    monkeypatch.setattr(agent_mod, "_run_async", _hang)
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: _FakeLLMClient([]))
+
+    result = ApiAgent(AgentConfig(timeout_sec=0.05)).run("p")
+    assert result.has_errors()
+    assert "timed out after 0.05s" in result.errors[0]
+
+
+def test_execute_reraises_internal_timeout_before_deadline(monkeypatch):
+    """A ``TimeoutError`` from inside the run (e.g. a provider socket timeout —
+    ``socket.timeout`` is ``TimeoutError`` since 3.10) raised well before the
+    configured deadline must not be relabeled as the agent-level timeout: it
+    re-raises to the base safety net, which tags the exception type and logs
+    the traceback."""
+
+    async def _boom(*_a: Any, **_kw: Any):
+        raise TimeoutError("socket read timed out")
+
+    monkeypatch.setattr(agent_mod, "_run_async", _boom)
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: _FakeLLMClient([]))
+
+    result = ApiAgent(AgentConfig(timeout_sec=600.0)).run("p")
+    assert result.has_errors()
+    assert result.errors[0] == "TimeoutError: socket read timed out"
+
+
+def test_execute_honors_max_turns_zero(monkeypatch):
+    """``max_turns=0`` means zero model turns — it must not be silently
+    replaced by the 50-turn default via a falsy-``or`` (review finding)."""
+    fake = _FakeLLMClient([_Turn(text="never called")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    result = ApiAgent(AgentConfig(max_turns=0)).run("p")
+    # The loop never invoked the model.
+    assert fake.calls == []
+    assert result.output == ""
+
+
+def test_execute_warns_when_extra_mcp_servers_dropped(monkeypatch, caplog):
+    """Only the first MCP binding is honored (documented aggregate behavior);
+    dropping servers 2..N must at least be visible in the logs."""
+    fake = _FakeLLMClient([_Turn(text="ok")])
+    mcp = _FakeMCPClient(tools=[])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+    caps = AllCapabilities(
+        mcp_servers=(
+            McpBinding(name="one", command=("server-a",)),
+            McpBinding(name="two", command=("server-b",)),
+        ),
+    )
+    with caplog.at_level("WARNING", logger="devops_bench.agents.api.agent"):
+        ApiAgent(AgentConfig(capabilities=caps)).run("p")
+    assert any("only the first MCP binding" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# No env-smuggling — neither BENCH_USE_MCP nor any direct env read
+# ---------------------------------------------------------------------------
+
+
+def test_execute_ignores_bench_use_mcp_env(monkeypatch):
+    """Setting BENCH_USE_MCP must not change the agent's behavior.
+
+    The MCP on/off gate is ``config.capabilities.mcp`` (a binding with a
+    non-empty ``command``), not env.
+    """
+    monkeypatch.setenv("BENCH_USE_MCP", "false")
+    fake = _FakeLLMClient([_Turn(text="ok")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    # No MCP binding → loop runs without MCP regardless of the env flag.
+    result = ApiAgent(AgentConfig()).run("p")
+    assert result.output == "ok"
+
+
+def test_agent_source_has_no_bench_use_mcp_or_environ_reads():
+    """Statically verify the agents/api source carries no env-smuggling.
+
+    The conventions doc forbids agents from reading ``BENCH_USE_MCP`` (the
+    harness threads the boolean instead) or any ``os.environ`` lookups inside
+    the agent — capability/MCP on-off comes from ``AgentConfig``. This test
+    walks the agents/api source AST and asserts no code (i.e. anything that is
+    not a docstring or comment) references those names.
+    """
+    import ast
+    import pathlib
+
+    api_root = pathlib.Path(agent_mod.__file__).parent
+    forbidden_names = {"get_env", "get_bool", "first_env", "require_env"}
+    forbidden_strings = {"BENCH_USE_MCP"}
+
+    for src in api_root.glob("*.py"):
+        tree = ast.parse(src.read_text(), filename=str(src))
+
+        for node in ast.walk(tree):
+            # Bare names: ``get_env(...)`` / ``os.environ``.
+            if isinstance(node, ast.Name) and node.id in forbidden_names:
+                pytest.fail(
+                    f"{src.name} references env-helper {node.id!r} at line "
+                    f"{node.lineno}; config flows through AgentConfig"
+                )
+            # Attribute access: ``os.environ``, ``os.getenv``, and the
+            # ``os.environ.get(...)`` call form (which presents as an outer
+            # Attribute("get", Attribute("environ", Name("os")))).
+            if isinstance(node, ast.Attribute):
+                attr_chain = []
+                cur: ast.AST | None = node
+                while isinstance(cur, ast.Attribute):
+                    attr_chain.append(cur.attr)
+                    cur = cur.value
+                if isinstance(cur, ast.Name):
+                    attr_chain.append(cur.id)
+                joined = ".".join(reversed(attr_chain))
+                assert joined != "os.environ", (
+                    f"{src.name} accesses os.environ at line {node.lineno}; "
+                    "config flows through AgentConfig"
+                )
+                assert joined != "os.getenv", (
+                    f"{src.name} calls os.getenv at line {node.lineno}; "
+                    "config flows through AgentConfig"
+                )
+                assert joined != "os.environ.get", (
+                    f"{src.name} calls os.environ.get at line {node.lineno}; "
+                    "config flows through AgentConfig"
+                )
+            # Subscript access: ``os.environ["FOO"]`` / ``os.environ.get(...)``
+            # patterns. The outer ``ast.Subscript`` wraps the ``os.environ``
+            # attribute lookup; the inner Attribute is also caught above via
+            # ast.walk, but checking the Subscript explicitly makes the intent
+            # legible and bug-proofs the guard against future AST refactors.
+            if isinstance(node, ast.Subscript):
+                target = node.value
+                if isinstance(target, ast.Attribute):
+                    attr_chain = []
+                    cur = target
+                    while isinstance(cur, ast.Attribute):
+                        attr_chain.append(cur.attr)
+                        cur = cur.value
+                    if isinstance(cur, ast.Name):
+                        attr_chain.append(cur.id)
+                    joined = ".".join(reversed(attr_chain))
+                    assert joined != "os.environ", (
+                        f"{src.name} subscripts os.environ[...] at line "
+                        f"{node.lineno}; config flows through AgentConfig"
+                    )
+            # String literals: catch ``getenv("BENCH_USE_MCP")`` /
+            # ``os.environ["BENCH_USE_MCP"]`` patterns even when wrapped in a
+            # helper we didn't enumerate. Docstrings are still ``Str``/
+            # ``Constant`` nodes but the parent statement is an ``Expr`` at the
+            # head of a module/function/class — skip those.
+            if (
+                isinstance(node, ast.Constant)
+                and isinstance(node.value, str)
+                and node.value in forbidden_strings
+            ):
+                # Allow doc references — only reject when the same line names an
+                # env accessor (``environ`` / ``getenv`` / ``get_env``).
+                line_text = src.read_text().splitlines()[node.lineno - 1]
+                accessor_hit = any(a in line_text for a in ("environ", "getenv", "get_env"))
+                assert not accessor_hit, (
+                    f"{src.name} reads {node.value!r} via an env accessor at line {node.lineno}"
+                )
+
+
+def test_api_package_does_not_expose_legacy_context_or_system_instruction():
+    """The PR2 contract drops the ``context``/``system_instruction`` grab-bag.
+
+    No symbol or kwarg with that name should remain in the public surface.
+    """
+    import inspect
+
+    sig = inspect.signature(ApiAgent.run)
+    assert list(sig.parameters) == ["self", "prompt", "workspace_path"], (
+        "ApiAgent.run must take only (self, prompt, workspace_path); the legacy "
+        "context/system_instruction kwargs are gone."
+    )
+    assert "context" not in sig.parameters
+    assert "system_instruction" not in sig.parameters
+    init_sig = inspect.signature(ApiAgent.__init__)
+    # Inherited from AgentHarness — accepts config only.
+    assert list(init_sig.parameters) == ["self", "config"]
+
+
+@pytest.mark.parametrize("method_name", ["_execute"])
+def test_execute_is_synchronous_and_safe_for_harness_invocation(method_name):
+    """The harness calls ``run(prompt)`` synchronously; ``_execute`` must be sync too."""
+    import inspect
+
+    method = getattr(ApiAgent, method_name)
+    assert not inspect.iscoroutinefunction(method), (
+        f"ApiAgent.{method_name} must be synchronous so the harness can call "
+        "agent.run(prompt) without managing an event loop itself."
+    )
+
+
+# ---------------------------------------------------------------------------
+# PR3 — capability negotiation: ApiAgent implements every Supports* Protocol
+# ---------------------------------------------------------------------------
+
+
+def test_api_agent_satisfies_all_three_capability_protocols():
+    """``isinstance`` against each Protocol is how the harness negotiates
+    capabilities before granting a binding (handoff §6). ApiAgent declares
+    every capability it can drive — MCP, skills, rules — so an instance must
+    pass each ``runtime_checkable`` check."""
+    agent = ApiAgent(AgentConfig())
+    assert isinstance(agent, SupportsMcp)
+    assert isinstance(agent, SupportsSkills)
+    assert isinstance(agent, SupportsRules)
+
+
+def test_api_agent_mirrors_capability_bindings_onto_mixin_attributes():
+    """The structural-Protocol attributes (``mcp_servers``/``skills``/``rules``)
+    must reflect the bindings the orchestrator granted; otherwise capability
+    negotiation would see the mixin defaults instead of the live config."""
+    binding = McpBinding(name="x", command=("/bin/mcp",), tools=("t",))
+    caps = AllCapabilities(
+        mcp_servers=(binding,),
+        skills=SkillBinding(paths=("/sk",)),
+        rules=AgentRules(text="rules"),
+    )
+    agent = ApiAgent(AgentConfig(capabilities=caps))
+    assert agent.mcp_servers == (binding,)
+    assert agent.skills == SkillBinding(paths=("/sk",))
+    assert agent.rules == AgentRules(text="rules")
+
+
+# ---------------------------------------------------------------------------
+# Skills ⊥ MCP independence still holds under the binding-based config
+# ---------------------------------------------------------------------------
+
+
+def test_execute_runs_with_mcp_only_no_skills(monkeypatch):
+    """MCP binding present, skills binding empty → MCP path opens, no skills loaded."""
+    fc = [{"name": "do_thing", "args": {}, "id": "c1"}]
+    fake = _FakeLLMClient([_Turn(text="working", calls=fc), _Turn(text="done")])
+    mcp_tools = [SimpleNamespace(name="do_thing", description="d", inputSchema=None)]
+    mcp = _FakeMCPClient(tools=mcp_tools)
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+
+    result = ApiAgent(AgentConfig(capabilities=_mcp_caps("server"))).run("p")
+    assert result.errors == []
+    assert mcp.entered
+    assert "skills_loaded" not in result.metadata  # SkillBinding stayed empty
+
+
+def test_execute_runs_with_both_mcp_and_skills(monkeypatch, tmp_path):
+    """Both bindings populated → MCP session is opened *and* skills are discovered."""
+    skill_dir = tmp_path / "skills"
+    (skill_dir / "demo").mkdir(parents=True)
+    (skill_dir / "demo" / "SKILL.md").write_text('---\nname: "demo"\ndescription: x\n---\nbody\n')
+
+    fc = [{"name": "do_thing", "args": {}, "id": "c1"}]
+    fake = _FakeLLMClient([_Turn(text="working", calls=fc), _Turn(text="done")])
+    mcp = _FakeMCPClient(
+        tools=[SimpleNamespace(name="do_thing", description="d", inputSchema=None)]
+    )
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="t", command=("server",)),),
+        skills=SkillBinding(paths=(str(skill_dir),)),
+    )
+    result = ApiAgent(AgentConfig(capabilities=caps)).run("p")
+    assert result.errors == []
+    assert mcp.entered
+    assert result.metadata["skills_loaded"] == ["demo"]
+
+
+def test_execute_runs_with_neither_mcp_nor_skills(monkeypatch):
+    """Default capabilities → tool-less run, no MCP session, no skills loaded."""
+    fake = _FakeLLMClient([_Turn(text="bare")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    # If MCPClient is ever entered the test would import mcp; replace with a sentinel.
+    monkeypatch.setattr(
+        agent_mod, "MCPClient", lambda _path: pytest.fail("MCPClient must not be used")
+    )
+    result = ApiAgent(AgentConfig()).run("p")
+    assert result.output == "bare"
+    assert result.errors == []
+    assert "skills_loaded" not in result.metadata
+
+
+# ---------------------------------------------------------------------------
+# Rules flow into the loop's system_instruction
+# ---------------------------------------------------------------------------
+
+
+def test_execute_threads_rules_text_into_system_instruction(monkeypatch):
+    """Non-empty rules text must ride on the provider's ``system_instruction``."""
+    fake = _FakeLLMClient([_Turn(text="ok")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    caps = AllCapabilities(rules=AgentRules(text="be careful"))
+    ApiAgent(AgentConfig(capabilities=caps)).run("p")
+    assert fake.calls[0]["system_instruction"] == "be careful"
+
+
+def test_execute_empty_rules_text_yields_none_system_instruction(monkeypatch):
+    """Empty rules text → ``system_instruction=None`` (the loop's "no preamble")."""
+    fake = _FakeLLMClient([_Turn(text="ok")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    ApiAgent(AgentConfig()).run("p")
+    assert fake.calls[0]["system_instruction"] is None
+
+
+# ---------------------------------------------------------------------------
+# Mcp gate: an empty-command McpBinding does NOT open an MCP session in the
+# API agent (it is for CLI agents whose binary launches MCP in-process).
+# ---------------------------------------------------------------------------
+
+
+def test_execute_skips_mcp_when_binding_has_no_command(monkeypatch):
+    """A binding with no launch command (CLI-agent shape) → API agent runs MCP-off."""
+    fake = _FakeLLMClient([_Turn(text="ok")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(
+        agent_mod, "MCPClient", lambda _path: pytest.fail("MCPClient must not be used")
+    )
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="cli-shape", command=(), tools=("x",)),),
+    )
+    result = ApiAgent(AgentConfig(capabilities=caps)).run("p")
+    assert result.output == "ok"
+
+
+def test_execute_preserves_spaced_command_token_through_shlex_roundtrip(monkeypatch):
+    """A spaced argv token (``("uv run", "mcp-server")``) must reach MCPClient
+    intact: ``shlex.join`` quotes it on the way in, ``MCPClient``'s
+    ``shlex.split`` recovers the original parts on the way out.
+
+    Regression for the lossy ``" ".join`` that previously silently expanded
+    one token into two when the binding carried a spaced word (e.g. a launch
+    command that wraps an interpreter invocation).
+    """
+    import shlex
+
+    captured: dict = {}
+
+    class _RecordingMCP(_FakeMCPClient):
+        def __init__(self, path: str) -> None:
+            super().__init__(tools=[])
+            captured["path"] = path
+
+    fake = _FakeLLMClient([_Turn(text="done")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", _RecordingMCP)
+
+    original = ("uv run", "mcp-server", "--flag")
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="spaced", command=original),),
+    )
+    ApiAgent(AgentConfig(capabilities=caps)).run("p")
+
+    # MCPClient calls ``shlex.split`` on its ``server_path``; re-splitting the
+    # path the agent handed it must recover the original tuple element-for-
+    # element, including the spaced first token.
+    assert tuple(shlex.split(captured["path"])) == original

--- a/tests/unit/agents/api/test_agents_api_import_hygiene.py
+++ b/tests/unit/agents/api/test_agents_api_import_hygiene.py
@@ -1,0 +1,72 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``import devops_bench.agents.api`` must stay light per CONVENTIONS §8."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_agents_api_package_import_pulls_no_sdk_or_mcp():
+    """A fresh interpreter import of ``devops_bench.agents.api`` is mcp/SDK-free."""
+    script = textwrap.dedent(
+        """
+        import sys
+        import devops_bench.agents.api  # noqa: F401
+        loaded = sorted(sys.modules)
+        heavy = ['mcp', 'deepeval', 'anthropic', 'google.genai', 'openai']
+        hits = [m for m in loaded if any(m == h or m.startswith(h + '.') for h in heavy)]
+        if hits:
+            print('LEAKED:', ','.join(hits))
+            sys.exit(1)
+        print('OK')
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK" in result.stdout
+
+
+def test_agents_api_agent_module_import_pulls_no_sdk_or_mcp():
+    """Importing the concrete agent module must not eagerly load mcp / deepeval.
+
+    Even the module that holds the registered :class:`ApiAgent` must keep the
+    heavy imports function-local — the harness imports it (to register the
+    agent) on every benchmark startup, including dry runs that never invoke a
+    real MCP server.
+    """
+    script = textwrap.dedent(
+        """
+        import sys
+        import devops_bench.agents.api.agent  # noqa: F401
+        loaded = sorted(sys.modules)
+        heavy = ['mcp.client', 'mcp.server', 'deepeval', 'anthropic',
+                 'google.genai', 'openai']
+        hits = [m for m in loaded if any(m == h or m.startswith(h + '.') for h in heavy)]
+        if hits:
+            print('LEAKED:', ','.join(hits))
+            sys.exit(1)
+        print('OK')
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK" in result.stdout

--- a/tests/unit/agents/api/test_agents_api_import_hygiene.py
+++ b/tests/unit/agents/api/test_agents_api_import_hygiene.py
@@ -21,7 +21,7 @@ import sys
 import textwrap
 
 
-def test_agents_api_package_import_pulls_no_sdk_or_mcp():
+def test_agents_api_package_import_pulls_no_sdk_or_mcp() -> None:
     """A fresh interpreter import of ``devops_bench.agents.api`` is mcp/SDK-free."""
     script = textwrap.dedent(
         """
@@ -37,13 +37,13 @@ def test_agents_api_package_import_pulls_no_sdk_or_mcp():
         """
     )
     result = subprocess.run(
-        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False, timeout=30
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert "OK" in result.stdout
 
 
-def test_agents_api_agent_module_import_pulls_no_sdk_or_mcp():
+def test_agents_api_agent_module_import_pulls_no_sdk_or_mcp() -> None:
     """Importing the concrete agent module must not eagerly load mcp / deepeval.
 
     Even the module that holds the registered :class:`ApiAgent` must keep the
@@ -66,7 +66,7 @@ def test_agents_api_agent_module_import_pulls_no_sdk_or_mcp():
         """
     )
     result = subprocess.run(
-        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False, timeout=30
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert "OK" in result.stdout

--- a/tests/unit/agents/api/test_agents_api_mcp.py
+++ b/tests/unit/agents/api/test_agents_api_mcp.py
@@ -24,29 +24,29 @@ import pytest
 from devops_bench.agents.api.mcp import MCPClient, extract_tool_text
 
 
-def test_extract_tool_text_joins_text_blocks():
+def test_extract_tool_text_joins_text_blocks() -> None:
     blocks = [SimpleNamespace(text="alpha"), SimpleNamespace(text="beta")]
     assert extract_tool_text(SimpleNamespace(content=blocks)) == "alpha\nbeta"
 
 
-def test_extract_tool_text_skips_blocks_without_text():
+def test_extract_tool_text_skips_blocks_without_text() -> None:
     # A block missing ``.text`` must not crash; mixed lists fall through to the
     # text-only blocks.
     blocks = [SimpleNamespace(text="alpha"), SimpleNamespace()]
     assert extract_tool_text(SimpleNamespace(content=blocks)) == "alpha"
 
 
-def test_extract_tool_text_falls_back_to_str_when_no_blocks():
+def test_extract_tool_text_falls_back_to_str_when_no_blocks() -> None:
     obj = SimpleNamespace(content=[])
     assert extract_tool_text(obj) == str(obj)
 
 
-def test_extract_tool_text_falls_back_to_str_when_no_content_attr():
+def test_extract_tool_text_falls_back_to_str_when_no_content_attr() -> None:
     obj = SimpleNamespace()
     assert extract_tool_text(obj) == str(obj)
 
 
-def test_mcp_client_enter_rejects_empty_server_path():
+def test_mcp_client_enter_rejects_empty_server_path() -> None:
     # We must surface a clear error rather than spawning ``""``; ValueError
     # surfaces through the agent's _execute as an errored result (see
     # test_execute_returns_errored_on_empty_mcp_server_string).
@@ -55,7 +55,9 @@ def test_mcp_client_enter_rejects_empty_server_path():
         asyncio.run(client.__aenter__())
 
 
-def test_aenter_unwinds_exit_stack_when_session_setup_fails(monkeypatch):
+def test_aenter_unwinds_exit_stack_when_session_setup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """If session setup fails after the stdio transport spawned the server,
     ``__aenter__`` must unwind its exit stack — ``__aexit__`` never runs when
     ``__aenter__`` raises, so without the unwind the server subprocess leaks
@@ -91,7 +93,9 @@ def test_aenter_unwinds_exit_stack_when_session_setup_fails(monkeypatch):
     assert state["transport_exited"] is True
 
 
-def test_call_tool_degrades_gracefully_when_deepeval_missing(monkeypatch):
+def test_call_tool_degrades_gracefully_when_deepeval_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """If ``deepeval`` is not installed, ``call_tool`` still works (untraced).
 
     The legacy implementation imported ``deepeval.tracing.observe`` at the top
@@ -129,7 +133,7 @@ def test_call_tool_degrades_gracefully_when_deepeval_missing(monkeypatch):
     assert client.session.calls == [("t", {"k": "v"})]
 
 
-def test_mcp_module_does_not_import_sdk_at_module_load():
+def test_mcp_module_does_not_import_sdk_at_module_load() -> None:
     """Importing the module must not pull the ``mcp`` SDK — it loads on enter."""
     import subprocess
     import sys

--- a/tests/unit/agents/api/test_agents_api_mcp.py
+++ b/tests/unit/agents/api/test_agents_api_mcp.py
@@ -1,0 +1,156 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for :mod:`devops_bench.agents.api.mcp`."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from devops_bench.agents.api.mcp import MCPClient, extract_tool_text
+
+
+def test_extract_tool_text_joins_text_blocks():
+    blocks = [SimpleNamespace(text="alpha"), SimpleNamespace(text="beta")]
+    assert extract_tool_text(SimpleNamespace(content=blocks)) == "alpha\nbeta"
+
+
+def test_extract_tool_text_skips_blocks_without_text():
+    # A block missing ``.text`` must not crash; mixed lists fall through to the
+    # text-only blocks.
+    blocks = [SimpleNamespace(text="alpha"), SimpleNamespace()]
+    assert extract_tool_text(SimpleNamespace(content=blocks)) == "alpha"
+
+
+def test_extract_tool_text_falls_back_to_str_when_no_blocks():
+    obj = SimpleNamespace(content=[])
+    assert extract_tool_text(obj) == str(obj)
+
+
+def test_extract_tool_text_falls_back_to_str_when_no_content_attr():
+    obj = SimpleNamespace()
+    assert extract_tool_text(obj) == str(obj)
+
+
+def test_mcp_client_enter_rejects_empty_server_path():
+    # We must surface a clear error rather than spawning ``""``; ValueError
+    # surfaces through the agent's _execute as an errored result (see
+    # test_execute_returns_errored_on_empty_mcp_server_string).
+    client = MCPClient("   ")
+    with pytest.raises(ValueError, match="MCP server_path is empty"):
+        asyncio.run(client.__aenter__())
+
+
+def test_aenter_unwinds_exit_stack_when_session_setup_fails(monkeypatch):
+    """If session setup fails after the stdio transport spawned the server,
+    ``__aenter__`` must unwind its exit stack — ``__aexit__`` never runs when
+    ``__aenter__`` raises, so without the unwind the server subprocess leaks
+    (regression for the review finding)."""
+    import mcp.client.session as session_mod
+    import mcp.client.stdio as stdio_mod
+
+    state = {"transport_exited": False}
+
+    class _Transport:
+        def __init__(self, _params) -> None: ...
+
+        async def __aenter__(self):
+            return (SimpleNamespace(), SimpleNamespace())
+
+        async def __aexit__(self, *_a) -> None:
+            state["transport_exited"] = True
+
+    class _BoomSession:
+        def __init__(self, _r, _w) -> None: ...
+
+        async def __aenter__(self):
+            raise RuntimeError("handshake failed")
+
+        async def __aexit__(self, *_a) -> None: ...
+
+    monkeypatch.setattr(stdio_mod, "stdio_client", lambda params: _Transport(params))
+    monkeypatch.setattr(session_mod, "ClientSession", _BoomSession)
+
+    client = MCPClient("server")
+    with pytest.raises(RuntimeError, match="handshake failed"):
+        asyncio.run(client.__aenter__())
+    assert state["transport_exited"] is True
+
+
+def test_call_tool_degrades_gracefully_when_deepeval_missing(monkeypatch):
+    """If ``deepeval`` is not installed, ``call_tool`` still works (untraced).
+
+    The legacy implementation imported ``deepeval.tracing.observe`` at the top
+    of ``call_tool``, so a host without deepeval would crash with ImportError
+    on the first tool call. The fix mirrors
+    :func:`devops_bench.agents.base._maybe_observe`: try the import, fall
+    through to the bare ``call_tool`` on failure.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("deepeval"):
+            raise ImportError(f"simulated missing dependency: {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    sentinel = SimpleNamespace(content=[SimpleNamespace(text="ok")])
+
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict]] = []
+
+        async def call_tool(self, name: str, arguments: dict) -> SimpleNamespace:
+            self.calls.append((name, arguments))
+            return sentinel
+
+    client = MCPClient("does-not-matter")
+    client.session = _FakeSession()
+
+    result = asyncio.run(client.call_tool("t", {"k": "v"}))
+    assert result is sentinel
+    assert client.session.calls == [("t", {"k": "v"})]
+
+
+def test_mcp_module_does_not_import_sdk_at_module_load():
+    """Importing the module must not pull the ``mcp`` SDK — it loads on enter."""
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import sys
+        import devops_bench.agents.api.mcp  # noqa: F401
+        forbidden = ("mcp.client", "mcp.server", "deepeval", "anthropic",
+                     "google.genai", "openai")
+        hits = sorted(
+            m for m in sys.modules
+            if any(m == p or m.startswith(p + ".") for p in forbidden)
+        )
+        if hits:
+            sys.stderr.write("LEAKED:" + ",".join(hits))
+            sys.exit(1)
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/unit/agents/api/test_agents_api_skills.py
+++ b/tests/unit/agents/api/test_agents_api_skills.py
@@ -16,6 +16,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
+
 from devops_bench.agents.api.skills import (
     SkillToolInfo,
     discover_skill_tools,
@@ -23,7 +27,7 @@ from devops_bench.agents.api.skills import (
 )
 
 
-def test_parse_skill_md_extracts_frontmatter(tmp_path):
+def test_parse_skill_md_extracts_frontmatter(tmp_path: Path) -> None:
     f = tmp_path / "SKILL.md"
     f.write_text('---\nname: "my-skill"\ndescription: does things\n---\nbody text\n')
     name, description, content = parse_skill_md(str(f))
@@ -32,7 +36,7 @@ def test_parse_skill_md_extracts_frontmatter(tmp_path):
     assert "body text" in content
 
 
-def test_parse_skill_md_strips_single_and_double_quotes(tmp_path):
+def test_parse_skill_md_strips_single_and_double_quotes(tmp_path: Path) -> None:
     f = tmp_path / "SKILL.md"
     f.write_text("---\nname: 'quoted'\ndescription: \"plain\"\n---\n")
     name, description, _ = parse_skill_md(str(f))
@@ -40,7 +44,7 @@ def test_parse_skill_md_strips_single_and_double_quotes(tmp_path):
     assert description == "plain"
 
 
-def test_parse_skill_md_reads_multiline_block_scalar(tmp_path):
+def test_parse_skill_md_reads_multiline_block_scalar(tmp_path: Path) -> None:
     f = tmp_path / "SKILL.md"
     f.write_text(
         "---\n"
@@ -55,31 +59,31 @@ def test_parse_skill_md_reads_multiline_block_scalar(tmp_path):
     assert description == "use this skill when rotating a secret across namespaces"
 
 
-def test_parse_skill_md_missing_file_returns_none():
+def test_parse_skill_md_missing_file_returns_none() -> None:
     assert parse_skill_md("/nonexistent/SKILL.md") == (None, None, None)
 
 
-def test_parse_skill_md_no_frontmatter_returns_none(tmp_path):
+def test_parse_skill_md_no_frontmatter_returns_none(tmp_path: Path) -> None:
     f = tmp_path / "SKILL.md"
     f.write_text("just body, no frontmatter")
     assert parse_skill_md(str(f)) == (None, None, None)
 
 
-def test_discover_skill_tools_empty_paths_returns_empty_lists():
+def test_discover_skill_tools_empty_paths_returns_empty_lists() -> None:
     tools, resources, names = discover_skill_tools(())
     assert tools == []
     assert resources == {}
     assert names == []
 
 
-def test_discover_skill_tools_missing_path_is_skipped(tmp_path):
+def test_discover_skill_tools_missing_path_is_skipped(tmp_path: Path) -> None:
     tools, resources, names = discover_skill_tools((str(tmp_path / "missing"),))
     assert tools == []
     assert resources == {}
     assert names == []
 
 
-def test_discover_skill_tools_normalizes_dashes_to_underscores(tmp_path):
+def test_discover_skill_tools_normalizes_dashes_to_underscores(tmp_path: Path) -> None:
     skill = tmp_path / "first" / "SKILL.md"
     skill.parent.mkdir(parents=True)
     body = '---\nname: "my-cool-skill"\ndescription: ok\n---\nbody\n'
@@ -96,7 +100,7 @@ def test_discover_skill_tools_normalizes_dashes_to_underscores(tmp_path):
     assert names == ["my-cool-skill"]
 
 
-def test_discover_skill_tools_falls_back_to_default_description(tmp_path):
+def test_discover_skill_tools_falls_back_to_default_description(tmp_path: Path) -> None:
     """Missing description still loads the skill with a synthetic description."""
     skill = tmp_path / "SKILL.md"
     skill.write_text('---\nname: "noun"\n---\nbody\n')
@@ -104,7 +108,7 @@ def test_discover_skill_tools_falls_back_to_default_description(tmp_path):
     assert tools[0].description == "Exposes skill: noun"
 
 
-def test_discover_skill_tools_walks_multiple_paths(tmp_path):
+def test_discover_skill_tools_walks_multiple_paths(tmp_path: Path) -> None:
     a = tmp_path / "a" / "SKILL.md"
     b = tmp_path / "b" / "SKILL.md"
     for path, name in [(a, "alpha"), (b, "beta")]:
@@ -116,14 +120,14 @@ def test_discover_skill_tools_walks_multiple_paths(tmp_path):
     assert sorted(names) == ["alpha", "beta"]
 
 
-def test_discover_skill_tools_skips_empty_path_strings(tmp_path):
+def test_discover_skill_tools_skips_empty_path_strings(tmp_path: Path) -> None:
     # Empty / whitespace-only entries from CSV parsing must not be treated as
     # the current working directory.
     tools, _resources, _names = discover_skill_tools(("", str(tmp_path)))
     assert tools == []
 
 
-def test_skill_tool_info_defaults_to_empty_object_schema():
+def test_skill_tool_info_defaults_to_empty_object_schema() -> None:
     """``inputSchema`` must never be ``None`` — the Anthropic/OpenAI-style
     adapters forward the attribute verbatim and those APIs reject a null
     schema (regression for the review finding that broke every skills-enabled
@@ -134,7 +138,9 @@ def test_skill_tool_info_defaults_to_empty_object_schema():
     assert SkillToolInfo(name="skill_y", description="d").inputSchema is not tool.inputSchema
 
 
-def test_discover_skill_tools_expands_user_home(tmp_path, monkeypatch):
+def test_discover_skill_tools_expands_user_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A ``~/...`` skills path must work — the shared walk expanduser-expands it
     (previously the API agent warned-and-skipped where CLI agents loaded it)."""
     monkeypatch.setenv("HOME", str(tmp_path))
@@ -146,7 +152,23 @@ def test_discover_skill_tools_expands_user_home(tmp_path, monkeypatch):
     assert names == ["home-skill"]
 
 
-def test_discover_skill_tools_dedupes_duplicate_names_first_wins(tmp_path):
+def test_discover_skill_tools_dedupes_normalized_name_collisions(tmp_path: Path) -> None:
+    """Distinct raw names that normalize to the same tool name (``my-skill``
+    vs ``my_skill``) must not advertise duplicate tools or silently overwrite
+    the resources map — first wins, later collisions are warned and skipped."""
+    for d, name, body in [("a", "my-skill", "first"), ("b", "my_skill", "second")]:
+        f = tmp_path / d / "SKILL.md"
+        f.parent.mkdir(parents=True)
+        f.write_text(f'---\nname: "{name}"\ndescription: d\n---\n{body}\n')
+
+    tools, resources, names = discover_skill_tools((str(tmp_path),))
+
+    assert [t.name for t in tools] == ["skill_my_skill"]
+    assert resources["skill_my_skill"].endswith("first\n")
+    assert names == ["my-skill"]
+
+
+def test_discover_skill_tools_dedupes_duplicate_names_first_wins(tmp_path: Path) -> None:
     """Duplicate skill names are first-wins in sorted order (shared-walk
     semantics) — previously both were advertised and the resources map was
     last-wins, nondeterministically."""
@@ -161,7 +183,7 @@ def test_discover_skill_tools_dedupes_duplicate_names_first_wins(tmp_path):
     assert names == ["dup"]
 
 
-def test_skills_module_pulls_no_heavy_dependencies():
+def test_skills_module_pulls_no_heavy_dependencies() -> None:
     """``skills`` does only stdlib filesystem work — no SDK/deepeval/mcp."""
     import subprocess
     import sys

--- a/tests/unit/agents/api/test_agents_api_skills.py
+++ b/tests/unit/agents/api/test_agents_api_skills.py
@@ -1,0 +1,187 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for :mod:`devops_bench.agents.api.skills`."""
+
+from __future__ import annotations
+
+from devops_bench.agents.api.skills import (
+    SkillToolInfo,
+    discover_skill_tools,
+    parse_skill_md,
+)
+
+
+def test_parse_skill_md_extracts_frontmatter(tmp_path):
+    f = tmp_path / "SKILL.md"
+    f.write_text('---\nname: "my-skill"\ndescription: does things\n---\nbody text\n')
+    name, description, content = parse_skill_md(str(f))
+    assert name == "my-skill"
+    assert description == "does things"
+    assert "body text" in content
+
+
+def test_parse_skill_md_strips_single_and_double_quotes(tmp_path):
+    f = tmp_path / "SKILL.md"
+    f.write_text("---\nname: 'quoted'\ndescription: \"plain\"\n---\n")
+    name, description, _ = parse_skill_md(str(f))
+    assert name == "quoted"
+    assert description == "plain"
+
+
+def test_parse_skill_md_reads_multiline_block_scalar(tmp_path):
+    f = tmp_path / "SKILL.md"
+    f.write_text(
+        "---\n"
+        "name: multi\n"
+        "description: >-\n"
+        "  use this skill when rotating\n"
+        "  a secret across namespaces\n"
+        "---\nbody\n"
+    )
+    name, description, _ = parse_skill_md(str(f))
+    assert name == "multi"
+    assert description == "use this skill when rotating a secret across namespaces"
+
+
+def test_parse_skill_md_missing_file_returns_none():
+    assert parse_skill_md("/nonexistent/SKILL.md") == (None, None, None)
+
+
+def test_parse_skill_md_no_frontmatter_returns_none(tmp_path):
+    f = tmp_path / "SKILL.md"
+    f.write_text("just body, no frontmatter")
+    assert parse_skill_md(str(f)) == (None, None, None)
+
+
+def test_discover_skill_tools_empty_paths_returns_empty_lists():
+    tools, resources, names = discover_skill_tools(())
+    assert tools == []
+    assert resources == {}
+    assert names == []
+
+
+def test_discover_skill_tools_missing_path_is_skipped(tmp_path):
+    tools, resources, names = discover_skill_tools((str(tmp_path / "missing"),))
+    assert tools == []
+    assert resources == {}
+    assert names == []
+
+
+def test_discover_skill_tools_normalizes_dashes_to_underscores(tmp_path):
+    skill = tmp_path / "first" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    body = '---\nname: "my-cool-skill"\ndescription: ok\n---\nbody\n'
+    skill.write_text(body)
+
+    tools, resources, names = discover_skill_tools((str(tmp_path),))
+    assert len(tools) == 1
+    assert isinstance(tools[0], SkillToolInfo)
+    assert tools[0].name == "skill_my_cool_skill"
+    assert tools[0].description == "ok"
+    # Resources carry the file *content* captured at discovery, so dispatch
+    # serves exactly what was advertised with no re-read / TOCTOU window.
+    assert resources == {"skill_my_cool_skill": body}
+    assert names == ["my-cool-skill"]
+
+
+def test_discover_skill_tools_falls_back_to_default_description(tmp_path):
+    """Missing description still loads the skill with a synthetic description."""
+    skill = tmp_path / "SKILL.md"
+    skill.write_text('---\nname: "noun"\n---\nbody\n')
+    tools, _resources, _names = discover_skill_tools((str(tmp_path),))
+    assert tools[0].description == "Exposes skill: noun"
+
+
+def test_discover_skill_tools_walks_multiple_paths(tmp_path):
+    a = tmp_path / "a" / "SKILL.md"
+    b = tmp_path / "b" / "SKILL.md"
+    for path, name in [(a, "alpha"), (b, "beta")]:
+        path.parent.mkdir(parents=True)
+        path.write_text(f'---\nname: "{name}"\ndescription: d\n---\n')
+
+    tools, _resources, names = discover_skill_tools((str(a.parent), str(b.parent)))
+    assert sorted(t.name for t in tools) == ["skill_alpha", "skill_beta"]
+    assert sorted(names) == ["alpha", "beta"]
+
+
+def test_discover_skill_tools_skips_empty_path_strings(tmp_path):
+    # Empty / whitespace-only entries from CSV parsing must not be treated as
+    # the current working directory.
+    tools, _resources, _names = discover_skill_tools(("", str(tmp_path)))
+    assert tools == []
+
+
+def test_skill_tool_info_defaults_to_empty_object_schema():
+    """``inputSchema`` must never be ``None`` — the Anthropic/OpenAI-style
+    adapters forward the attribute verbatim and those APIs reject a null
+    schema (regression for the review finding that broke every skills-enabled
+    Anthropic run on turn 1)."""
+    tool = SkillToolInfo(name="skill_x", description="d")
+    assert tool.inputSchema == {"type": "object", "properties": {}}
+    # Fresh dict per instance — no shared mutable default.
+    assert SkillToolInfo(name="skill_y", description="d").inputSchema is not tool.inputSchema
+
+
+def test_discover_skill_tools_expands_user_home(tmp_path, monkeypatch):
+    """A ``~/...`` skills path must work — the shared walk expanduser-expands it
+    (previously the API agent warned-and-skipped where CLI agents loaded it)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    skill = tmp_path / "sk" / "demo" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text('---\nname: "home-skill"\ndescription: d\n---\nbody\n')
+    tools, _resources, names = discover_skill_tools(("~/sk",))
+    assert [t.name for t in tools] == ["skill_home_skill"]
+    assert names == ["home-skill"]
+
+
+def test_discover_skill_tools_dedupes_duplicate_names_first_wins(tmp_path):
+    """Duplicate skill names are first-wins in sorted order (shared-walk
+    semantics) — previously both were advertised and the resources map was
+    last-wins, nondeterministically."""
+    for d, desc in [("a", "first"), ("b", "second")]:
+        f = tmp_path / d / "SKILL.md"
+        f.parent.mkdir(parents=True)
+        f.write_text(f'---\nname: "dup"\ndescription: {desc}\n---\nbody-{d}\n')
+    tools, resources, names = discover_skill_tools((str(tmp_path),))
+    assert len(tools) == 1
+    assert tools[0].description == "first"
+    assert resources["skill_dup"].endswith("body-a\n")
+    assert names == ["dup"]
+
+
+def test_skills_module_pulls_no_heavy_dependencies():
+    """``skills`` does only stdlib filesystem work — no SDK/deepeval/mcp."""
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import sys
+        import devops_bench.agents.api.skills  # noqa: F401
+        forbidden = ("mcp", "deepeval", "anthropic", "google.genai", "openai")
+        hits = sorted(
+            m for m in sys.modules
+            if any(m == p or m.startswith(p + ".") for p in forbidden)
+        )
+        if hits:
+            sys.stderr.write("LEAKED:" + ",".join(hits))
+            sys.exit(1)
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,12 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -457,6 +463,7 @@ source = { editable = "." }
 dependencies = [
     { name = "deepeval" },
     { name = "google-genai" },
+    { name = "mcp" },
     { name = "pydantic" },
     { name = "ruamel-yaml" },
 ]
@@ -484,6 +491,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.104.1" },
     { name = "deepeval", specifier = ">=4.0.3" },
     { name = "google-genai", specifier = ">=2.8.0" },
+    { name = "mcp", specifier = ">=1.27.1" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "ruamel-yaml", specifier = ">=0.18.0" },
@@ -752,6 +760,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
@@ -859,6 +876,33 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -931,6 +975,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]
@@ -1446,6 +1515,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1547,6 +1630,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
 name = "pywin32"
 version = "312"
 source = { registry = "https://pypi.org/simple" }
@@ -1624,6 +1716,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1649,6 +1755,102 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
 ]
 
 [[package]]
@@ -1726,6 +1928,32 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/10/a34c656829ffc1c4b22ef36d70d9ebb6b99c020e2aeb17cee5485099f028/sse_starlette-3.4.6.tar.gz", hash = "sha256:725f8a1bd6d26ae1b2c9610c0ef5065dfdd496f3988d28adcf8c4b49dc25c627", size = 32542, upload-time = "2026-07-20T14:16:32.201Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/36/e10c1d1b7ca881d2625db2ec28508578499187bb1c389952c398474e1834/sse_starlette-3.4.6-py3-none-any.whl", hash = "sha256:56217ab4c9a9f9c5db7b21e08732d3e7c2b807f45231ad23de0551a24c4a41f6", size = 16516, upload-time = "2026-07-20T14:16:30.978Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
 name = "tabulate"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1798,6 +2026,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.51.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/65/b7c6c443ccc58678c91e1e973bbe2a878591538655d6e1d47f24ba1c51f3/uvicorn-0.51.0.tar.gz", hash = "sha256:f6f4b69b657c312f516dd2d268ab9ae6f254b11e4bac504f37b2ab58b24dd0b0", size = 94412, upload-time = "2026-07-08T10:59:05.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/ec/dbb7e5a6b91f86bfb9eb7d2988a2730907b6a729875b949c7f022e8b88fa/uvicorn-0.51.0-py3-none-any.whl", hash = "sha256:5d38af6cd620f2ae3849fb44fd4879e0890aa1febe8d47eb355fb45d93fe6a5b", size = 73219, upload-time = "2026-07-08T10:59:04.44Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds an API-driven agent harness on the shared tool-call loop: an async stdio MCP client, local SKILL.md skills advertised as synthetic tools, trajectory folding with FIFO pairing for id-less provider tool calls, provider token extraction, and a whole-run wall-clock timeout.

Skill discovery lives in a shared iter_skills walk (expanduser, sorted order, escaping and duplicate names warned and skipped) consumed by both the CLI skill materializer and the new agent, so discovery semantics cannot diverge per harness. Adds the mcp dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API agent capable of using local skills and connected tool servers.
  * Added automatic skill discovery from configured directories, including descriptions and content.
  * Added support for tool-call tracking and token usage reporting across providers.
* **Bug Fixes**
  * Tool failures are now reported without stopping the entire run.
  * Improved handling of missing tools, unmatched results, timeouts, and invalid configurations.
  * Heavy runtime integrations load only when needed, improving startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->