### PR TITLE
Add the CLI entrypoint and benchmark runner

### DIFF
--- a/devops_bench/__main__.py
+++ b/devops_bench/__main__.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""devops-bench: a standardized benchmarking suite for DevOps agents and models."""
+"""Console entry: ``python -m devops_bench`` delegating to the CLI."""
 
 from __future__ import annotations
 
-from devops_bench.run import BenchmarkConfig, BenchmarkResult, run_benchmark
+import sys
 
-__version__: str = "0.1.0"
+from devops_bench.cli import main
 
-__all__ = ["__version__", "BenchmarkConfig", "BenchmarkResult", "run_benchmark"]
+if __name__ == "__main__":
+    sys.exit(main())

--- a/devops_bench/cli.py
+++ b/devops_bench/cli.py
@@ -1,0 +1,171 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Thin argparse CLI wrapping :func:`devops_bench.run.run_benchmark`.
+
+The library entrypoint owns all real work; this module only parses flags into a
+:class:`~devops_bench.run.BenchmarkConfig` and maps the outcome to an exit code.
+``run`` imports stay function-local so ``import devops_bench.cli`` stays light.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from devops_bench.core import ConfigError
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only imports
+    from devops_bench.run import BenchmarkConfig
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the ``devops-bench`` console script.
+
+    Returns:
+        A configured :class:`argparse.ArgumentParser`.
+    """
+    parser = argparse.ArgumentParser(
+        prog="devops-bench",
+        description="Run the DevOps-bench evaluation pipeline over a task source.",
+    )
+    parser.add_argument(
+        "source",
+        help="Tasks directory or task spec file (.yaml / .yml / .json).",
+    )
+    parser.add_argument("--project", dest="project_id", default=None, help="Cloud project id.")
+    parser.add_argument("--cluster", dest="cluster_name", default=None, help="Target cluster name.")
+    parser.add_argument("--limit", type=int, default=None, help="Run only the first N tasks.")
+    parser.add_argument("--results-root", default=None, help="Root directory for run artifacts.")
+    parser.add_argument("--agent-type", default=None, help="Override BENCH_AGENT_TYPE.")
+    parser.add_argument("--judge-provider", default=None, help="Override JUDGE_PROVIDER.")
+    parser.add_argument("--judge-model", default=None, help="Override JUDGE_MODEL.")
+    # Tri-state (default None) so a flag can override the env in either
+    # direction; store_true could only ever turn these on, never back off.
+    parser.add_argument(
+        "--no-infra",
+        dest="no_infra",
+        action="store_const",
+        const=True,
+        default=None,
+        help="Skip infrastructure provisioning (no project/cluster required).",
+    )
+    parser.add_argument(
+        "--infra",
+        dest="no_infra",
+        action="store_const",
+        const=False,
+        help="Force infrastructure provisioning even if BENCH_NO_INFRA is set.",
+    )
+    parser.add_argument(
+        "--no-teardown",
+        dest="no_teardown",
+        action="store_const",
+        const=True,
+        default=None,
+        help="Skip teardown of provisioned infrastructure.",
+    )
+    parser.add_argument(
+        "--teardown",
+        dest="no_teardown",
+        action="store_const",
+        const=False,
+        help="Force teardown even if BENCH_NO_TEARDOWN is set.",
+    )
+    parser.add_argument(
+        "--parallel",
+        action="store_true",
+        help=(
+            "Isolate this run (own kubeconfig / gcloud config / tofu data dir and "
+            "a run-unique cluster name) so it can run concurrently with others."
+        ),
+    )
+    parser.add_argument(
+        "--run-id",
+        dest="run_id",
+        default=None,
+        help="Explicit run id for isolation/artifact naming (default: RUN_ID env or generated).",
+    )
+    return parser
+
+
+def args_to_config(args: argparse.Namespace) -> BenchmarkConfig:
+    """Merge parsed CLI args over an env-resolved base config.
+
+    Flags that were provided override the env base; unset flags fall back to env.
+
+    Args:
+        args: Parsed namespace from :func:`build_parser`.
+
+    Returns:
+        The merged :class:`~devops_bench.run.BenchmarkConfig`.
+    """
+    from devops_bench.run import BenchmarkConfig
+
+    base = BenchmarkConfig.from_env(args.source)
+
+    overrides: dict[str, object] = {}
+    for field in (
+        "project_id",
+        "cluster_name",
+        "limit",
+        "results_root",
+        "agent_type",
+        "judge_provider",
+        "judge_model",
+        "run_id",
+    ):
+        value = getattr(args, field)
+        if value is not None:
+            overrides[field] = value
+
+    return replace(
+        base,
+        **overrides,
+        no_infra=args.no_infra if args.no_infra is not None else base.no_infra,
+        no_teardown=(args.no_teardown if args.no_teardown is not None else base.no_teardown),
+        parallel=args.parallel or base.parallel,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Console entry point: parse args, run the benchmark, return an exit code.
+
+    Args:
+        argv: Argument vector (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        ``0`` if no task failed, ``1`` if at least one failed, ``2`` on
+        configuration error.
+    """
+    from devops_bench.run import run_benchmark
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    # args_to_config runs inside the try: BenchmarkConfig.from_env raises
+    # ConfigError on malformed env (e.g. a non-integer EVAL_LIMIT), which must
+    # exit 2 like every other configuration error, not escape as a traceback.
+    try:
+        config = args_to_config(args)
+        result = run_benchmark(config)
+    except ConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    failed = sum(1 for r in result.results if r.get("status") == "failed")
+    print(f"ran {len(result.results)} task(s), {failed} failed; results: {result.results_path}")
+    return 1 if failed else 0

--- a/devops_bench/core/run_env.py
+++ b/devops_bench/core/run_env.py
@@ -35,8 +35,9 @@ import hashlib
 import os
 import tempfile
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import ClassVar
 
 from devops_bench.core.config import get_env
 from devops_bench.core.logging import get_logger
@@ -90,6 +91,21 @@ class RunEnv:
     kubeconfig_path: str | None
     gcloud_config_path: str | None
     tf_data_dir: str | None
+    # Pre-apply() values of the mutated env keys, captured so restore() can
+    # undo the mutation for library embedders; None marks a key that was absent.
+    _saved_env: dict[str, str | None] | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+
+    #: Environment keys apply() writes and restore() puts back.
+    _MUTATED_KEYS: ClassVar[tuple[str, ...]] = (
+        "KUBECONFIG",
+        "CLOUDSDK_CONFIG",
+        "TF_DATA_DIR",
+        "RUN_ID",
+        "BENCH_RUN_DIR",
+        "BENCH_PARALLEL",
+    )
 
     @classmethod
     def create(
@@ -146,9 +162,17 @@ class RunEnv:
         A no-op when not isolated. Mutates ``os.environ`` so every subprocess
         spawned afterward (``gcloud`` / ``kubectl`` / ``tofu`` / agents)
         inherits the isolated kubeconfig, gcloud config, and tofu data dir.
+        Pair with :meth:`restore` so the mutations do not outlive the run in
+        a long-lived embedding process.
         """
         if not self.isolated:
             return
+        # Snapshot the prior values (None = absent) so restore() can undo.
+        object.__setattr__(
+            self,
+            "_saved_env",
+            {key: os.environ.get(key) for key in self._MUTATED_KEYS},
+        )
         self.run_dir.mkdir(parents=True, exist_ok=True)
         Path(self.gcloud_config_path).mkdir(parents=True, exist_ok=True)  # type: ignore[arg-type]
         Path(self.tf_data_dir).mkdir(parents=True, exist_ok=True)  # type: ignore[arg-type]
@@ -160,6 +184,11 @@ class RunEnv:
         # dir) can locate per-run paths without re-deriving them.
         os.environ["RUN_ID"] = self.run_id
         os.environ["BENCH_RUN_DIR"] = str(self.run_dir)
+        # Publish the parallel flag itself: components constructed after this
+        # point read ``BENCH_PARALLEL`` from env (e.g. the eval harness picking
+        # a free chaos port-forward port), and must observe parallel mode even
+        # when isolation was requested via a flag rather than the env.
+        os.environ["BENCH_PARALLEL"] = "true"
         _log.info(
             "run isolation active (run_id=%s): KUBECONFIG=%s CLOUDSDK_CONFIG=%s TF_DATA_DIR=%s",
             self.run_id,
@@ -167,6 +196,24 @@ class RunEnv:
             self.gcloud_config_path,
             self.tf_data_dir,
         )
+
+    def restore(self) -> None:
+        """Undo :meth:`apply`'s environment mutations.
+
+        Puts every key from the pre-apply snapshot back (removing keys that
+        were absent), so an isolated run does not leak ``BENCH_PARALLEL`` /
+        ``KUBECONFIG`` / etc. into a later serial invocation from the same
+        process. A no-op when not isolated or when :meth:`apply` never ran;
+        safe to call from a ``finally`` block.
+        """
+        if not self.isolated or self._saved_env is None:
+            return
+        for key, value in self._saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        object.__setattr__(self, "_saved_env", None)
 
     @property
     def cluster_token(self) -> str:

--- a/devops_bench/run.py
+++ b/devops_bench/run.py
@@ -1,0 +1,216 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Library entrypoint: load config + tasks, run the harness, return results.
+
+A bare ``import devops_bench.run`` must not pull ``deepeval`` / provider SDKs /
+``mcp``; the harness, task loader, and judge factory are imported inside
+:func:`run_benchmark`, not at module top.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from devops_bench.core import (
+    ConfigError,
+    RunEnv,
+    get_bool,
+    get_env,
+    get_int,
+    get_logger,
+)
+
+__all__ = ["BenchmarkConfig", "BenchmarkResult", "run_benchmark"]
+
+_log = get_logger("run")
+
+
+@dataclass(frozen=True)
+class BenchmarkConfig:
+    """Resolved configuration for a single benchmark run.
+
+    Attributes:
+        source: Tasks directory or task spec file (``.yaml`` / ``.yml`` / ``.json``).
+        project_id: Cloud project id; required unless infra is disabled.
+        cluster_name: Name of the target Kubernetes cluster; required unless
+            infra is disabled.
+        limit: Optional cap on the number of tasks to run (slice from the front).
+        results_root: Root directory under which per-run subdirectories are created.
+        agent_type: Override for ``BENCH_AGENT_TYPE``; ``None`` leaves env in control.
+        judge_provider: Override for ``JUDGE_PROVIDER`` used to build the judge.
+        judge_model: Override for ``JUDGE_MODEL`` used to build the judge.
+        no_infra: Skip infrastructure provisioning (no project/cluster required).
+        no_teardown: Skip teardown of provisioned infrastructure.
+        parallel: Enable per-run isolation (own kubeconfig / gcloud config /
+            tofu data dir and a run-unique cluster name) so multiple benchmark
+            processes can run concurrently on one host.
+        run_id: Explicit run id used for isolation and artifact naming; ``None``
+            falls back to ``RUN_ID`` env, then a generated PID/timestamp id.
+    """
+
+    source: str
+    project_id: str | None = None
+    cluster_name: str | None = None
+    limit: int | None = None
+    results_root: str = "results"
+    agent_type: str | None = None
+    judge_provider: str | None = None
+    judge_model: str | None = None
+    no_infra: bool = False
+    no_teardown: bool = False
+    parallel: bool = False
+    run_id: str | None = None
+
+    @classmethod
+    def from_env(cls, source: str, *, env: Mapping[str, str] | None = None) -> BenchmarkConfig:
+        """Build a config from ``source`` plus environment variables.
+
+        This is the only place environment variables are folded into a config;
+        :func:`run_benchmark` treats the config it receives as authoritative.
+        Only vendor-neutral names are read here — provider-specific variables
+        (e.g. ``GCP_PROJECT_ID``) are resolved by the provider layer itself
+        (GCP provisioning and Vertex AI model auth read it directly).
+
+        Args:
+            source: Tasks directory or task spec file.
+            env: Optional mapping to read from instead of ``os.environ``.
+
+        Returns:
+            A :class:`BenchmarkConfig` with fields resolved from the environment.
+        """
+        return cls(
+            source=source,
+            project_id=get_env("PROJECT_ID", env=env),
+            cluster_name=get_env("CLUSTER_NAME", env=env),
+            limit=get_int("EVAL_LIMIT", env=env),
+            results_root=get_env("RESULTS_ROOT", "results", env=env),
+            agent_type=get_env("BENCH_AGENT_TYPE", env=env),
+            judge_provider=get_env("JUDGE_PROVIDER", env=env),
+            judge_model=get_env("JUDGE_MODEL", env=env),
+            no_infra=get_bool("BENCH_NO_INFRA", env=env),
+            no_teardown=get_bool("BENCH_NO_TEARDOWN", env=env),
+            parallel=get_bool("BENCH_PARALLEL", env=env),
+            run_id=get_env("RUN_ID", env=env),
+        )
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    """Outcome of a benchmark run.
+
+    Attributes:
+        results: Per-task result dicts.
+        run_dir: Directory holding the run's artifacts.
+        results_path: Path of the written ``results.json``.
+        rows_path: Path of the flattened, ingest-ready ``rows.json``. The file is
+            written best-effort, so it may be absent if row emission failed.
+        manifest_path: Path of the run-level ``manifest.json`` (same best-effort
+            caveat as ``rows_path``).
+    """
+
+    results: list[dict[str, Any]]
+    run_dir: Path
+    results_path: Path
+    rows_path: Path
+    manifest_path: Path
+
+
+def run_benchmark(config: BenchmarkConfig) -> BenchmarkResult:
+    """Run the benchmark pipeline described by ``config``.
+
+    Args:
+        config: Resolved run configuration. Taken as authoritative: values are
+            used as-is, with environment folding done only by
+            :meth:`BenchmarkConfig.from_env`.
+
+    Returns:
+        A :class:`BenchmarkResult` carrying the results, run directory, and the
+        ``results.json`` path.
+
+    Raises:
+        ConfigError: If infrastructure is enabled but project id / cluster name
+            are missing, or if ``config.source`` does not exist.
+    """
+    # The config is authoritative: env resolution happens only in
+    # ``BenchmarkConfig.from_env``, so validation and the harness always
+    # observe the same values and an explicit setting is never overridden
+    # by ambient environment variables.
+    if not config.no_infra and (not config.project_id or not config.cluster_name):
+        raise ConfigError(
+            "PROJECT_ID and CLUSTER_NAME must be set (or pass --no-infra / BENCH_NO_INFRA=true)"
+        )
+    project_id = config.project_id or "no-infra-project"
+    cluster_name = config.cluster_name or "no-infra-cluster"
+
+    # Establish per-run isolation BEFORE any provisioning so every gcloud /
+    # kubectl / tofu / agent subprocess inherits the run-scoped kubeconfig,
+    # gcloud config, and tofu data dir. A no-op unless ``parallel`` is set.
+    run_env = RunEnv.create(parallel=config.parallel, run_id=config.run_id)
+    run_env.apply()
+    cluster_name = run_env.cluster_name(cluster_name)
+
+    # restore() in the finally keeps apply()'s process-env mutations scoped to
+    # this invocation, so an isolated run does not leak BENCH_PARALLEL /
+    # KUBECONFIG / etc. into a later serial call from the same process.
+    try:
+        from devops_bench.evalharness import DefaultEvalHarness, ResultReporter
+        from devops_bench.tasks import FileSystemTaskLoader
+
+        judge = None
+        if config.judge_provider or config.judge_model:
+            from devops_bench.metrics import get_judge_model
+
+            judge = get_judge_model(provider=config.judge_provider, model_name=config.judge_model)
+
+        tasks = FileSystemTaskLoader().load_tasks(config.source)
+        if config.limit is not None:
+            tasks = tasks[: config.limit]
+
+        # An explicitly supplied run id names the artifacts even in serial
+        # mode; the auto-generated id stays out of serial dir names so the
+        # default timestamped naming is unchanged.
+        reporter = ResultReporter(
+            config.results_root,
+            run_id=config.run_id or (run_env.run_id if run_env.isolated else None),
+        )
+        harness = DefaultEvalHarness(
+            project_id,
+            cluster_name,
+            judge_model=judge,
+            results_root=config.results_root,
+            reporter=reporter,
+            agent_type=config.agent_type,
+            no_infra=config.no_infra,
+            no_teardown=config.no_teardown,
+        )
+        results = harness.run(tasks)
+
+        run_dir = reporter.last_run_dir
+        if run_dir is None:  # pragma: no cover - defensive; harness always creates one
+            run_dir = Path(config.results_root)
+        results_path = run_dir / "results.json"
+        _log.info("benchmark results written to %s", results_path)
+        return BenchmarkResult(
+            results=results,
+            run_dir=run_dir,
+            results_path=results_path,
+            rows_path=run_dir / "rows.json",
+            manifest_path=run_dir / "manifest.json",
+        )
+    finally:
+        run_env.restore()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,14 @@ dependencies = [
 anthropic = ["anthropic>=0.104.1"]
 openai = ["openai>=1.0.0"]
 
+[project.scripts]
+devops-bench = "devops_bench.cli:main"
+
 [tool.hatch.version]
 path = "devops_bench/__init__.py"
+# Hatchling's default regex does not accept an annotated assignment
+# (``__version__: str = ...``), which the repo's type-hint guideline requires.
+pattern = "__version__: str = [\"'](?P<version>[^\"']+)[\"']"
 
 [tool.hatch.build.targets.wheel]
 packages = ["devops_bench"]

--- a/tests/unit/core/test_run_env.py
+++ b/tests/unit/core/test_run_env.py
@@ -15,6 +15,9 @@
 """Unit tests for devops_bench.core.run_env."""
 
 import os
+from pathlib import Path
+
+import pytest
 
 from devops_bench.core.run_env import RunEnv
 
@@ -62,6 +65,58 @@ def test_apply_sets_isolated_env_and_creates_dirs(monkeypatch, tmp_path):
     # gcloud config + tofu data dirs are created so the tools find them.
     assert (expected_dir / "gcloud").is_dir()
     assert (expected_dir / "tf-data").is_dir()
+
+
+def test_apply_publishes_parallel_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Swap in a copy so apply()'s mutations never touch the real environment.
+    monkeypatch.setattr(os, "environ", os.environ.copy())
+    monkeypatch.delenv("BENCH_PARALLEL", raising=False)
+
+    RunEnv.create(parallel=True, run_id="run-1", state_root=tmp_path).apply()
+
+    # Components constructed after apply() (e.g. the eval harness) read
+    # BENCH_PARALLEL from env, so flag-only parallel must be published.
+    assert os.environ["BENCH_PARALLEL"] == "true"
+
+
+def test_apply_does_not_publish_parallel_when_not_isolated(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(os, "environ", os.environ.copy())
+    monkeypatch.delenv("BENCH_PARALLEL", raising=False)
+
+    RunEnv.create(parallel=False, run_id="run-1").apply()
+
+    assert "BENCH_PARALLEL" not in os.environ
+
+
+def test_restore_undoes_apply_mutations(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(os, "environ", os.environ.copy())
+    monkeypatch.setenv("KUBECONFIG", "/original/kubeconfig")
+    added = ("CLOUDSDK_CONFIG", "TF_DATA_DIR", "RUN_ID", "BENCH_RUN_DIR", "BENCH_PARALLEL")
+    for var in added:
+        monkeypatch.delenv(var, raising=False)
+
+    run_env = RunEnv.create(parallel=True, run_id="run-1", state_root=tmp_path)
+    run_env.apply()
+    assert os.environ["BENCH_PARALLEL"] == "true"
+
+    run_env.restore()
+
+    # Pre-existing keys return to their prior values; added keys are removed.
+    assert os.environ["KUBECONFIG"] == "/original/kubeconfig"
+    for var in added:
+        assert var not in os.environ
+
+
+def test_restore_is_noop_without_apply(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(os, "environ", os.environ.copy())
+    snapshot = dict(os.environ)
+
+    # Neither the non-isolated pass-through nor an isolated env whose apply()
+    # never ran may touch the environment on restore().
+    RunEnv.create(parallel=False, run_id="run-1").restore()
+    RunEnv.create(parallel=True, run_id="run-2", state_root=tmp_path).restore()
+
+    assert dict(os.environ) == snapshot
 
 
 def test_state_root_from_env(monkeypatch, tmp_path):

--- a/tests/unit/run/__init__.py
+++ b/tests/unit/run/__init__.py
@@ -12,12 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""devops-bench: a standardized benchmarking suite for DevOps agents and models."""
-
-from __future__ import annotations
-
-from devops_bench.run import BenchmarkConfig, BenchmarkResult, run_benchmark
-
-__version__: str = "0.1.0"
-
-__all__ = ["__version__", "BenchmarkConfig", "BenchmarkResult", "run_benchmark"]

--- a/tests/unit/run/test_cli.py
+++ b/tests/unit/run/test_cli.py
@@ -1,0 +1,153 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the thin argparse CLI (parser, config merge, exit codes)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from devops_bench.cli import args_to_config, build_parser, main
+from devops_bench.core import ConfigError
+from devops_bench.run import BenchmarkResult
+
+
+def test_build_parser_parses_flags() -> None:
+    """Positional source and optional flags land on the namespace."""
+    parser = build_parser()
+    args = parser.parse_args(
+        ["src", "--limit", "3", "--project", "p", "--cluster", "c", "--no-infra"]
+    )
+    assert args.source == "src"
+    assert args.limit == 3
+    assert args.project_id == "p"
+    assert args.cluster_name == "c"
+    assert args.no_infra is True
+    # Tri-state: an unset flag is None (env fallback in args_to_config), not False.
+    assert args.no_teardown is None
+
+
+def test_infra_flag_forces_provisioning_over_truthy_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--infra`` overrides a truthy ``BENCH_NO_INFRA`` env back to False.
+
+    The previous ``store_true`` flag could only ever skip infra; the tri-state
+    pair lets the CLI force provisioning back on regardless of the env.
+    """
+    monkeypatch.setenv("BENCH_NO_INFRA", "true")
+    parser = build_parser()
+    args = parser.parse_args(["src", "--infra"])
+    config = args_to_config(args)
+    assert config.no_infra is False
+
+
+def test_args_to_config_flags_override_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provided flags win over env; unset flags fall back to env."""
+    monkeypatch.setenv("PROJECT_ID", "env-proj")
+    monkeypatch.setenv("CLUSTER_NAME", "env-clus")
+    monkeypatch.setenv("EVAL_LIMIT", "9")
+    parser = build_parser()
+    args = parser.parse_args(["src", "--project", "flag-proj"])
+    config = args_to_config(args)
+    # Flag override.
+    assert config.project_id == "flag-proj"
+    # Env fallbacks (no flag given).
+    assert config.cluster_name == "env-clus"
+    assert config.limit == 9
+
+
+def test_args_to_config_bools_or_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Boolean flags OR the env value (env stays a fallback)."""
+    monkeypatch.setenv("BENCH_NO_TEARDOWN", "true")
+    monkeypatch.delenv("BENCH_NO_INFRA", raising=False)
+    parser = build_parser()
+    args = parser.parse_args(["src", "--no-infra"])
+    config = args_to_config(args)
+    assert config.no_infra is True  # from flag
+    assert config.no_teardown is True  # from env
+
+
+def _result(results: list[dict[str, object]], tmp_path: Path) -> BenchmarkResult:
+    return BenchmarkResult(
+        results=results,
+        run_dir=tmp_path,
+        results_path=tmp_path / "results.json",
+        rows_path=tmp_path / "rows.json",
+        manifest_path=tmp_path / "manifest.json",
+    )
+
+
+def test_main_exit_zero_on_no_failures(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        "devops_bench.run.run_benchmark",
+        lambda config: _result([{"status": "success"}], tmp_path),
+    )
+    assert main(["src", "--no-infra"]) == 0
+    assert "0 failed" in capsys.readouterr().out
+
+
+def test_main_exit_one_on_failure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "devops_bench.run.run_benchmark",
+        lambda config: _result([{"status": "success"}, {"status": "failed"}], tmp_path),
+    )
+    assert main(["src", "--no-infra"]) == 1
+
+
+def test_main_exit_two_on_config_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def _raise(config: object) -> BenchmarkResult:
+        raise ConfigError("boom")
+
+    monkeypatch.setattr("devops_bench.run.run_benchmark", _raise)
+    assert main(["src"]) == 2
+    assert "error: boom" in capsys.readouterr().err
+
+
+def test_main_exit_two_on_missing_source(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A nonexistent source is a config error (exit 2), distinct from task failures.
+
+    No ``FileNotFoundError`` handler is needed in the CLI: the task loader
+    normalizes missing paths and parse failures into ``ConfigError``.
+    """
+    monkeypatch.delenv("BENCH_PARALLEL", raising=False)
+    missing = tmp_path / "does-not-exist.yaml"
+    assert main([str(missing), "--no-infra"]) == 2
+    err = capsys.readouterr().err
+    assert "error:" in err
+    assert "not found" in err
+
+
+def test_main_exit_two_on_malformed_env(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A config error raised while building the config (not just running) exits 2.
+
+    ``BenchmarkConfig.from_env`` raises ``ConfigError`` on a malformed env
+    value, so ``args_to_config`` must sit inside ``main``'s try — otherwise
+    the error escapes as a traceback with the wrong exit code.
+    """
+    monkeypatch.setenv("EVAL_LIMIT", "abc")
+    assert main(["src", "--no-infra"]) == 2
+    err = capsys.readouterr().err
+    assert "error:" in err
+    assert "EVAL_LIMIT" in err

--- a/tests/unit/run/test_config.py
+++ b/tests/unit/run/test_config.py
@@ -1,0 +1,87 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``BenchmarkConfig.from_env`` resolution (env passed explicitly)."""
+
+from __future__ import annotations
+
+from devops_bench.run import BenchmarkConfig
+
+
+def test_from_env_reads_primary_aliases() -> None:
+    """Primary env names populate project/cluster/limit/results_root."""
+    config = BenchmarkConfig.from_env(
+        "tasks/demo.yaml",
+        env={
+            "PROJECT_ID": "proj-primary",
+            "CLUSTER_NAME": "clus-primary",
+            "EVAL_LIMIT": "7",
+            "RESULTS_ROOT": "/tmp/out",
+        },
+    )
+    assert config.source == "tasks/demo.yaml"
+    assert config.project_id == "proj-primary"
+    assert config.cluster_name == "clus-primary"
+    assert config.limit == 7
+    assert config.results_root == "/tmp/out"
+
+
+def test_from_env_ignores_provider_specific_names() -> None:
+    """The generic layer reads only vendor-neutral names.
+
+    ``GCP_PROJECT_ID`` / ``GKE_CLUSTER_NAME`` are provider-layer variables,
+    resolved by the GCP provider and Vertex model auth directly — the runner
+    must not read them.
+    """
+    config = BenchmarkConfig.from_env(
+        "tasks/demo.yaml",
+        env={
+            "GCP_PROJECT_ID": "ignored",
+            "GKE_CLUSTER_NAME": "ignored",
+        },
+    )
+    assert config.project_id is None
+    assert config.cluster_name is None
+
+
+def test_from_env_defaults() -> None:
+    """An empty env yields sensible defaults; agent_type stays None."""
+    config = BenchmarkConfig.from_env("tasks/demo.yaml", env={})
+    assert config.project_id is None
+    assert config.cluster_name is None
+    assert config.limit is None
+    assert config.results_root == "results"
+    assert config.agent_type is None
+    assert config.judge_provider is None
+    assert config.judge_model is None
+    assert config.no_infra is False
+    assert config.no_teardown is False
+    assert config.parallel is False
+
+
+def test_from_env_agent_type_when_set() -> None:
+    """BENCH_AGENT_TYPE is read when present."""
+    config = BenchmarkConfig.from_env("tasks/demo.yaml", env={"BENCH_AGENT_TYPE": "api"})
+    assert config.agent_type == "api"
+
+
+def test_from_env_bool_flags() -> None:
+    """BENCH_NO_INFRA / BENCH_NO_TEARDOWN / BENCH_PARALLEL parse as booleans."""
+    config = BenchmarkConfig.from_env(
+        "tasks/demo.yaml",
+        env={"BENCH_NO_INFRA": "true", "BENCH_NO_TEARDOWN": "1", "BENCH_PARALLEL": "true"},
+    )
+    assert config.no_infra is True
+    assert config.no_teardown is True
+    assert config.parallel is True

--- a/tests/unit/run/test_package_import.py
+++ b/tests/unit/run/test_package_import.py
@@ -1,0 +1,80 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``import devops_bench`` / ``.run`` / ``.cli`` pull no provider SDK (CONVENTIONS.md §8).
+
+Under the current policy only the provider model SDKs must stay lazy (``deepeval``/``mcp``
+are allowed eager). The entrypoint happens to stay free of those too, but the contract it
+must keep is SDK-absence.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+_FORBIDDEN = ("anthropic", "google.genai", "google.generativeai", "openai", "ollama")
+
+
+def _run_in_subprocess(snippet: str) -> str:
+    """Run ``snippet`` in a clean Python process and return stdout.
+
+    A fresh interpreter prevents leaks from earlier test imports (the wider
+    test session has often already pulled ``deepeval``).
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(snippet)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _leak_check(import_line: str) -> list[str]:
+    output = _run_in_subprocess(
+        f"""
+        import sys
+        {import_line}  # noqa: F401
+        forbidden = {_FORBIDDEN!r}
+        leaked = sorted(name for name in forbidden if name in sys.modules)
+        print(",".join(leaked))
+        """
+    )
+    return [name for name in output.strip().split(",") if name]
+
+
+def test_import_package_pulls_no_sdk() -> None:
+    """A bare ``import devops_bench`` does not pull heavy modules."""
+    assert _leak_check("import devops_bench") == []
+
+
+def test_import_run_pulls_no_sdk() -> None:
+    """``import devops_bench.run`` does not pull heavy modules."""
+    assert _leak_check("import devops_bench.run") == []
+
+
+def test_import_cli_pulls_no_sdk() -> None:
+    """``import devops_bench.cli`` does not pull heavy modules."""
+    assert _leak_check("import devops_bench.cli") == []
+
+
+def test_top_level_exports_resolve() -> None:
+    """Top-level public exports resolve from the package."""
+    import devops_bench
+
+    assert devops_bench.run_benchmark.__name__ == "run_benchmark"
+    assert devops_bench.BenchmarkConfig.__name__ == "BenchmarkConfig"
+    assert devops_bench.BenchmarkResult.__name__ == "BenchmarkResult"

--- a/tests/unit/run/test_run_benchmark.py
+++ b/tests/unit/run/test_run_benchmark.py
@@ -1,0 +1,219 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``run_benchmark`` with a stubbed harness and task loader."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from devops_bench.core import ConfigError
+from devops_bench.run import BenchmarkConfig, BenchmarkResult, run_benchmark
+
+_CANNED_RESULTS = [
+    {"name": "a", "status": "success"},
+    {"name": "b", "status": "failed"},
+]
+
+
+class FakeHarness:
+    """Records construction kwargs and the env at construction time."""
+
+    instances: list[FakeHarness] = []
+
+    def __init__(
+        self,
+        project_id: str,
+        cluster_name: str,
+        *,
+        judge_model: object = None,
+        results_root: str = "results",
+        reporter: object = None,
+        **kwargs: object,
+    ) -> None:
+        self.project_id = project_id
+        self.cluster_name = cluster_name
+        self.judge_model = judge_model
+        self.results_root = results_root
+        self.reporter = reporter
+        # Flag overrides now arrive as explicit constructor kwargs (DI), not via
+        # ``os.environ``; capture them so tests assert on what was injected.
+        self.agent_type = kwargs.get("agent_type")
+        self.no_infra = kwargs.get("no_infra")
+        self.no_teardown = kwargs.get("no_teardown")
+        self.env_at_construction = dict(os.environ)
+        self.task_count: int | None = None
+        FakeHarness.instances.append(self)
+
+    def run(self, tasks: list[object]) -> list[dict[str, object]]:
+        self.task_count = len(tasks)
+        self.reporter.new_run_dir()  # set reporter.last_run_dir
+        return list(_CANNED_RESULTS)
+
+
+def _fake_load_tasks(count: int) -> Callable[[object, str], list[object]]:
+    def _loader(self: object, source: str) -> list[object]:
+        return [{"task": i} for i in range(count)]
+
+    return _loader
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_instances() -> None:
+    FakeHarness.instances = []
+
+
+def _patch(monkeypatch: pytest.MonkeyPatch, *, task_count: int = 5) -> None:
+    monkeypatch.setattr("devops_bench.evalharness.DefaultEvalHarness", FakeHarness)
+    monkeypatch.setattr(
+        "devops_bench.tasks.FileSystemTaskLoader.load_tasks", _fake_load_tasks(task_count)
+    )
+
+
+def test_loads_and_limits_tasks(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch(monkeypatch, task_count=5)
+    config = BenchmarkConfig(
+        source="src",
+        no_infra=True,
+        limit=2,
+        results_root=str(tmp_path),
+    )
+    run_benchmark(config)
+    assert FakeHarness.instances[0].task_count == 2
+
+
+def test_returns_benchmark_result(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch(monkeypatch)
+    config = BenchmarkConfig(source="src", no_infra=True, results_root=str(tmp_path))
+    result = run_benchmark(config)
+    assert isinstance(result, BenchmarkResult)
+    assert result.results == _CANNED_RESULTS
+    assert result.run_dir.parent == tmp_path
+    assert result.results_path == result.run_dir / "results.json"
+    assert result.rows_path == result.run_dir / "rows.json"
+    assert result.manifest_path == result.run_dir / "manifest.json"
+
+
+def test_infra_enabled_missing_project_cluster_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch(monkeypatch)
+    monkeypatch.delenv("BENCH_NO_INFRA", raising=False)
+    config = BenchmarkConfig(
+        source="src",
+        no_infra=False,
+        project_id=None,
+        cluster_name=None,
+        results_root=str(tmp_path),
+    )
+    with pytest.raises(ConfigError):
+        run_benchmark(config)
+
+
+def test_no_infra_uses_placeholders(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch(monkeypatch)
+    config = BenchmarkConfig(source="src", no_infra=True, results_root=str(tmp_path))
+    run_benchmark(config)
+    harness = FakeHarness.instances[0]
+    assert harness.project_id == "no-infra-project"
+    assert harness.cluster_name == "no-infra-cluster"
+
+
+def test_agent_type_flag_overrides_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch(monkeypatch)
+    monkeypatch.setenv("BENCH_AGENT_TYPE", "gemini-cli")
+    config = BenchmarkConfig(
+        source="src",
+        no_infra=True,
+        agent_type="api",
+        results_root=str(tmp_path),
+    )
+    run_benchmark(config)
+    # The flag is injected into the harness constructor, not written to env.
+    assert FakeHarness.instances[0].agent_type == "api"
+    assert os.environ.get("BENCH_AGENT_TYPE") == "gemini-cli"
+
+
+def test_config_is_authoritative_over_ambient_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Explicit config wins; env toggles fold in only via ``from_env``.
+
+    A hand-built ``BenchmarkConfig`` (``no_infra=False``) must still require
+    project/cluster even when ``BENCH_NO_INFRA=true`` is in the environment,
+    so validation and the harness always observe the same values. The CLI
+    path picks the env up through ``from_env`` instead.
+    """
+    _patch(monkeypatch)
+    monkeypatch.setenv("BENCH_NO_INFRA", "true")
+    monkeypatch.setenv("BENCH_NO_TEARDOWN", "true")
+    monkeypatch.delenv("BENCH_PARALLEL", raising=False)
+
+    # Hand-built config: the ambient env must NOT flip no_infra, so the
+    # missing project/cluster is still a validation error.
+    with pytest.raises(ConfigError):
+        run_benchmark(BenchmarkConfig(source="src", results_root=str(tmp_path)))
+    assert FakeHarness.instances == []
+
+    # from_env is the one place the env folds in.
+    config = replace(BenchmarkConfig.from_env("src"), results_root=str(tmp_path))
+    run_benchmark(config)
+    harness = FakeHarness.instances[0]
+    assert harness.no_infra is True
+    assert harness.no_teardown is True
+
+
+def test_parallel_config_reaches_harness_via_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``parallel=True`` set only on the config is visible at harness construction.
+
+    The harness reads ``BENCH_PARALLEL`` from env; ``RunEnv.apply`` exports it
+    before the harness is built so a flag-only ``--parallel`` still routes the
+    chaos port-forward onto a free per-run port.
+    """
+    _patch(monkeypatch)
+    # Swap in a copy so apply()'s mutations never touch the real environment.
+    monkeypatch.setattr(os, "environ", os.environ.copy())
+    monkeypatch.delenv("BENCH_PARALLEL", raising=False)
+    monkeypatch.setenv("BENCH_RUN_STATE_ROOT", str(tmp_path / "state"))
+    config = BenchmarkConfig(source="src", no_infra=True, parallel=True, results_root=str(tmp_path))
+    run_benchmark(config)
+    harness = FakeHarness.instances[0]
+    assert harness.env_at_construction.get("BENCH_PARALLEL") == "true"
+
+    # apply()'s mutations are scoped to the invocation: the env is restored
+    # once the run returns...
+    assert "BENCH_PARALLEL" not in os.environ
+    # ...so a later serial invocation does not inherit parallel mode.
+    run_benchmark(replace(config, parallel=False))
+    serial = FakeHarness.instances[1]
+    assert serial.env_at_construction.get("BENCH_PARALLEL") is None
+
+
+def test_explicit_run_id_names_serial_run_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An explicit run id names the artifacts even without parallel isolation."""
+    _patch(monkeypatch)
+    config = BenchmarkConfig(
+        source="src", no_infra=True, results_root=str(tmp_path), run_id="release-07"
+    )
+    result = run_benchmark(config)
+    assert "release-07" in result.run_dir.name


### PR DESCRIPTION
Adds the command-line entrypoint for running the benchmark:

- `devops_bench/run.py` — `run_benchmark()` loads tasks, builds the eval harness, and reports results. Heavy imports stay function-local so `import devops_bench.run` stays light.
- `devops_bench/cli.py` + `devops_bench/__main__.py` — argument parsing and `python -m devops_bench`.
- A `devops-bench` console script in `pyproject.toml`, and the package-root re-export of `run_benchmark`.
- Unit tests under `tests/unit/run/`.

Depends on #37 (merged): `run_benchmark` drives `DefaultEvalHarness`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `devops-bench` command-line interface and `python -m devops_bench` entrypoint for running benchmarks with selection, limits, infra/teardown toggles, parallelism, and run isolation.
  - Exposed benchmark configuration/results/execution APIs at the package level and clarified public exports.
  - Improved run environment signaling (including `BENCH_PARALLEL`) and ensured environment changes are reverted after runs.
  - Added run summary output with distinct exit codes for config errors vs task failures.
- **Tests**
  - Expanded unit coverage for CLI precedence/error handling, environment resolution, SDK import laziness, run execution/path reporting, and environment apply/restore behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
