### PR TITLE
Remove the unused _RECORD_KEYS constant

### DIFF
--- a/devops_bench/evalharness/default.py
+++ b/devops_bench/evalharness/default.py
@@ -818,39 +818,6 @@ class DefaultEvalHarness(Harness):
 
         return result
 
-    #: Top-level keys present on **every** record (success and failed alike).
-    #: Exposed so downstream parsers / tests can pin the symmetric schema
-    #: without reproducing the literal in every spot.
-    _RECORD_KEYS: frozenset[str] = frozenset(
-        {
-            "input",
-            "output",
-            "latency",
-            "tokens",
-            "tools",
-            "trajectory",
-            "skills",
-            "name",
-            "folder",
-            "status",
-            "error",
-            "errors",
-            "scores",
-            "expected_output",
-            "expected_output_raw",
-            "retrieval_context",
-            "chaos_spec",
-            "verification_spec",
-            "chaos_report",
-            "perf_report",
-            "documentation",
-            "capabilities_granted",
-            "verification_parse_errors",
-            "generation_only",
-            "validated",
-        }
-    )
-
     def _build_success_record(
         self,
         *,
@@ -865,10 +832,10 @@ class DefaultEvalHarness(Harness):
         """Shape a typed :class:`AgentResult` + reports into the on-disk schema.
 
         Routes every typed value through ``to_dict()`` / ``model_dump()`` and
-        emits the **symmetric** key union (every key in :attr:`_RECORD_KEYS`
-        is present on every record), so success and failed records never differ
-        in top-level shape — a downstream parser iterating one shape can never
-        ``KeyError`` crossing into the other.
+        emits the **symmetric** key union (every key is present on every
+        record), so success and failed records never differ in top-level
+        shape — a downstream parser iterating one shape can never ``KeyError``
+        crossing into the other.
 
         Capability metadata (``capabilities_granted``) is recorded so metrics
         / downstream consumers can read what the agent was actually granted
@@ -924,11 +891,11 @@ class DefaultEvalHarness(Harness):
     ) -> dict[str, Any]:
         """Build a failed-task record so the failure stays visible.
 
-        Emits the **same** top-level key set as :meth:`_build_success_record`
-        (pinned in :attr:`_RECORD_KEYS`): a downstream parser iterating either
-        shape never trips a ``KeyError`` crossing between them. The differences
-        are values only — ``status=\"failed\"``, ``error`` carries the
-        exception text, ``scores`` stays empty.
+        Emits the **same** top-level key set as :meth:`_build_success_record`:
+        a downstream parser iterating either shape never trips a ``KeyError``
+        crossing between them. The differences are values only —
+        ``status=\"failed\"``, ``error`` carries the exception text, ``scores``
+        stays empty.
 
         Args:
             task: The task that failed.

--- a/tests/unit/evalharness/test_default_harness.py
+++ b/tests/unit/evalharness/test_default_harness.py
@@ -400,7 +400,7 @@ def test_resolve_deployment_and_namespace_precedence_and_types(
     assert ns == "456"
 
 
-# --- results.json schema (Decision D3): _RECORD_KEYS is the source of truth ---
+# --- results.json schema (Decision D3) ---
 
 # Pinned symmetric key set. Every key must be present on *both* the success and
 # failed record, so a downstream parser iterating one shape never KeyErrors on
@@ -466,11 +466,6 @@ def _stub_agent_result() -> AgentResult:
         tokens={"input": 10, "output": 5},
         latency=1.5,
     )
-
-
-def test_record_keys_class_constant_matches_golden(isolated_env: None) -> None:
-    """``_RECORD_KEYS`` is the authoritative schema; pin it against the golden set."""
-    assert DefaultEvalHarness._RECORD_KEYS == _RESULTS_JSON_REQUIRED_KEYS  # noqa: SLF001
 
 
 def test_success_record_keys_match_golden(isolated_env: None) -> None:


### PR DESCRIPTION
`DefaultEvalHarness._RECORD_KEYS` is never read at runtime. Both record builders
construct their key set from the `_empty_record` literal, so the frozenset was a
second, hand-maintained copy of the schema that could silently drift from the
records it claimed to describe.

This drops the constant and the two docstring references to it. The
symmetric-shape invariant stays pinned by the golden tests in
`test_default_harness.py`, which assert that `_build_success_record` and
`_build_failed_record` emit exactly the same expected key set.

Follow-up to the review discussion on #37.

/kind cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal record schema documentation while preserving the existing output structure for successful and failed results.

* **Tests**
  * Clarified documentation for the results file schema.
  * Continued validating that successful and failed records contain matching required fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->