### PR TITLE
Move load-fault transport ownership into GenerateLoadFault

### DIFF
--- a/devops_bench/chaos/base.py
+++ b/devops_bench/chaos/base.py
@@ -26,11 +26,29 @@ from devops_bench.core.context import RunContext
 
 __all__ = [
     "ChaosResult",
+    "ENV_LOCAL_PORT",
+    "ENV_SKIP_PORT_FORWARD",
+    "ENV_TARGET_DEPLOYMENT",
+    "ENV_TARGET_NAMESPACE",
     "Fault",
     "Trigger",
     "FAULTS",
     "TRIGGERS",
 ]
+
+# ``RunContext.env`` keys naming the workload a fault targets. The harness
+# writes them before :meth:`Fault.inject`; a fault that needs cluster
+# connectivity reads them and decides its own transport. Keeping the contract
+# here — rather than in one fault's module — lets the harness stay agnostic
+# about which fault it is scheduling.
+ENV_TARGET_DEPLOYMENT = "CHAOS_TARGET_DEPLOYMENT"
+ENV_TARGET_NAMESPACE = "CHAOS_TARGET_NAMESPACE"
+#: Set when the caller has no reachable cluster (smoke / unit runs), telling a
+#: fault to run against whatever target it already carries.
+ENV_SKIP_PORT_FORWARD = "CHAOS_SKIP_PORT_FORWARD"
+#: Per-run local port the harness allocates so concurrent runs do not contend
+#: on the local side of a port-forward.
+ENV_LOCAL_PORT = "CHAOS_LOCAL_PORT"
 
 #: Registry of concrete :class:`Fault` subclasses, keyed by their ``type``.
 #: ``entry_point_group`` lets external packages register a fault without

--- a/devops_bench/chaos/faults/generate_load.py
+++ b/devops_bench/chaos/faults/generate_load.py
@@ -32,16 +32,25 @@ import shlex
 import textwrap
 import threading
 import time
+from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-from devops_bench.chaos.base import FAULTS, ChaosResult, Fault
+from devops_bench.chaos.base import (
+    ENV_LOCAL_PORT,
+    ENV_SKIP_PORT_FORWARD,
+    ENV_TARGET_DEPLOYMENT,
+    ENV_TARGET_NAMESPACE,
+    FAULTS,
+    ChaosResult,
+    Fault,
+)
 from devops_bench.core import get_logger
 from devops_bench.core.context import RunContext
 from devops_bench.core.subprocess import run
-from devops_bench.k8s import port_forward, rollout_status
+from devops_bench.k8s import get_resource, poll_until, port_forward, rollout_status
 
 __all__ = [
     "GenerateLoadFault",
@@ -60,23 +69,19 @@ _LOAD_MARKER = "fortio load"
 # Wall-clock ceiling for a single chaos command.
 _COMMAND_TIMEOUT = 40
 
-# The workload's in-cluster (remote) port for chaos load generation, and the
-# default local side of the port-forward. Parallel runs override only the local
-# side via ``_ENV_LOCAL_PORT`` so two concurrent forwards do not contend.
-_LOCAL_PORT = 8080
+# Fallback port used only when the target Service cannot be read. The real
+# ports are discovered from the Service (see :func:`_resolve_endpoint`).
+_FALLBACK_PORT = 8080
 
 # Single source of truth for the load target when a spec omits one. The local
 # port-forward URL the cluster workload is exposed on.
-_DEFAULT_TARGET_URL = f"http://localhost:{_LOCAL_PORT}"
+_DEFAULT_TARGET_URL = f"http://localhost:{_FALLBACK_PORT}"
 
-# ``RunContext.env`` keys naming the port-forward target the harness writes
-# onto the context before injection.
-_ENV_TARGET_DEPLOYMENT = "CHAOS_TARGET_DEPLOYMENT"
-_ENV_TARGET_NAMESPACE = "CHAOS_TARGET_NAMESPACE"
-_ENV_SKIP_PORT_FORWARD = "CHAOS_SKIP_PORT_FORWARD"
-# Optional per-run local port the harness allocates for parallel isolation; the
-# fault binds the port-forward's local side here and points the load URL at it.
-_ENV_LOCAL_PORT = "CHAOS_LOCAL_PORT"
+# Seconds to wait for the target Service's external LoadBalancer IP to be
+# assigned. LB provisioning typically completes within a minute but can lag —
+# bound it so a stuck assignment falls back to the port-forward path instead of
+# stalling the run.
+_LB_IP_TIMEOUT_SEC = 180
 
 # Seconds to wait for the target deployment's rollout to finish before opening
 # the port-forward. The agent often mutates the deployment (e.g. adds resource
@@ -216,6 +221,99 @@ def run_chaos_command(
         return f"Error: {exc}"
 
 
+@dataclass(frozen=True)
+class _Endpoint:
+    """How the target workload can be reached, as read from its Service.
+
+    Attributes:
+        port: The Service's exposed port — what a client outside the cluster
+            (an external LoadBalancer) connects to.
+        target_port: The pod-side port a ``kubectl port-forward`` must target.
+            Falls back to :attr:`port` when the Service names it symbolically,
+            since a named port cannot be forwarded without resolving the pod
+            spec.
+        lb_host: External LoadBalancer IP or hostname, or ``None`` when the
+            Service is not a LoadBalancer or none was assigned in time.
+    """
+
+    port: int
+    target_port: int
+    lb_host: str | None
+
+
+def _read_ports(doc: dict[str, Any]) -> tuple[int, int]:
+    """Extract ``(port, target_port)`` from a Service document."""
+    ports = (doc.get("spec") or {}).get("ports") or []
+    entry = ports[0] if ports else {}
+    port = entry.get("port") or _FALLBACK_PORT
+    raw_target = entry.get("targetPort")
+    # A symbolic targetPort ("http") would need the pod spec to resolve; the
+    # Service port is the closest usable stand-in.
+    target_port = raw_target if isinstance(raw_target, int) else port
+    return int(port), int(target_port)
+
+
+def _resolve_endpoint(service: str, namespace: str, *, wait_for_lb: bool) -> _Endpoint | None:
+    """Read the target Service's ports and, optionally, its LoadBalancer host.
+
+    Args:
+        service: Service name (named after the target deployment).
+        namespace: Namespace the Service lives in.
+        wait_for_lb: Poll up to :data:`_LB_IP_TIMEOUT_SEC` for an external
+            LoadBalancer ingress. Skipped for local clusters, which never get
+            one and would otherwise burn the full timeout.
+
+    Returns:
+        The resolved :class:`_Endpoint`, or ``None`` when the Service cannot be
+        read at all — the caller then falls back to default ports.
+    """
+    try:
+        doc = get_resource("service", service, namespace=namespace)
+    except Exception as exc:  # noqa: BLE001 - unreadable Service is a soft failure
+        _log.warning("could not read service %s/%s: %s", namespace, service, exc)
+        return None
+
+    port, target_port = _read_ports(doc)
+    # Only a LoadBalancer Service will ever be assigned an ingress, so polling
+    # any other type just burns the full timeout before falling back.
+    is_lb = (doc.get("spec") or {}).get("type") == "LoadBalancer"
+    if not wait_for_lb or not is_lb:
+        return _Endpoint(port=port, target_port=target_port, lb_host=None)
+
+    resolved: dict[str, str] = {}
+
+    def _has_ip() -> bool:
+        try:
+            current = get_resource("service", service, namespace=namespace)
+        except Exception as exc:  # noqa: BLE001 - poll keeps retrying
+            _log.debug("waiting for LB IP on %s/%s: %s", namespace, service, exc)
+            return False
+        ingress = (current.get("status") or {}).get("loadBalancer", {}).get("ingress") or []
+        entry = (ingress[0] if ingress else {}) or {}
+        host = entry.get("ip") or entry.get("hostname")
+        if not host:
+            return False
+        resolved["host"] = host
+        return True
+
+    _log.info(
+        "resolving external LB host for service %s/%s (timeout %ss)",
+        namespace,
+        service,
+        _LB_IP_TIMEOUT_SEC,
+    )
+    if not poll_until(_has_ip, timeout_sec=_LB_IP_TIMEOUT_SEC):
+        _log.warning(
+            "external LB host for service %s/%s not assigned within %ss; "
+            "falling back to port-forward",
+            namespace,
+            service,
+            _LB_IP_TIMEOUT_SEC,
+        )
+        return _Endpoint(port=port, target_port=target_port, lb_host=None)
+    return _Endpoint(port=port, target_port=target_port, lb_host=resolved["host"])
+
+
 class LoadTarget(BaseModel):
     """Target for a generated load spike.
 
@@ -291,21 +389,22 @@ class GenerateLoadFault(Fault):
         ctx: RunContext,
         chaos_active_event: threading.Event | None = None,
     ) -> ChaosResult:
-        """Open a port-forward, run the LLM-planned chaos loop, tear it down.
+        """Reach the target workload, run the LLM-planned chaos loop, tear down.
 
-        The fault owns its own connectivity: when the run context names a
-        target deployment (via :data:`_ENV_TARGET_DEPLOYMENT` /
-        :data:`_ENV_TARGET_NAMESPACE` on ``ctx.env``) and the port-forward is
-        not skipped, :meth:`inject` opens a ``kubectl port-forward`` to that
-        deployment, points the load URL at ``http://localhost:<port>`` for the
-        duration of injection, generates load, and tears the tunnel down in a
-        ``finally``. When the deployment is absent or
-        :data:`_ENV_SKIP_PORT_FORWARD` is set (E2E smoke / unit tests), it runs
-        the chaos loop against whatever URL the target already carries.
+        The fault owns its transport end to end. When the run context names a
+        target deployment (via :data:`~devops_bench.chaos.ENV_TARGET_DEPLOYMENT`
+        / :data:`~devops_bench.chaos.ENV_TARGET_NAMESPACE` on ``ctx.env``) and
+        the caller did not opt out, it reads the target Service to learn its
+        real ports and, on a non-local cluster, its external LoadBalancer host.
+        An assigned LoadBalancer is addressed directly; otherwise the fault
+        opens its own ``kubectl port-forward`` and points the load URL at the
+        local tunnel for the duration of injection. When the deployment is
+        absent or :data:`~devops_bench.chaos.ENV_SKIP_PORT_FORWARD` is set (E2E
+        smoke / unit tests), it runs against whatever URL the target carries.
 
         Args:
-            ctx: Run context; ``ctx.env`` carries the port-forward target the
-                harness threaded in (deployment, namespace, skip flag).
+            ctx: Run context; ``ctx.env`` names the target workload and
+                ``ctx.cluster`` tells the fault whether the cluster is local.
             chaos_active_event: Optional event the executor signals when a
                 load spike starts, so the harness can synchronize measurements.
 
@@ -316,9 +415,9 @@ class GenerateLoadFault(Fault):
             ``error``.
         """
         env = ctx.env or {}
-        deployment = env.get(_ENV_TARGET_DEPLOYMENT)
-        namespace = env.get(_ENV_TARGET_NAMESPACE, "default")
-        skip_port_forward = bool(env.get(_ENV_SKIP_PORT_FORWARD))
+        deployment = env.get(ENV_TARGET_DEPLOYMENT)
+        namespace = env.get(ENV_TARGET_NAMESPACE, "default")
+        skip_port_forward = bool(env.get(ENV_SKIP_PORT_FORWARD))
 
         start = time.monotonic()
         # Populated by ``run_chaos_command`` with the spike's real exit status so
@@ -326,16 +425,31 @@ class GenerateLoadFault(Fault):
         load_result: dict[str, Any] = {}
         try:
             # Parallel runs pass a free local port so two concurrent forwards do
-            # not contend; the remote (workload) side stays ``_LOCAL_PORT``.
-            # Parsed inside the guard so a malformed value fails this fault
-            # instead of escaping ``inject``.
-            local_port = int(env.get(_ENV_LOCAL_PORT) or _LOCAL_PORT)
+            # not contend. Parsed inside the guard so a malformed value fails
+            # this fault instead of escaping ``inject``.
+            local_port = int(env.get(ENV_LOCAL_PORT) or _FALLBACK_PORT)
 
-            # Open the fault's own tunnel only when a target deployment is named
-            # and the caller did not opt out; otherwise run against the existing
-            # URL.
-            forward: contextlib.AbstractContextManager[Any]
+            endpoint: _Endpoint | None = None
             if deployment and not skip_port_forward:
+                # A local cluster never gets a LoadBalancer, so skip the poll
+                # rather than burning the full timeout before falling back.
+                is_local = ctx.cluster is not None and ctx.cluster.location == "local"
+                endpoint = _resolve_endpoint(
+                    deployment, namespace, wait_for_lb=not is_local
+                ) or _Endpoint(port=_FALLBACK_PORT, target_port=_FALLBACK_PORT, lb_host=None)
+
+            forward: contextlib.AbstractContextManager[Any]
+            effective_url: str | None
+            if endpoint is None:
+                # Nothing to reach for us: run against the URL the spec carries.
+                forward = contextlib.nullcontext()
+                effective_url = None
+            elif endpoint.lb_host is not None:
+                # Reachable directly: no tunnel needed from any runner location.
+                effective_url = f"http://{endpoint.lb_host}:{endpoint.port}"
+                _log.info("chaos load will hit external LB %s (no port-forward)", effective_url)
+                forward = contextlib.nullcontext()
+            else:
                 # Wait for the deployment to be rolled out (a Ready pod exists)
                 # before forwarding, so the port-forward does not race a rolling
                 # update the agent may have just triggered. Best-effort: a
@@ -357,16 +471,13 @@ class GenerateLoadFault(Fault):
                 forward = port_forward(
                     f"deployment/{deployment}",
                     local_port,
-                    remote_port=_LOCAL_PORT,
+                    remote_port=endpoint.target_port,
                     namespace=namespace,
                 )
-                local_url: str | None = f"http://localhost:{local_port}"
-            else:
-                forward = contextlib.nullcontext()
-                local_url = None
+                effective_url = f"http://localhost:{local_port}"
 
             with forward:
-                output = self._run_agent_loop(local_url, chaos_active_event, load_result)
+                output = self._run_agent_loop(effective_url, chaos_active_event, load_result)
         except Exception as exc:  # noqa: BLE001 - one fault must never abort the run
             elapsed = time.monotonic() - start
             _log.exception("generate_load fault crashed")
@@ -409,21 +520,21 @@ class GenerateLoadFault(Fault):
 
     def _run_agent_loop(
         self,
-        local_url: str | None,
+        effective_url: str | None,
         chaos_active_event: threading.Event | None,
         load_result: dict[str, Any],
     ) -> str:
         """Drive the chaos agent against the effective target URL.
 
-        When ``local_url`` is set the fault is reaching its target through a
-        port-forward, so the load URL is pointed at the local tunnel for the
-        duration of the loop (and restored afterwards) — this keeps both the
-        system instruction and the goal prompt agreeing with the URL the load
-        actually hits. When ``local_url`` is ``None`` the existing target URL is
-        used unchanged.
+        When ``effective_url`` is set the fault resolved its own route to the
+        workload (an external LoadBalancer or a local port-forward), so the load
+        URL is pointed there for the duration of the loop and restored
+        afterwards — this keeps both the system instruction and the goal prompt
+        agreeing with the URL the load actually hits. When it is ``None`` the
+        existing target URL is used unchanged.
 
         Args:
-            local_url: Local port-forward URL to target, or ``None`` to use the
+            effective_url: Resolved URL to target, or ``None`` to use the
                 target's own ``service_url``.
             chaos_active_event: Optional event signaled when load goes active.
             load_result: Mutable dict the tool handler records the spike's exit
@@ -443,8 +554,8 @@ class GenerateLoadFault(Fault):
             return run_chaos_command(command, event, load_result=load_result)
 
         original_url = self.target.service_url
-        if local_url is not None:
-            self.target.service_url = local_url
+        if effective_url is not None:
+            self.target.service_url = effective_url
         try:
             system_instruction = build_system_instruction(self.target.service_url)
             agent = ChaosAgent(

--- a/devops_bench/evalharness/scenario.py
+++ b/devops_bench/evalharness/scenario.py
@@ -14,11 +14,11 @@
 
 """Background chaos + verification on a daemon thread.
 
-The :class:`ScenarioManager` resolves the target Service's external
-LoadBalancer IP, points the load action at it, threads the port-forward target
-env onto the run context as a fallback, and runs chaos plus verification on a
-daemon thread, resolving :attr:`ChaosSpec.verify` against a name-keyed
-verification mapping supplied by the caller.
+The :class:`ScenarioManager` names the target workload on the run context and
+runs chaos plus verification on a daemon thread, resolving
+:attr:`ChaosSpec.verify` against a name-keyed verification mapping supplied by
+the caller. Reaching the workload is the fault's own decision, so this module
+stays independent of whichever fault is scheduled.
 """
 
 from __future__ import annotations
@@ -90,18 +90,16 @@ class ScenarioManager:
     :meth:`~devops_bench.verification.VerifierAgent.run_entry` on the resolved
     entry, so the entry's resolved mode (``converge`` vs ``assert``) governs
     whether the check polls or evaluates once, exactly as it does in the
-    post-run verification pass. The load fault reaches its target through the
-    target Service's external LoadBalancer IP — the manager resolves it from the
-    Service status and rewrites the action's load URL before injection — so the
-    fortio spike works from any runner location (in-VPC bastion or off-VPC
-    local). The ``kubectl port-forward`` the fault still owns is kept as a
-    fallback for when LB resolution fails or the caller opts out.
+    post-run verification pass. The manager names the target workload on
+    ``ctx.env`` and stops there: how to reach it — an external LoadBalancer, a
+    port-forward, or the URL the action already carries — is the fault's own
+    decision, which keeps this independent of whichever fault is scheduled.
 
     Args:
-        target_deployment: Deployment the load fault should disrupt. Also the
-            Service name (the optimize-scale stack seeds the Service with the
-            same name), used here to look up the external LB IP and threaded
-            onto ``ctx.env`` for the fault's port-forward fallback.
+        target_deployment: Deployment the fault should disrupt, threaded onto
+            ``ctx.env``. Also the Service name (the optimize-scale stack seeds
+            the Service with the same name), which is what a fault resolving its
+            own transport looks up.
         namespace: Namespace the deployment / Service lives in; threaded onto
             ``ctx.env``.
         verification_mapping: Name-keyed mapping of
@@ -110,11 +108,12 @@ class ScenarioManager:
             up the entry by name and hands it directly to
             ``VerifierAgent.run_entry``, so the entry's resolved mode governs
             the check. Empty mapping disables verification lookups.
-        skip_port_forward: When True, the fault runs without resolving an LB IP
-            and without opening a ``kubectl port-forward``. The E2E smoke
-            harness (against :class:`~devops_bench.deployers.NoOpDeployer`)
-            flips this on so tests can exercise the wiring without a real
-            cluster.
+        skip_port_forward: When True, flags on ``ctx.env`` that there is no
+            reachable cluster, so the fault runs against whatever target it
+            already carries instead of resolving its own transport. The E2E
+            smoke harness (against
+            :class:`~devops_bench.deployers.NoOpDeployer`) flips this on so
+            tests can exercise the wiring without a real cluster.
 
     Attributes:
         chaos_active_event: Set by the chaos fault once the disruption is

--- a/devops_bench/evalharness/scenario.py
+++ b/devops_bench/evalharness/scenario.py
@@ -31,16 +31,14 @@ import time
 from typing import Any
 
 from devops_bench.chaos import ChaosResult, ChaosSpec
-from devops_bench.chaos.faults.generate_load import (
-    _ENV_LOCAL_PORT,
-    _ENV_SKIP_PORT_FORWARD,
-    _ENV_TARGET_DEPLOYMENT,
-    _ENV_TARGET_NAMESPACE,
-    _LOCAL_PORT,
+from devops_bench.chaos.base import (
+    ENV_LOCAL_PORT,
+    ENV_SKIP_PORT_FORWARD,
+    ENV_TARGET_DEPLOYMENT,
+    ENV_TARGET_NAMESPACE,
 )
 from devops_bench.core import get_logger
 from devops_bench.core.context import RunContext
-from devops_bench.k8s import get_resource, poll_until
 from devops_bench.verification import VerificationEntry, VerifierAgent
 
 __all__ = [
@@ -63,13 +61,6 @@ VERIFICATION_TIMEOUT_SEC = 120
 # this bounds the pass as a whole. Assert-mode entries still always run, since
 # a safeguard that goes unchecked defeats the point of having it.
 VERIFICATION_TOTAL_BUDGET_SEC = 600
-
-# Seconds to wait for the target Service's external LoadBalancer IP to be
-# assigned by the cloud provider's load balancer controller. LB provisioning
-# typically completes within a minute but can lag, so this bounds the wait
-# so a stuck assignment falls back to the port-forward path instead of
-# stalling the run.
-_LB_IP_TIMEOUT_SEC = 180
 
 
 def pick_free_port() -> int:
@@ -242,15 +233,11 @@ class ScenarioManager:
 
         The trigger is a typed node; wait through its own ``wait(ctx)`` rather
         than reading raw ``delay_seconds`` here — the harness only knows the
-        ``Trigger`` Protocol, not the concrete trigger's parameters. Before
-        injecting, the manager resolves the target Service's external
-        LoadBalancer IP and points the action's load URL at
-        ``http://<lb-ip>:8080`` (so the fortio spike hits the workload directly
-        from any runner location); the port-forward target is also threaded onto
-        ``ctx.env`` as a fallback for when LB resolution fails. When
-        ``skip_port_forward`` is True (E2E smoke / no real cluster), the LB
-        resolution is skipped and the fault runs against whatever URL the
-        action already carries.
+        ``Trigger`` Protocol, not the concrete trigger's parameters. The manager
+        names the target workload on ``ctx.env`` and stops there: how to reach
+        it (external LoadBalancer, port-forward, or the URL the action already
+        carries) is the fault's decision, so this stays independent of which
+        fault is scheduled.
 
         Args:
             spec: Typed chaos spec.
@@ -261,107 +248,16 @@ class ScenarioManager:
         """
         spec.trigger.wait(ctx)
 
-        # Thread the port-forward target onto the context. ``ctx.env`` values
-        # are strings; flags are written only when truthy so the fault's
-        # ``bool(env.get(...))`` reads cleanly.
-        ctx.env[_ENV_TARGET_DEPLOYMENT] = self.target_deployment
-        ctx.env[_ENV_TARGET_NAMESPACE] = self.namespace
+        # ``ctx.env`` values are strings; flags are written only when truthy so
+        # the fault's ``bool(env.get(...))`` reads cleanly.
+        ctx.env[ENV_TARGET_DEPLOYMENT] = self.target_deployment
+        ctx.env[ENV_TARGET_NAMESPACE] = self.namespace
         if self.local_port is not None:
-            ctx.env[_ENV_LOCAL_PORT] = str(self.local_port)
-
+            ctx.env[ENV_LOCAL_PORT] = str(self.local_port)
         if self.skip_port_forward:
-            # Smoke / no-cluster path: there is no cluster to query for an LB
-            # IP, so leave the action's URL alone and just flag the fault to
-            # skip the tunnel.
-            ctx.env[_ENV_SKIP_PORT_FORWARD] = "1"
-        else:
-            is_local = ctx.cluster is not None and ctx.cluster.location == "local"
-            if is_local:
-                _log.info(
-                    "local cluster (location=%r) detected; skipping LoadBalancer IP resolution "
-                    "to rely directly on port-forward fallback",
-                    ctx.cluster.location,
-                )
-                lb_ip = None
-            else:
-                # Real-cluster path: resolve the external LB IP and rewrite the
-                # action's load URL to point at it directly. Fall back to the
-                # port-forward path if resolution fails or times out — that way a
-                # delayed LB still produces a load attempt instead of an aborted
-                # run.
-                lb_ip = self._resolve_lb_ip(self.target_deployment, self.namespace)
-
-            if lb_ip is not None and hasattr(spec.action, "target"):
-                target = spec.action.target
-                if hasattr(target, "service_url"):
-                    lb_url = f"http://{lb_ip}:{_LOCAL_PORT}"
-                    _log.info(
-                        "chaos load will hit external LB %s (no port-forward)",
-                        lb_url,
-                    )
-                    target.service_url = lb_url
-                    ctx.env[_ENV_SKIP_PORT_FORWARD] = "1"
-            # If lb_ip is None (timeout / local skip / kubectl error) the skip env is left
-            # unset; the fault then opens its own port-forward as the fallback.
+            ctx.env[ENV_SKIP_PORT_FORWARD] = "1"
 
         return spec.action.inject(ctx, self.chaos_active_event)
-
-    @staticmethod
-    def _resolve_lb_ip(service: str, namespace: str) -> str | None:
-        """Poll the target Service for an external LoadBalancer IP.
-
-        Reads ``status.loadBalancer.ingress[0].ip`` (falling back to
-        ``hostname`` when the cloud provider hands back a DNS name instead of an
-        IP) and waits up to :data:`_LB_IP_TIMEOUT_SEC` for it to appear, since
-        LoadBalancer provisioning may take a minute or two to set up the
-        underlying network LB and firewall rule.
-
-        Args:
-            service: Service name (the optimize-scale target Service is named
-                after the target deployment, so the manager reuses
-                ``target_deployment`` here).
-            namespace: Namespace the Service lives in.
-
-        Returns:
-            The external IP/hostname as a string, or ``None`` if the timeout
-            elapses or kubectl fails. The caller treats ``None`` as a signal to
-            fall back to the port-forward transport.
-        """
-        resolved: dict[str, str] = {}
-
-        def _has_ip() -> bool:
-            try:
-                doc = get_resource("service", service, namespace=namespace)
-            except Exception as exc:  # noqa: BLE001 - poll keeps retrying
-                _log.debug("waiting for LB IP on %s/%s: %s", namespace, service, exc)
-                return False
-            ingress = (doc.get("status") or {}).get("loadBalancer", {}).get("ingress") or []
-            if not ingress:
-                return False
-            entry = ingress[0] or {}
-            ip = entry.get("ip") or entry.get("hostname")
-            if not ip:
-                return False
-            resolved["ip"] = ip
-            return True
-
-        _log.info(
-            "resolving external LB IP for service %s/%s (timeout %ss)",
-            namespace,
-            service,
-            _LB_IP_TIMEOUT_SEC,
-        )
-        ok = poll_until(_has_ip, timeout_sec=_LB_IP_TIMEOUT_SEC)
-        if not ok:
-            _log.warning(
-                "external LB IP for service %s/%s not assigned within %ss; "
-                "falling back to port-forward",
-                namespace,
-                service,
-                _LB_IP_TIMEOUT_SEC,
-            )
-            return None
-        return resolved["ip"]
 
     @staticmethod
     def _chaos_report_from_result(spec: ChaosSpec, result: Any) -> dict[str, Any]:

--- a/tests/unit/chaos/test_generate_load.py
+++ b/tests/unit/chaos/test_generate_load.py
@@ -27,12 +27,15 @@ from subprocess import CompletedProcess
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from devops_bench.chaos.base import ChaosResult
+from devops_bench.chaos.base import (
+    ENV_LOCAL_PORT,
+    ENV_SKIP_PORT_FORWARD,
+    ENV_TARGET_DEPLOYMENT,
+    ENV_TARGET_NAMESPACE,
+    ChaosResult,
+)
 from devops_bench.chaos.faults import generate_load as gl
 from devops_bench.chaos.faults.generate_load import (
-    _ENV_SKIP_PORT_FORWARD,
-    _ENV_TARGET_DEPLOYMENT,
-    _ENV_TARGET_NAMESPACE,
     GenerateLoadFault,
     LoadTarget,
     build_system_instruction,
@@ -44,6 +47,28 @@ from devops_bench.k8s import kubectl as k8s_kubectl
 
 def _make_ctx(env: dict[str, str] | None = None) -> RunContext:
     return RunContext(task_id="test", env=env or {})
+
+
+def _service_doc(
+    port: int = 8080,
+    target_port: int | str = 8080,
+    lb_host: str | None = None,
+    svc_type: str | None = None,
+):
+    """Build a Service document as ``get_resource`` would return it."""
+    if svc_type is None:
+        svc_type = "LoadBalancer" if lb_host is not None else "ClusterIP"
+    doc: dict[str, Any] = {
+        "spec": {"type": svc_type, "ports": [{"port": port, "targetPort": target_port}]}
+    }
+    if lb_host is not None:
+        doc["status"] = {"loadBalancer": {"ingress": [{"ip": lb_host}]}}
+    return doc
+
+
+def _patch_service(**kwargs: Any):
+    """Patch the Service lookup the fault uses to discover ports / LB host."""
+    return patch.object(gl, "get_resource", return_value=_service_doc(**kwargs))
 
 
 def _drive_load(
@@ -262,8 +287,11 @@ def test_inject_opens_port_forward_and_points_url_at_local_tunnel() -> None:
             _drive_load(self.kwargs)
             return "spike complete"
 
-    ctx = _make_ctx({_ENV_TARGET_DEPLOYMENT: "web-app", _ENV_TARGET_NAMESPACE: "prod"})
+    ctx = _make_ctx({ENV_TARGET_DEPLOYMENT: "web-app", ENV_TARGET_NAMESPACE: "prod"})
     with (
+        # The fault reads the target Service to discover its ports; a ClusterIP
+        # Service on 8080 keeps this test on the port-forward path.
+        _patch_service(port=8080, target_port=8080),
         patch.object(k8s_kubectl.subprocess, "Popen", return_value=proc) as popen_mock,
         patch.object(k8s_kubectl.time, "sleep"),  # don't actually sleep the settle window
         # The fault waits for the target rollout before forwarding; stub it so
@@ -301,7 +329,6 @@ def test_inject_uses_custom_local_port_for_parallel_runs() -> None:
     Parallel runs pass a free local port so two concurrent forwards do not
     contend; the remote (workload) side stays 8080.
     """
-    from devops_bench.chaos.faults.generate_load import _ENV_LOCAL_PORT
 
     fault = GenerateLoadFault(
         target=LoadTarget(service_url="http://example.svc.cluster.local", qps=50)
@@ -317,7 +344,7 @@ def test_inject_uses_custom_local_port_for_parallel_runs() -> None:
             captured["url_during_run"] = fault.target.service_url
             return "spike complete"
 
-    ctx = _make_ctx({_ENV_TARGET_DEPLOYMENT: "web-app", _ENV_LOCAL_PORT: "34567"})
+    ctx = _make_ctx({ENV_TARGET_DEPLOYMENT: "web-app", ENV_LOCAL_PORT: "34567"})
     with (
         patch.object(k8s_kubectl.subprocess, "Popen", return_value=proc) as popen_mock,
         patch.object(k8s_kubectl.time, "sleep"),
@@ -338,7 +365,7 @@ def test_inject_early_port_forward_exit_becomes_failed_result() -> None:
     dead.poll.return_value = 1  # exited during the settle window
     dead.returncode = 1
 
-    ctx = _make_ctx({_ENV_TARGET_DEPLOYMENT: "web-app"})
+    ctx = _make_ctx({ENV_TARGET_DEPLOYMENT: "web-app"})
     with (
         patch.object(k8s_kubectl.subprocess, "Popen", return_value=dead),
         patch.object(k8s_kubectl.time, "sleep"),
@@ -373,8 +400,8 @@ def test_inject_skips_port_forward_when_flagged() -> None:
 
     ctx = _make_ctx(
         {
-            _ENV_TARGET_DEPLOYMENT: "web-app",
-            _ENV_SKIP_PORT_FORWARD: "1",
+            ENV_TARGET_DEPLOYMENT: "web-app",
+            ENV_SKIP_PORT_FORWARD: "1",
         }
     )
     with (
@@ -432,7 +459,7 @@ def test_inject_invalid_local_port_becomes_failed_result() -> None:
     """A malformed CHAOS_LOCAL_PORT fails the fault instead of escaping inject."""
     fault = GenerateLoadFault(target=LoadTarget(service_url="http://svc", qps=1))
 
-    result = fault.inject(_make_ctx({gl._ENV_LOCAL_PORT: "not-a-port"}))
+    result = fault.inject(_make_ctx({gl.ENV_LOCAL_PORT: "not-a-port"}))
 
     assert result.success is False
     assert result.error is not None
@@ -442,7 +469,7 @@ def test_inject_invalid_local_port_becomes_failed_result() -> None:
 def test_inject_port_forward_setup_failure_becomes_failed_result() -> None:
     """A port-forward that raises at construction yields a failed ChaosResult."""
     fault = GenerateLoadFault(target=LoadTarget(service_url="http://x.svc.cluster.local", qps=1))
-    ctx = _make_ctx({_ENV_TARGET_DEPLOYMENT: "web-app"})
+    ctx = _make_ctx({ENV_TARGET_DEPLOYMENT: "web-app"})
     with (
         patch.object(gl, "rollout_status"),
         patch.object(gl, "port_forward", side_effect=RuntimeError("kubectl missing")),
@@ -456,3 +483,193 @@ def test_inject_port_forward_setup_failure_becomes_failed_result() -> None:
     assert result.success is False
     assert result.error is not None
     assert "kubectl missing" in result.error
+
+
+# --- transport resolution: the fault decides how to reach its target ---
+
+
+def _stub_agent(captured: dict[str, Any], fault: GenerateLoadFault):
+    """Build a stub ChaosAgent that records the URL in force during the run."""
+
+    class _StubAgent:
+        def __init__(self, **kwargs: Any) -> None:
+            captured["system_instruction"] = kwargs["system_instruction"]
+            self.kwargs = kwargs
+
+        def run(self, goal: str) -> str:
+            captured["goal"] = goal
+            captured["url_during_run"] = fault.target.service_url
+            _drive_load(self.kwargs, command="fortio load http://x")
+            return "spike complete"
+
+    return _StubAgent
+
+
+def _local_cluster_ctx(env: dict[str, str]) -> RunContext:
+    from devops_bench.core.context import ClusterInfo
+
+    ctx = _make_ctx(env)
+    ctx.cluster = ClusterInfo(name="kind", location="local")
+    return ctx
+
+
+def test_inject_targets_external_lb_without_a_port_forward() -> None:
+    """An assigned LoadBalancer is addressed directly, using the Service's port."""
+    fault = GenerateLoadFault(target=LoadTarget(service_url="http://x.svc.cluster.local", qps=1))
+    captured: dict[str, Any] = {}
+    ctx = _make_ctx({ENV_TARGET_DEPLOYMENT: "web-app", ENV_TARGET_NAMESPACE: "prod"})
+
+    with (
+        _patch_service(port=8080, target_port=8080, lb_host="34.10.20.30") as svc,
+        patch.object(k8s_kubectl.subprocess, "Popen") as popen_mock,
+        patch("devops_bench.chaos.agent.ChaosAgent", _stub_agent(captured, fault)),
+    ):
+        result = fault.inject(ctx)
+
+    svc.assert_called_with("service", "web-app", namespace="prod")
+    # Reachable directly, so no tunnel is opened at all.
+    popen_mock.assert_not_called()
+    assert captured["url_during_run"] == "http://34.10.20.30:8080"
+    assert result.success is True
+    # The fault's own stored URL is restored once injection completes.
+    assert fault.target.service_url == "http://x.svc.cluster.local"
+
+
+def test_inject_lb_url_uses_the_service_port_not_a_hardcoded_one() -> None:
+    """The LB URL carries the Service's real port, not an assumed 8080."""
+    fault = GenerateLoadFault(target=LoadTarget(service_url="http://x.svc.cluster.local", qps=1))
+    captured: dict[str, Any] = {}
+
+    with (
+        _patch_service(port=8000, target_port=80, lb_host="lb.example.com"),
+        patch.object(k8s_kubectl.subprocess, "Popen"),
+        patch("devops_bench.chaos.agent.ChaosAgent", _stub_agent(captured, fault)),
+    ):
+        fault.inject(_make_ctx({ENV_TARGET_DEPLOYMENT: "web-app"}))
+
+    assert captured["url_during_run"] == "http://lb.example.com:8000"
+
+
+def test_inject_port_forward_uses_the_service_target_port() -> None:
+    """Without an LB, the tunnel's remote side is the Service's targetPort.
+
+    Previously the remote side was hardcoded to 8080, which forced every
+    chaos-eligible workload to listen on that port.
+    """
+    fault = GenerateLoadFault(target=LoadTarget(service_url="http://x.svc.cluster.local", qps=1))
+    captured: dict[str, Any] = {}
+    proc = _live_popen()
+
+    with (
+        _patch_service(port=8000, target_port=9090, lb_host=None),
+        patch.object(k8s_kubectl.subprocess, "Popen", return_value=proc) as popen_mock,
+        patch.object(k8s_kubectl.time, "sleep"),
+        patch("devops_bench.chaos.faults.generate_load.rollout_status"),
+        patch("devops_bench.chaos.agent.ChaosAgent", _stub_agent(captured, fault)),
+    ):
+        fault.inject(_make_ctx({ENV_TARGET_DEPLOYMENT: "web-app", ENV_LOCAL_PORT: "34567"}))
+
+    assert popen_mock.call_args.args[0][3] == "34567:9090"
+    assert captured["url_during_run"] == "http://localhost:34567"
+
+
+def test_inject_falls_back_to_default_port_when_service_unreadable() -> None:
+    """An unreadable Service degrades to the default port rather than aborting."""
+    fault = GenerateLoadFault(target=LoadTarget(service_url="http://x.svc.cluster.local", qps=1))
+    captured: dict[str, Any] = {}
+    proc = _live_popen()
+
+    with (
+        patch.object(gl, "get_resource", side_effect=RuntimeError("no such service")),
+        patch.object(k8s_kubectl.subprocess, "Popen", return_value=proc) as popen_mock,
+        patch.object(k8s_kubectl.time, "sleep"),
+        patch("devops_bench.chaos.faults.generate_load.rollout_status"),
+        patch("devops_bench.chaos.agent.ChaosAgent", _stub_agent(captured, fault)),
+    ):
+        result = fault.inject(_make_ctx({ENV_TARGET_DEPLOYMENT: "web-app"}))
+
+    assert popen_mock.call_args.args[0][3] == "8080:8080"
+    assert result.success is True
+
+
+def test_inject_skips_lb_poll_on_a_local_cluster() -> None:
+    """A local cluster never gets an LB, so the fault must not burn the timeout."""
+    fault = GenerateLoadFault(target=LoadTarget(service_url="http://x.svc.cluster.local", qps=1))
+    captured: dict[str, Any] = {}
+    proc = _live_popen()
+
+    with (
+        _patch_service(port=8080, target_port=8080, lb_host="10.0.0.1"),
+        patch.object(gl, "poll_until", side_effect=AssertionError("polled for an LB locally")),
+        patch.object(k8s_kubectl.subprocess, "Popen", return_value=proc),
+        patch.object(k8s_kubectl.time, "sleep"),
+        patch("devops_bench.chaos.faults.generate_load.rollout_status"),
+        patch("devops_bench.chaos.agent.ChaosAgent", _stub_agent(captured, fault)),
+    ):
+        result = fault.inject(_local_cluster_ctx({ENV_TARGET_DEPLOYMENT: "web-app"}))
+
+    # Port-forward path taken despite the Service advertising an ingress IP.
+    assert captured["url_during_run"] == "http://localhost:8080"
+    assert result.success is True
+
+
+def test_inject_skips_service_lookup_entirely_when_port_forward_skipped() -> None:
+    """The smoke path touches no cluster: no Service read, no tunnel."""
+    fault = GenerateLoadFault(target=LoadTarget(service_url="http://existing", qps=1))
+    captured: dict[str, Any] = {}
+
+    with (
+        patch.object(gl, "get_resource", side_effect=AssertionError("read a Service in smoke")),
+        patch.object(k8s_kubectl.subprocess, "Popen") as popen_mock,
+        patch("devops_bench.chaos.agent.ChaosAgent", _stub_agent(captured, fault)),
+    ):
+        result = fault.inject(
+            _make_ctx({ENV_TARGET_DEPLOYMENT: "web-app", ENV_SKIP_PORT_FORWARD: "1"})
+        )
+
+    popen_mock.assert_not_called()
+    assert captured["url_during_run"] == "http://existing"
+    assert result.success is True
+
+
+def test_inject_falls_back_to_port_forward_when_lb_never_assigned() -> None:
+    """A LoadBalancer whose ingress never appears degrades to the tunnel."""
+    fault = GenerateLoadFault(target=LoadTarget(service_url="http://x.svc.cluster.local", qps=1))
+    captured: dict[str, Any] = {}
+    proc = _live_popen()
+
+    with (
+        # Type LoadBalancer, but no ingress was ever assigned.
+        _patch_service(port=8080, target_port=8080, svc_type="LoadBalancer"),
+        # Bound the wait so the test does not sit through the real timeout.
+        patch.object(gl, "_LB_IP_TIMEOUT_SEC", 0.01),
+        patch.object(k8s_kubectl.subprocess, "Popen", return_value=proc) as popen_mock,
+        patch.object(k8s_kubectl.time, "sleep"),
+        patch("devops_bench.chaos.faults.generate_load.rollout_status"),
+        patch("devops_bench.chaos.agent.ChaosAgent", _stub_agent(captured, fault)),
+    ):
+        result = fault.inject(_make_ctx({ENV_TARGET_DEPLOYMENT: "web-app"}))
+
+    popen_mock.assert_called_once()
+    assert captured["url_during_run"] == "http://localhost:8080"
+    assert result.success is True
+
+
+def test_inject_skips_lb_poll_for_a_non_loadbalancer_service() -> None:
+    """A ClusterIP Service is never polled for an ingress that cannot come."""
+    fault = GenerateLoadFault(target=LoadTarget(service_url="http://x.svc.cluster.local", qps=1))
+    captured: dict[str, Any] = {}
+    proc = _live_popen()
+
+    with (
+        _patch_service(port=8080, target_port=8080, svc_type="ClusterIP"),
+        patch.object(gl, "poll_until", side_effect=AssertionError("polled a ClusterIP service")),
+        patch.object(k8s_kubectl.subprocess, "Popen", return_value=proc),
+        patch.object(k8s_kubectl.time, "sleep"),
+        patch("devops_bench.chaos.faults.generate_load.rollout_status"),
+        patch("devops_bench.chaos.agent.ChaosAgent", _stub_agent(captured, fault)),
+    ):
+        result = fault.inject(_make_ctx({ENV_TARGET_DEPLOYMENT: "web-app"}))
+
+    assert captured["url_during_run"] == "http://localhost:8080"
+    assert result.success is True

--- a/tests/unit/evalharness/test_scenario.py
+++ b/tests/unit/evalharness/test_scenario.py
@@ -28,8 +28,6 @@ from types import SimpleNamespace
 from typing import Any, Literal
 from unittest.mock import patch
 
-import pytest
-
 from devops_bench.chaos import ChaosResult, ChaosSpec
 from devops_bench.chaos.faults.generate_load import GenerateLoadFault
 from devops_bench.chaos.triggers.time_delay import TimeTrigger
@@ -115,10 +113,10 @@ def test_scenario_threads_port_forward_target_onto_ctx_env() -> None:
     target deployment / namespace (and the skip flag) via the run context's
     ``env`` so the fault can open its own tunnel.
     """
-    from devops_bench.chaos.faults.generate_load import (
-        _ENV_SKIP_PORT_FORWARD,
-        _ENV_TARGET_DEPLOYMENT,
-        _ENV_TARGET_NAMESPACE,
+    from devops_bench.chaos.base import (
+        ENV_SKIP_PORT_FORWARD,
+        ENV_TARGET_DEPLOYMENT,
+        ENV_TARGET_NAMESPACE,
     )
 
     spec = _build_spec(verify_key=None)
@@ -142,10 +140,10 @@ def test_scenario_threads_port_forward_target_onto_ctx_env() -> None:
         )
         manager.run_chaos_and_verification(spec, _build_ctx())
 
-    assert captured["env"][_ENV_TARGET_DEPLOYMENT] == "dep"
-    assert captured["env"][_ENV_TARGET_NAMESPACE] == "ns"
+    assert captured["env"][ENV_TARGET_DEPLOYMENT] == "dep"
+    assert captured["env"][ENV_TARGET_NAMESPACE] == "ns"
     # ``skip_port_forward=True`` flips the fault's opt-out flag on the env.
-    assert captured["env"][_ENV_SKIP_PORT_FORWARD] == "1"
+    assert captured["env"][ENV_SKIP_PORT_FORWARD] == "1"
     # The manager leaves the action's in-cluster URL alone — no rewrite seam.
     assert captured["service_url"] == "http://example.svc.cluster.local"
 
@@ -157,7 +155,7 @@ def test_scenario_threads_custom_local_port_onto_ctx_env() -> None:
     port via ``CHAOS_LOCAL_PORT``; the fault binds the port-forward's local side
     there. No port is threaded when ``local_port`` is None (default behavior).
     """
-    from devops_bench.chaos.faults.generate_load import _ENV_LOCAL_PORT
+    from devops_bench.chaos.base import ENV_LOCAL_PORT
 
     spec = _build_spec(verify_key=None)
     captured: dict[str, Any] = {}
@@ -179,12 +177,12 @@ def test_scenario_threads_custom_local_port_onto_ctx_env() -> None:
         assert manager.local_port == 34567
         manager.run_chaos_and_verification(spec, _build_ctx())
 
-    assert captured["env"][_ENV_LOCAL_PORT] == "34567"
+    assert captured["env"][ENV_LOCAL_PORT] == "34567"
 
 
 def test_scenario_omits_local_port_env_by_default() -> None:
     """Without a per-run port, no ``CHAOS_LOCAL_PORT`` is threaded (fault default)."""
-    from devops_bench.chaos.faults.generate_load import _ENV_LOCAL_PORT
+    from devops_bench.chaos.base import ENV_LOCAL_PORT
 
     spec = _build_spec(verify_key=None)
     captured: dict[str, Any] = {}
@@ -201,7 +199,7 @@ def test_scenario_omits_local_port_env_by_default() -> None:
             target_deployment="dep", namespace="ns", skip_port_forward=True
         ).run_chaos_and_verification(spec, _build_ctx())
 
-    assert _ENV_LOCAL_PORT not in captured["env"]
+    assert ENV_LOCAL_PORT not in captured["env"]
 
 
 def test_pick_free_port_returns_a_usable_port() -> None:
@@ -430,216 +428,3 @@ def test_stop_aborts_verification() -> None:
     assert manager._aborted.is_set()  # noqa: SLF001
     # Idempotent — the second call must not raise.
     manager.stop()
-
-
-def test_scenario_resolves_lb_ip_and_points_action_url_at_it() -> None:
-    """Real-cluster path: manager resolves the Service LB IP and rewrites the URL.
-
-    The harness no longer relies on a port-forward to reach the workload — it
-    reads ``status.loadBalancer.ingress[0].ip`` from the target Service and
-    rewrites the action's ``target.service_url`` to ``http://<ip>:8080`` so the
-    fortio spike hits the LB directly. The skip flag is set on ``ctx.env`` so
-    the fault does not also open a redundant tunnel.
-    """
-    from devops_bench.chaos.faults.generate_load import (
-        _ENV_SKIP_PORT_FORWARD,
-        _ENV_TARGET_DEPLOYMENT,
-        _ENV_TARGET_NAMESPACE,
-    )
-
-    spec = _build_spec(verify_key=None)
-    captured: dict[str, Any] = {}
-
-    def fake_inject(self: GenerateLoadFault, ctx: RunContext, event):
-        captured["env"] = dict(ctx.env)
-        captured["service_url"] = self.target.service_url
-        return ChaosResult(success=True, injected_fault=self.type, elapsed_time=0.0)
-
-    fake_svc = {"status": {"loadBalancer": {"ingress": [{"ip": "34.10.20.30"}]}}}
-
-    with (
-        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
-        patch.object(GenerateLoadFault, "inject", fake_inject),
-        patch(
-            "devops_bench.evalharness.scenario.get_resource",
-            return_value=fake_svc,
-        ) as get_resource_mock,
-    ):
-        manager = ScenarioManager(
-            target_deployment="dep",
-            namespace="ns",
-            skip_port_forward=False,
-        )
-        manager.run_chaos_and_verification(spec, _build_ctx())
-
-    # The Service was queried by deployment name in the right namespace.
-    get_resource_mock.assert_called_with("service", "dep", namespace="ns")
-    # The action's URL was rewritten to the LB endpoint, port 8080.
-    assert captured["service_url"] == "http://34.10.20.30:8080"
-    # Skip flag is set so the fault doesn't also open a port-forward.
-    assert captured["env"][_ENV_SKIP_PORT_FORWARD] == "1"
-    # Deployment / namespace are still threaded for the fallback path.
-    assert captured["env"][_ENV_TARGET_DEPLOYMENT] == "dep"
-    assert captured["env"][_ENV_TARGET_NAMESPACE] == "ns"
-
-
-def test_scenario_falls_back_to_port_forward_when_lb_ip_unavailable() -> None:
-    """When LB resolution times out, the manager leaves the skip flag unset.
-
-    The fault then opens its own ``kubectl port-forward`` to the target
-    deployment as the fallback transport — a degraded but functional path so
-    the run still attempts load.
-    """
-    from devops_bench.chaos.faults.generate_load import _ENV_SKIP_PORT_FORWARD
-
-    spec = _build_spec(verify_key=None)
-    captured: dict[str, Any] = {}
-
-    def fake_inject(self: GenerateLoadFault, ctx: RunContext, event):
-        captured["env"] = dict(ctx.env)
-        captured["service_url"] = self.target.service_url
-        return ChaosResult(success=True, injected_fault=self.type, elapsed_time=0.0)
-
-    # Service has no LB ingress assigned yet — every poll returns "not ready",
-    # and the bounded poll eventually gives up.
-    no_ip_svc = {"status": {"loadBalancer": {}}}
-
-    with (
-        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
-        patch.object(GenerateLoadFault, "inject", fake_inject),
-        patch(
-            "devops_bench.evalharness.scenario.get_resource",
-            return_value=no_ip_svc,
-        ),
-        # Make poll_until short-circuit to a single failed check so the test
-        # doesn't actually wait 180s on the wall clock.
-        patch(
-            "devops_bench.evalharness.scenario.poll_until",
-            return_value=False,
-        ) as poll_mock,
-    ):
-        manager = ScenarioManager(
-            target_deployment="dep",
-            namespace="ns",
-            skip_port_forward=False,
-        )
-        manager.run_chaos_and_verification(spec, _build_ctx())
-
-    poll_mock.assert_called_once()
-    # The action URL is untouched (no IP to rewrite to).
-    assert captured["service_url"] == "http://example.svc.cluster.local"
-    # And critically the skip flag is NOT set — the fault falls back to its
-    # port-forward to keep the run functional.
-    assert _ENV_SKIP_PORT_FORWARD not in captured["env"]
-
-
-def test_scenario_skips_lb_resolution_in_smoke_path() -> None:
-    """``skip_port_forward=True`` (smoke) never queries the cluster for an LB IP.
-
-    The smoke harness runs against NoOpDeployer with no real cluster, so
-    asking kubectl for a Service would either fail or accidentally hit the
-    operator's current context. The skip flag short-circuits both the
-    resolution and the port-forward.
-    """
-    from devops_bench.chaos.faults.generate_load import _ENV_SKIP_PORT_FORWARD
-
-    spec = _build_spec(verify_key=None)
-    captured: dict[str, Any] = {}
-
-    def fake_inject(self: GenerateLoadFault, ctx: RunContext, event):
-        captured["env"] = dict(ctx.env)
-        captured["service_url"] = self.target.service_url
-        return ChaosResult(success=True, injected_fault=self.type, elapsed_time=0.0)
-
-    with (
-        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
-        patch.object(GenerateLoadFault, "inject", fake_inject),
-        patch(
-            "devops_bench.evalharness.scenario.get_resource",
-            side_effect=AssertionError("smoke path must not query the cluster"),
-        ),
-        patch(
-            "devops_bench.evalharness.scenario.poll_until",
-            side_effect=AssertionError("smoke path must not poll"),
-        ),
-    ):
-        manager = ScenarioManager(
-            target_deployment="dep",
-            namespace="ns",
-            skip_port_forward=True,
-        )
-        manager.run_chaos_and_verification(spec, _build_ctx())
-
-    # Skip flag set, URL untouched, no kubectl / poll happened (the patches
-    # would have raised AssertionError otherwise).
-    assert captured["env"][_ENV_SKIP_PORT_FORWARD] == "1"
-    assert captured["service_url"] == "http://example.svc.cluster.local"
-
-
-def test_scenario_skips_lb_resolution_for_local_cluster() -> None:
-    """When the cluster is local (location='local'), skip LB resolution but keep port-forward fallback.
-
-    This avoids the 180s LoadBalancer IP resolution timeout on KinD, where
-    the Service type is ClusterIP and will never get an external IP, while
-    still allowing the port-forward tunnel to be opened.
-    """
-    from devops_bench.chaos.faults.generate_load import (
-        _ENV_SKIP_PORT_FORWARD,
-        _ENV_TARGET_DEPLOYMENT,
-        _ENV_TARGET_NAMESPACE,
-    )
-    from devops_bench.core.context import ClusterInfo
-
-    spec = _build_spec(verify_key=None)
-    captured: dict[str, Any] = {}
-
-    def fake_inject(self: GenerateLoadFault, ctx: RunContext, event):
-        captured["env"] = dict(ctx.env)
-        captured["service_url"] = self.target.service_url
-        return ChaosResult(success=True, injected_fault=self.type, elapsed_time=0.0)
-
-    # Local cluster info
-    local_cluster = ClusterInfo(name="my-kind", location="local")
-    ctx = _build_ctx()
-    ctx.cluster = local_cluster
-
-    with (
-        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
-        patch.object(GenerateLoadFault, "inject", fake_inject),
-        patch(
-            "devops_bench.evalharness.scenario.get_resource",
-            side_effect=AssertionError("local path must not query the cluster for LB"),
-        ),
-        patch(
-            "devops_bench.evalharness.scenario.poll_until",
-            side_effect=AssertionError("local path must not poll for LB"),
-        ),
-    ):
-        manager = ScenarioManager(
-            target_deployment="dep",
-            namespace="ns",
-            skip_port_forward=False,
-        )
-        manager.run_chaos_and_verification(spec, ctx)
-
-    assert captured["service_url"] == "http://example.svc.cluster.local"
-    assert _ENV_SKIP_PORT_FORWARD not in captured["env"]
-    assert captured["env"][_ENV_TARGET_DEPLOYMENT] == "dep"
-    assert captured["env"][_ENV_TARGET_NAMESPACE] == "ns"
-
-
-@pytest.fixture(autouse=True)
-def _no_real_kubectl(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Guard against this file accidentally shelling out to ``kubectl``.
-
-    Tests that don't exercise the port-forward path run with
-    ``skip_port_forward=True`` so the load fault never opens a tunnel; this guard
-    patches the ``subprocess.Popen`` the port-forward helper would use so a test
-    that forgets the flag (and isn't deliberately driving the port-forward path)
-    fails loudly instead of attempting a real port-forward.
-    """
-
-    def _boom(*args, **kwargs):  # pragma: no cover - exercised only on regression
-        raise RuntimeError("test attempted to spawn a real kubectl process")
-
-    monkeypatch.setattr("devops_bench.k8s.kubectl.subprocess.Popen", _boom)


### PR DESCRIPTION
`ScenarioManager._inject_chaos` owned transport setup for the load fault: it imported
private names from `chaos/faults/generate_load.py`, polled for the target Service's
LoadBalancer IP, and rewrote the action's `service_url` through a `hasattr` duck-type
check. That put one fault's connectivity logic in the fault-agnostic scheduling layer.

It also assumed port 8080 in two places: the rewritten LoadBalancer URL, and the
port-forward's remote side. A Service exposing any other port could not be reached,
which is why `tf/prebuilt/optimize-scale/main.tf` documents that the workload
"MUST listen on 8080".

## Changes

- Promote the four `ctx.env` target keys to public constants in `chaos/base.py`,
  documented as the harness-to-fault contract. The `devops_bench.chaos` export list is
  unchanged.
- `GenerateLoadFault.inject` now reads the target Service to discover its real `port`
  and `targetPort`, resolves the LoadBalancer host itself, and chooses between
  addressing the LB directly and opening its own port-forward.
- The LoadBalancer URL uses the Service port; the port-forward uses the Service
  `targetPort`. An unreadable Service falls back to the previous default rather than
  failing the fault.
- Only poll for an ingress when the Service is `type: LoadBalancer`, so a ClusterIP
  Service no longer burns the full timeout before falling back.
- `_inject_chaos` is reduced to waiting the trigger and naming the target workload on
  `ctx.env`.

The URL override is now applied for the duration of injection and restored afterwards,
instead of permanently mutating the spec.

## Tests

Tests for LoadBalancer versus port-forward selection move from the scenario suite to the
fault suite, with new cases for a non-default Service port, a distinct `targetPort`, an
unreadable Service, an unassigned LoadBalancer, and the local-cluster and smoke paths.

Follow-up to the review discussion on #37. Overlaps #33, which also edits `inject()`; the
two are separable and whichever lands second can rebase.

/kind cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configuration options for target deployment, namespace, local port, and port-forwarding behavior.
  - Load generation now selects the correct service port and target automatically.
  - Supports direct access through an external LoadBalancer when available.
  - Added an overall time limit for post-run verification.

- **Bug Fixes**
  - Falls back to port forwarding when external access is unavailable.
  - Improved detection and reporting of unsuccessful load spikes.
  - Prevents unnecessary service lookups and port-forwarding when disabled.
  - Verification entries now execute through the standard verification flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->