### PR TITLE
Add a vendor-neutrality review guideline

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -19,6 +19,10 @@ reviews:
       instructions: |
         Review against Python 3.12+ idioms. All Python code must include type hints. Ensure docstrings are provided for public classes and functions. Enforce `uv` for dependency/environment management and `ruff` for linting and formatting. Ensure Apache 2.0 license headers are present on all new source files.
 
+    - path: "{devops_bench,docs}/**"
+      instructions: |
+        Flag vendor-specific terminology (GKE, GCP, gcloud, Google Cloud) in user-facing surfaces: docstrings, CLI help text, error messages, public API names, and docs. The benchmark is vendor-neutral. Also flag generic framework layers (core, evalharness, run/cli, tasks, metrics) reading provider-specific environment variables such as GCP_PROJECT_ID — provider resolution belongs in devops_bench/providers/ and deployer implementations. Provider-specific terms are acceptable only in those provider modules, in tf/, or when naming a real provider artifact. Suggest neutral phrasing such as "cloud project id" or "target Kubernetes cluster" elsewhere.
+
     - path: "tests/**/*.py"
       instructions: |
         Verify unit test coverage, fixture scoping, mock usage, and pytest assertions. Ensure test functions have proper type annotations and clean structure.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - **Dependencies**: Do NOT use `pip`, `virtualenv`, or `poetry`. Exclusively use **`uv`** for dependency and environment management.
 - **Linting & Formatting**: Do NOT use `black` or `flake8`. Exclusively use **`ruff`**.
 - **Documentation**: Provide clear, concise docstrings for public functions and classes.
+- **Vendor neutrality**: User-facing text (docstrings, CLI help, error messages, docs) and the generic framework layers must be vendor-neutral. Provider-specific terms and environment variables (GKE, GCP, `gcloud`, `GCP_PROJECT_ID`, ...) belong only in provider-specific modules (`devops_bench/providers/`, deployer implementations, `tf/`) or where they name a real provider artifact.
 
 ## Development Workflow
 All commands should be run from the project root.


### PR DESCRIPTION
Vendor-specific terminology in user-facing text and provider-specific env reads in the generic framework layers keep coming up in review (#41). Encode the rule so CodeRabbit flags it automatically:

- `AGENTS.md` — a vendor-neutrality guideline (also feeds CodeRabbit's code-guidelines knowledge base).
- `.coderabbit.yaml` — a path instruction that flags vendor-specific terms in user-facing surfaces and provider-specific env vars read outside `devops_bench/providers/`, deployer implementations, and `tf/`.

/kind documentation

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidelines promoting vendor-neutral language in user-facing text and shared framework components.
  * Documented appropriate handling of provider-specific terminology and environment variables.
* **Chores**
  * Updated review configuration to flag provider-specific wording and environment handling in relevant areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->