### PR TITLE
feat(deployers): allow overriding the TF stack root via BENCH_TF_ROOT

### DIFF
--- a/devops_bench/deployers/tofu.py
+++ b/devops_bench/deployers/tofu.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""OpenTofu-backed deployer driving repo-local ``tf/`` stacks."""
+"""OpenTofu-backed deployer driving ``tf/`` stacks.
+
+Relative stack names resolve under the stack root: ``$BENCH_TF_ROOT`` when set,
+else the checkout's ``<repo_root>/tf``. The override is what lets a
+pip-installed devops-bench (no repo checkout, ``tf/`` is not packaged) drive
+stacks maintained in a downstream repository.
+"""
 
 from __future__ import annotations
 
@@ -23,7 +29,7 @@ import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from devops_bench.core import ClusterInfo, ConfigError, get_logger
+from devops_bench.core import ClusterInfo, ConfigError, get_env, get_logger
 from devops_bench.core.subprocess import run
 from devops_bench.deployers.base import Deployer
 
@@ -34,10 +40,27 @@ __all__ = ["TFDeployer"]
 
 # This module lives at ``<repo_root>/devops_bench/deployers/tofu.py``; the repo
 # root is therefore three levels up, and Tofu stacks live under ``<repo_root>/tf``.
+# Default only — ``_resolve_tf_root`` consults ``BENCH_TF_ROOT`` first.
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _TF_ROOT = _REPO_ROOT / "tf"
 
 _log = get_logger("deployers.tofu")
+
+
+def _resolve_tf_root() -> Path:
+    """Return the stack root: ``$BENCH_TF_ROOT`` override, else ``<repo_root>/tf``.
+
+    Read per call (not at import) so setting the variable after import works.
+    Under a pip install the default points inside ``site-packages`` where no
+    ``tf/`` tree exists, so installed-library users set ``BENCH_TF_ROOT`` to the
+    directory holding their stacks. Two constraints on an override root: it is
+    copied *whole* per isolated run (stacks reference modules via relative
+    ``../../`` paths, so keep it lean), and it should not be an ancestor of the
+    run scratch dir (``BENCH_RUN_STATE_ROOT``) — :func:`_isolated_work_dir`
+    refuses to copy in that case and degrades to the shared stack dir.
+    """
+    override = get_env("BENCH_TF_ROOT")
+    return Path(override).expanduser().resolve() if override else _TF_ROOT
 
 
 def _format_var(value: Any) -> str:
@@ -97,12 +120,13 @@ def _isolated_work_dir(stack_dir: str, tf_root: Path) -> str:
     both still ran ``tofu`` in the *shared* ``tf/prebuilt/<stack>`` directory, so
     two concurrent runs of the SAME stack contend on its ``.terraform.lock.hcl``
     (no lock file is committed, so every ``init`` rewrites it). To give each run a
-    private working directory, copy the WHOLE ``tf/`` tree — stacks reference
+    private working directory, copy the WHOLE ``tf_root`` tree — stacks reference
     modules via relative ``../../`` paths, so a leaf-only copy would break — into
     the run's scratch dir (the parent of ``TF_DATA_DIR``, beside the per-run
     state file) and run tofu in the copied stack.
 
-    Only applies to in-repo stacks under an isolated (parallel) run; external or
+    Only applies to stacks under ``tf_root`` (the checkout's ``tf/`` or a
+    ``BENCH_TF_ROOT`` override) during an isolated (parallel) run; external or
     absolute stacks and single (non-isolated) runs keep the original directory.
     Any copy failure falls back to the original directory so provisioning still
     proceeds (degrading to the shared-dir behavior, never failing).
@@ -114,9 +138,21 @@ def _isolated_work_dir(stack_dir: str, tf_root: Path) -> str:
         rel = Path(stack_dir).resolve().relative_to(tf_root.resolve())
     except ValueError:
         return stack_dir  # external/absolute stack: cannot relocate safely
+    run_dir = Path(tf_data_dir).resolve().parent
+    dest_tf = run_dir / "tf"
+    if dest_tf.is_relative_to(tf_root.resolve()):
+        # Copying a tree into its own descendant recurses (each level's scandir
+        # sees the partial copy created one level up) until the OS path-length
+        # limit aborts it. Refuse and keep the shared dir instead.
+        _log.warning(
+            "cannot isolate tofu stack dir: stack root %s contains the run scratch dir %s; "
+            "using shared %s",
+            tf_root,
+            run_dir,
+            stack_dir,
+        )
+        return stack_dir
     try:
-        run_dir = Path(tf_data_dir).resolve().parent
-        dest_tf = run_dir / "tf"
         shutil.copytree(tf_root, dest_tf, dirs_exist_ok=True)
         return str(dest_tf / rel)
     except OSError as exc:
@@ -136,13 +172,15 @@ class TFDeployer(Deployer):
     its :class:`~devops_bench.providers.Provider`. Honors the ``TF_DATA_DIR``
     environment variable so OpenTofu state can be redirected for idempotent runs.
 
-    Path resolution: a relative ``tf_dir`` is resolved under ``<repo_root>/tf``;
-    an absolute path (``~`` is expanded) is used as-is, so stacks may live outside
-    the repository.
+    Path resolution: a relative ``tf_dir`` is resolved under the stack root
+    (``$BENCH_TF_ROOT`` when set, else the checkout's ``<repo_root>/tf`` — see
+    :func:`_resolve_tf_root`); an absolute path (``~`` is expanded) is used
+    as-is. Relative stacks keep per-run isolation under an override root;
+    absolute stacks do not, so concurrent runs should not share one.
 
     Args:
         tf_dir: Stack directory; an absolute/``~`` path used as-is, or a name
-            resolved under ``<repo_root>/tf``.
+            resolved under the stack root.
         provider: Cloud provider supplying credentials and cluster details.
         variables: OpenTofu input variables passed as ``-var`` flags.
         custom_keys: Subset of ``variables`` that came from task-level config;
@@ -161,19 +199,24 @@ class TFDeployer(Deployer):
         custom_keys: set[str] | None = None,
     ) -> None:
         tf_path = Path(tf_dir).expanduser()
+        tf_root = _resolve_tf_root()
         if tf_path.is_absolute():
             if not tf_path.exists():
                 raise ConfigError(f"Absolute TF directory not found: {tf_dir}")
             self.tf_dir = str(tf_path)
         else:
-            repo_tf_path = _TF_ROOT / tf_path
-            if not repo_tf_path.exists():
-                raise ConfigError(f"TF stack not found in repo: {tf_dir} (checked {repo_tf_path})")
-            self.tf_dir = str(repo_tf_path)
+            rooted_tf_path = tf_root / tf_path
+            if not rooted_tf_path.exists():
+                raise ConfigError(
+                    f"TF stack not found under {tf_root}: {tf_dir} "
+                    "(set BENCH_TF_ROOT to override the stack root)"
+                )
+            self.tf_dir = str(rooted_tf_path)
 
-        # Per-run private working directory (a copy of the tf/ tree under the
-        # run's scratch dir) when isolated; otherwise the shared stack dir.
-        self.work_dir = _isolated_work_dir(self.tf_dir, _TF_ROOT)
+        # Per-run private working directory (a copy of the stack-root tree
+        # under the run's scratch dir) when isolated; otherwise the shared
+        # stack dir.
+        self.work_dir = _isolated_work_dir(self.tf_dir, tf_root)
 
         self.provider = provider
         self.variables = variables or {}

--- a/tests/unit/deployers/conftest.py
+++ b/tests/unit/deployers/conftest.py
@@ -1,0 +1,29 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared fixtures for the deployer test suite."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_bench_tf_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop ``BENCH_TF_ROOT`` so a developer's shell cannot skew resolution.
+
+    The deployer resolves relative stacks against ``$BENCH_TF_ROOT`` when set;
+    tests that exercise the override set it explicitly via ``monkeypatch``.
+    """
+    monkeypatch.delenv("BENCH_TF_ROOT", raising=False)

--- a/tests/unit/deployers/test_deployers_tofu.py
+++ b/tests/unit/deployers/test_deployers_tofu.py
@@ -253,8 +253,94 @@ def test_init_expands_user_path(tmp_path, monkeypatch, provider):
 
 
 def test_init_missing_dir_raises(provider):
-    with pytest.raises(ConfigError, match="TF stack not found in repo"):
+    with pytest.raises(ConfigError, match="TF stack not found under"):
         TFDeployer(tf_dir="non-existent-stack-xyz", provider=provider)
+
+
+def test_init_resolves_relative_stack_under_bench_tf_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, provider: StubProvider
+) -> None:
+    """A relative stack name resolves under ``$BENCH_TF_ROOT`` when set."""
+    root = tmp_path / "stacks"
+    (root / "my-stack").mkdir(parents=True)
+    monkeypatch.setenv("BENCH_TF_ROOT", str(root))
+    monkeypatch.delenv("TF_DATA_DIR", raising=False)
+
+    deployer = TFDeployer(tf_dir="my-stack", provider=provider)
+
+    assert Path(deployer.tf_dir) == root.resolve() / "my-stack"
+    # No isolation without TF_DATA_DIR: tofu runs in the shared stack dir.
+    assert deployer.work_dir == deployer.tf_dir
+
+
+def test_init_isolates_stack_under_bench_tf_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, provider: StubProvider
+) -> None:
+    """Per-run isolation still applies to stacks under an overridden root.
+
+    The roots are deliberately disjoint (``stacks/`` vs ``run/``): pointing
+    ``BENCH_TF_ROOT`` at an ancestor of the run scratch dir would make the
+    whole-tree copy fold run artifacts back into the stack tree.
+    """
+    root = tmp_path / "stacks"
+    (root / "my-stack").mkdir(parents=True)
+    run_dir = tmp_path / "run"
+    monkeypatch.setenv("BENCH_TF_ROOT", str(root))
+    monkeypatch.setenv("TF_DATA_DIR", str(run_dir / "tf-data"))
+
+    deployer = TFDeployer(tf_dir="my-stack", provider=provider)
+
+    assert Path(deployer.work_dir) == run_dir.resolve() / "tf" / "my-stack"
+    assert Path(deployer.work_dir).is_dir()
+    # The shared stack dir is untouched; tofu runs in the private copy.
+    assert Path(deployer.tf_dir) == root.resolve() / "my-stack"
+
+
+def test_isolation_refused_when_root_contains_scratch_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, provider: StubProvider, caplog: Any
+) -> None:
+    """A stack root that contains the run scratch dir must not be copied.
+
+    Copying a tree into its own descendant recurses until the OS path-length
+    limit; the deployer must refuse and degrade to the shared stack dir.
+    """
+    root = tmp_path  # scratch dir lives INSIDE the stack root
+    (root / "my-stack").mkdir()
+    monkeypatch.setenv("BENCH_TF_ROOT", str(root))
+    monkeypatch.setenv("TF_DATA_DIR", str(root / "runs" / "r1" / "tf-data"))
+
+    deployer = TFDeployer(tf_dir="my-stack", provider=provider)
+
+    assert deployer.work_dir == deployer.tf_dir  # shared dir, no copy
+    assert not (root / "runs" / "r1" / "tf").exists()
+    assert "contains the run scratch dir" in caplog.text
+
+
+def test_init_missing_stack_under_bench_tf_root_names_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, provider: StubProvider
+) -> None:
+    """The error for a missing stack names the checked root and the override."""
+    root = tmp_path / "stacks"
+    root.mkdir()
+    monkeypatch.setenv("BENCH_TF_ROOT", str(root))
+
+    with pytest.raises(ConfigError, match="TF stack not found under") as excinfo:
+        TFDeployer(tf_dir="absent-stack", provider=provider)
+
+    assert str(root.resolve()) in str(excinfo.value)
+    assert "BENCH_TF_ROOT" in str(excinfo.value)
+
+
+def test_init_blank_bench_tf_root_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch, provider: StubProvider
+) -> None:
+    """A blank override is treated as unset (``get_env`` semantics)."""
+    monkeypatch.setenv("BENCH_TF_ROOT", "   ")
+
+    with pytest.raises(ConfigError, match="TF stack not found under") as excinfo:
+        TFDeployer(tf_dir="non-existent-stack-xyz", provider=provider)
+
+    assert str(_TF_ROOT) in str(excinfo.value)
 
 
 def test_get_declared_variables_robustness(tmp_path):


### PR DESCRIPTION
## What

Make the OpenTofu deployer's stack root overridable via `BENCH_TF_ROOT` (vendor-neutral `BENCH_*` convention, read through the core `get_env` helper so blank means unset). A relative `stack:` in `task.yaml` now resolves against `$BENCH_TF_ROOT` when set, else the checkout's `<repo_root>/tf` exactly as before. The resolved root is threaded into `_isolated_work_dir`, so stacks under an overridden root keep per-run isolation for parallel runs.

## Why

`tofu.py` resolved relative stack names against `Path(__file__).resolve().parents[2] / "tf"`. Under a pip install that lands in `site-packages`, and `tf/` is not packaged — so every relative stack fails for library consumers (first: kube-agents, which authors stacks in its own repo). The existing escape hatch, absolute `stack:` paths, skips per-run isolation, so concurrent runs sharing one stack dir contend on `.terraform.lock.hcl`. `BENCH_TF_ROOT` fixes both: discovery and isolation. This was the last `Path(__file__)`-relative repo-root assumption in the package (judge skills already use `importlib.resources`).

The env read is lazy (per call, not at import), following the `TF_DATA_DIR` precedent in the same module.

## Why not ship tf/ as package data instead?

Complementary, not competing: package data would only fix the *bundled* stacks (`prebuilt/kind` default), while this override is what lets downstream repos point at **their own** stack trees with isolation intact. The bundled default remains unavailable under pip either way until a package-data follow-up; happy to discuss that separately.

## Safety guard

Pointing `BENCH_TF_ROOT` at an ancestor of the run scratch dir would make the per-run whole-tree copy recurse into its own output until the OS path-length limit (reproduced empirically: ~260-deep nesting before `File name too long`). `_isolated_work_dir` now detects that case, refuses the copy with a warning, and degrades to the shared stack dir — provisioning never fails on it.

## Tests

New cases in `tests/unit/deployers/test_deployers_tofu.py`: override resolution, override + `TF_DATA_DIR` isolation (disjoint roots), missing-stack error naming the checked root and the override, blank-override fallback, and the ancestor-guard refusal. A new `tests/unit/deployers/conftest.py` autouse fixture drops ambient `BENCH_TF_ROOT` so a developer's shell cannot skew the suite. The `_TF_ROOT` constant is kept as the default, so existing imports in both deployer test files are untouched.

`uv run pytest tests/unit` (882 passed), `ruff check` / `ruff format --check`, `pre-commit run --all-files`, and `uv lock --check` all clean. Verified from a wheel install in a clean venv: default root points into `site-packages` (the bug), `BENCH_TF_ROOT=/tmp/stacks` resolves a relative stack with no repo checkout.
