### PR TITLE
Add infrastructure and model provider documentation

### DIFF
--- a/docs/components/infra.md
+++ b/docs/components/infra.md
@@ -1,0 +1,122 @@
+# Infrastructure: deployers and cloud providers
+
+Every eval in devops-bench can stand up **real infrastructure** before the agent runs — a live GKE cluster, a local KinD cluster, or nothing at all. Provisioning is driven entirely by **OpenTofu**: a task points at a stack, and the harness runs `tofu` to bring it up and tear it down. A *cloud provider* sits alongside OpenTofu to supply credentials and fill in Terraform variable defaults (project, location, cluster name) so a stack doesn't have to hard-code them.
+
+> [!NOTE]
+> *Cloud providers* (GCP, KinD) are not the same thing as *model providers* (the LLM backends an agent talks to). This page is only about infrastructure. For model backends, see [model_providers.md](./model_providers.md).
+
+This is a quick overview of the deployer and cloud-provider layer and how to configure infra for an eval.
+
+## Deployers
+
+A deployer is the thing that provisions (or skips) infrastructure for a run. There are two.
+
+| Deployer | Key | What it does | Source |
+| --- | --- | --- | --- |
+| `TFDeployer` | `tofu` | Runs `tofu init` / `apply` / `destroy` / `output -json` against a stack. Stacks live under `tf/`; a relative stack name resolves there, and an absolute path is used as-is. Reads two TF outputs as a hard contract: `cluster_name` and `cluster_location`. | `devops_bench/deployers/tofu.py` |
+| `NoOpDeployer` | `noop` | Skips provisioning entirely. For manifest-generation tasks and runs against infrastructure that already exists. | `devops_bench/deployers/noop.py` |
+
+**Selection** happens in `get_deployer()` (`devops_bench/deployers/factory.py`):
+
+- `deployer: noop` in the task, the env var `BENCH_NO_INFRA=true`, or the `--no-infra` flag all force the `NoOpDeployer`. The env/flag override wins over whatever the task declares — handy for local smoke tests or running against an existing cluster.
+- Otherwise `tofu` is used.
+- Anything other than `tofu` or `noop` is a configuration error.
+
+## Cloud providers
+
+A cloud provider supplies credentials and Terraform variable defaults for a stack. Two ship today, both under `devops_bench/providers/`:
+
+| Provider | Name | Target |
+| --- | --- | --- |
+| `GcpProvider` | `gcp` | GKE clusters on Google Cloud |
+| `KindProvider` | `kind` | Local KinD clusters (no cloud identity) |
+
+Each implements the `Provider` interface (`devops_bench/providers/base.py`):
+
+- `ensure_account_credentials()` — make account-wide cloud identity active before provisioning or before a task calls cloud APIs. Local providers make this a no-op.
+- `ensure_cluster_credentials()` — make a provisioned cluster reachable (e.g. `gcloud container clusters get-credentials`) and return its `ClusterInfo`.
+- `resolve_variables()` — fill in default OpenTofu variables (project, location, cluster name, namespace…) without overwriting anything the task set explicitly.
+
+Both are listed in the `PROVIDERS` registry.
+
+**How the provider is picked** (precedence, highest first):
+
+1. The `INFRA_PROVIDER` environment variable.
+2. An explicit `provider:` key in the task's `infrastructure:` block.
+3. Deduced from the stack name: if `kind` appears in the name it's the `kind` provider, otherwise `gcp`.
+
+The env var outranks the config key so a task can pin a default `provider:` while runs stay overridable from the environment (the same way `TARGET_DEPLOYMENT_NAME` and `NAMESPACE` resolve).
+
+> [!IMPORTANT]
+> Deduction only applies to in-repo (relative) stacks. An absolute or external stack path **must** name its provider explicitly (via `provider:` or `INFRA_PROVIDER`) — the harness will not guess. An unknown provider name is a configuration error.
+
+## What the Terraform provisions
+
+The OpenTofu stacks live under `tf/`:
+
+- `tf/modules/` — reusable building blocks: `cluster/gke`, `cluster/kind`, and `bastion`.
+- `tf/prebuilt/<stack>/` — standard, ready-to-use stacks, currently `kind` (a local
+  cluster for offline / no-cloud runs). Task-specific stacks build on the modules and
+  ship alongside the tasks that provision them.
+
+Every stack root that `TFDeployer` drives must output `cluster_name` and `cluster_location` — that's the contract the deployer reads back.
+
+**Prerequisites:**
+
+- Always: the `tofu` binary on `PATH`.
+- For GCP stacks: `gcloud`, application-default credentials (ADC), and a project with the GKE and Artifact Registry APIs enabled.
+- For KinD stacks: Docker and the `kind` binary.
+
+## Configuring infra for an eval
+
+Infrastructure is declared in the `infrastructure:` block of a task's `task.yaml`:
+
+| Key | Meaning |
+| --- | --- |
+| `deployer` | `tofu` or `noop`. |
+| `stack` | Stack name under `tf/` (e.g. `prebuilt/kind`) or an absolute path. |
+| `provider` | Optional. `gcp` or `kind`. Omit to let it be deduced (in-repo stacks only). |
+| `teardown` | Whether to destroy infra after the run. Defaults to `true`. |
+| `variables` | A map passed straight to `tofu` as `-var key=value` flags. |
+
+A local KinD example:
+
+```yaml
+infrastructure:
+  deployer: "tofu"
+  stack: "prebuilt/kind"
+  teardown: true
+  variables:
+    cluster_name: "devops-bench-kind"
+```
+
+A no-infra example (manifest-generation task, or a run against an existing cluster):
+
+```yaml
+infrastructure:
+  deployer: "noop"
+```
+
+The provider fills in sensible defaults for whatever you leave out. For GCP that means `project_id`, `cluster_name`, and `location` (plus `namespace` when `NAMESPACE` is set); for KinD it means `cluster_name`, `location` (`local`), and `kubeconfig_path`. Anything you put in `variables` always wins over the defaults.
+
+**Environment variables that affect infra:**
+
+| Variable | Effect |
+| --- | --- |
+| `BENCH_NO_INFRA` | `true` forces the `NoOpDeployer`, overriding the task's `deployer`. |
+| `INFRA_PROVIDER` | Selects the provider, overriding any `provider:` key the task names. |
+| `GCP_PROJECT_ID` | Default GCP project for credentials and variable defaults. |
+| `GCP_LOCATION` | Default region/zone (falls back to `us-central1-a`). |
+| `NAMESPACE` | Passed through to GCP stacks as the `namespace` variable. |
+| `KUBECONFIG` | Kubeconfig path used by KinD and by no-infra runs. |
+
+The `--project` and `--cluster` CLI flags supply the project and cluster name for a run, feeding the same defaults the providers resolve from.
+
+## Adding a cloud provider (brief)
+
+Subclass `Provider` in `devops_bench/providers/<cloud>.py`, decorate it with `@PROVIDERS.register("<name>")`, and register it in `devops_bench/providers/__init__.py` (or ship it as an entry-point package under the `devops_bench.providers` group — no code change needed in this repo). Then add a `tf/prebuilt/<stack>/` whose root outputs `cluster_name` and `cluster_location` and declares input variables matching what your `resolve_variables()` fills in. You rarely need a new *deployer* — `TFDeployer` is the universal OpenTofu engine, and a new cloud is almost always just a new `Provider` plus a stack.
+
+## Parallel safety
+
+> [!NOTE]
+> Under parallel runs, each run gets an isolated OpenTofu data directory (a private copy of the `tf/` tree, with per-run state) and a run-unique cluster name, so concurrent stacks don't collide on lock files or state. If you author a task stack, make any **global** resource names (Artifact Registry repos, GCS buckets, IAM bindings, and the like) run-scoped, and clean them up on `destroy`.

--- a/docs/components/infra.md
+++ b/docs/components/infra.md
@@ -1,6 +1,6 @@
 # Infrastructure: deployers and cloud providers
 
-Every eval in devops-bench can stand up **real infrastructure** before the agent runs — a live GKE cluster, a local KinD cluster, or nothing at all. Provisioning is driven entirely by **OpenTofu**: a task points at a stack, and the harness runs `tofu` to bring it up and tear it down. A *cloud provider* sits alongside OpenTofu to supply credentials and fill in Terraform variable defaults (project, location, cluster name) so a stack doesn't have to hard-code them.
+Every eval in devops-bench can stand up **real infrastructure** before the agent runs — a managed Kubernetes cluster, a local KinD cluster, or nothing at all. Provisioning is driven entirely by **OpenTofu**: a task points at a stack, and the harness runs `tofu` to bring it up and tear it down. A *cloud provider* sits alongside OpenTofu to supply credentials and fill in Terraform variable defaults (project, location, cluster name) so a stack doesn't have to hard-code them.
 
 > [!NOTE]
 > *Cloud providers* (GCP, KinD) are not the same thing as *model providers* (the LLM backends an agent talks to). This page is only about infrastructure. For model backends, see [model_providers.md](./model_providers.md).
@@ -86,9 +86,11 @@ infrastructure:
   deployer: "tofu"
   stack: "prebuilt/kind"
   teardown: true
-  variables:
-    cluster_name: "devops-bench-kind"
 ```
+
+Leave `cluster_name` out of `variables`. Task variables are preserved over provider
+defaults, so pinning it here would override the run-scoped name and make concurrent runs
+collide on one cluster.
 
 A no-infra example (manifest-generation task, or a run against an existing cluster):
 

--- a/docs/components/infra.md
+++ b/docs/components/infra.md
@@ -43,12 +43,12 @@ Both are listed in the `PROVIDERS` registry.
 
 1. The `INFRA_PROVIDER` environment variable.
 2. An explicit `provider:` key in the task's `infrastructure:` block.
-3. Deduced from the stack name: if `kind` appears in the name it's the `kind` provider, otherwise `gcp`.
+3. Deduced from the stack name, in exactly one case: an in-repo (relative) stack whose final path segment is `kind` resolves to the `kind` provider.
 
 The env var outranks the config key so a task can pin a default `provider:` while runs stay overridable from the environment (the same way `TARGET_DEPLOYMENT_NAME` and `NAMESPACE` resolve).
 
 > [!IMPORTANT]
-> Deduction only applies to in-repo (relative) stacks. An absolute or external stack path **must** name its provider explicitly (via `provider:` or `INFRA_PROVIDER`) — the harness will not guess. An unknown provider name is a configuration error.
+> There is no default cloud. Any stack that does not deduce to `kind` — including every absolute or external path — **must** name its provider explicitly via `provider:` or `INFRA_PROVIDER`, or `_select_provider` raises a `ConfigError`. Nothing falls back to `gcp`, so a new provider never silently inherits another's defaults. An unknown provider name is likewise a configuration error.
 
 ## What the Terraform provisions
 

--- a/docs/components/model_providers.md
+++ b/docs/components/model_providers.md
@@ -1,0 +1,157 @@
+# Model providers
+
+devops-bench can drive an agent, a judge, and a chaos agent with different LLMs,
+and it does so through one small interface. Every provider implements the same
+`LLMClient` contract (`devops_bench/models/base.py`), and a single factory,
+`get_model()`, constructs the right adapter at runtime. Add a provider by
+dropping a file in `devops_bench/models/`; nothing else in the tree needs to
+change.
+
+> [!IMPORTANT]
+> This page is about the **LLM** that powers the agent under test and the judge
+> — not the **cloud** your benchmark infrastructure runs on. Those are separate
+> concerns. A run can use Claude on Anthropic's API while provisioning Google
+> Cloud resources, for example. For the cloud/infra side, see
+> [infra.md](./infra.md).
+
+## Supported providers and models
+
+Every harness — the `api` runner and the `gemini`/`openclaw` CLIs — resolves
+`AGENT_PROVIDER` through one shared contract
+(`devops_bench/core/model_providers.py`). A provider resolves to an *adapter
+family* (which `LLMClient` the `api` harness builds), a *backend* hint
+(genai/vertex/bedrock), the *openclaw wire-provider*, and the *API-key env
+var(s)* a CLI harness sets — so the same `AGENT_*` config behaves identically
+across harnesses.
+
+| Provider key | Aliases | Adapter family | Backend | Key env var(s) | Keyless |
+| --- | --- | --- | --- | --- | --- |
+| `google` | `gemini` | `gemini` | genai (API key) | `GEMINI_API_KEY`, `GOOGLE_API_KEY` | no |
+| `google-vertex` | `google_vertex` | `gemini` | Vertex AI | `GOOGLE_CLOUD_API_KEY` | yes (ADC) |
+| `anthropic` | `claude` | `claude` | inferred (api/vertex/bedrock) | `ANTHROPIC_API_KEY` | no |
+| `anthropic-vertex` | `anthropic_vertex` | `claude` | Vertex AI | — | yes (ADC) |
+| `anthropic-bedrock` | `anthropic_bedrock` | `claude` | Amazon Bedrock | — | yes (AWS creds) |
+| `openai` | — | `openai` | — | `OPENAI_API_KEY` | no |
+| `ollama` | — | `ollama` | local OpenAI-compatible server | optional `AGENT_API_KEY` | yes |
+
+Default models: `gemini` → `gemini-3.1-pro-preview`; `claude` → backend-specific
+(`api` → `claude-sonnet-4-5`; Bedrock requires `AGENT_MODEL`); `ollama` →
+`gemma4:2b`.
+
+A few things worth calling out:
+
+- **Vertex and Bedrock are keyless.** `google-vertex`, `anthropic-vertex`, and
+  `anthropic-bedrock` authenticate via ADC / AWS credentials; the contract never
+  forces an API key onto them (their key-env list is empty). The bare
+  `anthropic` provider still infers its backend from the environment.
+- **Ollama accepts an optional key.** It defaults to a dummy the local server
+  ignores, but uses `AGENT_API_KEY` when set (for remote/hosted endpoints).
+- **Install extras are named by PyPI package, not by provider key.** The extras
+  are `anthropic` and `openai` — a different axis from the provider keys above.
+  The most surprising consequence: the `openai` extra is what backs the
+  `ollama` provider, because the Ollama adapter talks to its server through the
+  `openai` client. `google-genai` needs no extra; it is a base dependency, so
+  `gemini` works out of the box. Install the SDK you need:
+
+  ```bash
+  pip install "devops-bench[anthropic]"   # claude
+  pip install "devops-bench[openai]"      # ollama
+  ```
+
+## How a model is selected
+
+There are three roles, and each reads its own environment variables.
+
+| Role | Provider var | Model var | Notes |
+| --- | --- | --- | --- |
+| Agent under test | `AGENT_PROVIDER` | `AGENT_MODEL` | Also `AGENT_API_KEY`, `AGENT_MAX_TOKENS`. |
+| Judge | `JUDGE_PROVIDER` | `JUDGE_MODEL` | Also settable via the `--judge-provider` / `--judge-model` CLI flags. |
+| Chaos agent | `CHAOS_PROVIDER` | `CHAOS_MODEL` | Falls back to `AGENT_PROVIDER` / `AGENT_MODEL` when unset. |
+
+When no provider is given anywhere, the contract defaults to `google`.
+
+### Backend selection
+
+The cleanest way to pick a backend is the **provider key** itself —
+`google-vertex`, `anthropic-vertex`, and `anthropic-bedrock` select Vertex AI /
+Bedrock deterministically, independent of which keys happen to be in the
+environment. These also flow consistently into the CLI harnesses.
+
+These variables still influence backend/transport details:
+
+| Variable | Effect |
+| --- | --- |
+| `GCP_PROJECT_ID` + `GCP_VERTEX_LOCATION` | Vertex project/region (`GCP_VERTEX_LOCATION` defaults to `global`). |
+| `ANTHROPIC_BACKEND` | Forces the Claude backend (`api`/`vertex`/`bedrock`) for the bare `anthropic` provider. |
+| `AWS_REGION` / `AWS_DEFAULT_REGION` | Region for the Claude Bedrock backend. |
+| `OLLAMA_BASE_URL` | Endpoint for the Ollama server (defaults to `http://localhost:11434/v1`). |
+
+For the bare `anthropic` provider (no explicit `-vertex`/`-bedrock` key and no
+`ANTHROPIC_BACKEND`), the adapter still infers a backend: an API key
+(`AGENT_API_KEY` / `ANTHROPIC_API_KEY`) selects `api`, then `GCP_PROJECT_ID`
+selects `vertex`, then an AWS region selects `bedrock`, with `vertex` as the
+final fallback.
+
+> [!NOTE]
+> **All harnesses share one provider contract.** The `api` runner and the
+> `gemini`/`openclaw` CLIs all resolve `AGENT_PROVIDER` through
+> `devops_bench/core/model_providers.py`. The `api` harness uses it to pick the
+> adapter family and backend for `get_model()`; the CLI harnesses use it to route
+> `AGENT_API_KEY` onto the binary's provider-specific env var(s) (e.g. `google` →
+> `GEMINI_API_KEY` + `GOOGLE_API_KEY`, `google-vertex` → `GOOGLE_CLOUD_API_KEY`)
+> and, for openclaw, to pin the per-run model-catalog transport. A keyless
+> provider routes no key.
+
+## Configuration examples
+
+These are copy-pasteable. Set the variables in your shell (or in whatever you use
+to launch a run) before invoking the benchmark.
+
+**Gemini via AI Studio (API key):**
+
+```bash
+export AGENT_PROVIDER=gemini
+export AGENT_MODEL=gemini-3.1-pro-preview
+export AGENT_API_KEY="$YOUR_AI_STUDIO_KEY"
+```
+
+**Gemini on Vertex AI (no key — uses ADC + project):**
+
+```bash
+export AGENT_PROVIDER=gemini
+export AGENT_MODEL=gemini-3.1-pro-preview
+export GCP_PROJECT_ID=my-gcp-project
+export GCP_VERTEX_LOCATION=global
+# No AGENT_API_KEY: the adapter uses Application Default Credentials.
+```
+
+**Claude via the first-party Anthropic API:**
+
+```bash
+export AGENT_PROVIDER=claude
+export AGENT_MODEL=claude-sonnet-4-5
+export AGENT_API_KEY="$YOUR_ANTHROPIC_KEY"
+```
+
+**Claude on Vertex AI (no key — uses ADC + project):**
+
+```bash
+export AGENT_PROVIDER=anthropic-vertex
+export AGENT_MODEL=claude-sonnet-4-5@20250929
+export GCP_PROJECT_ID=my-gcp-project
+export GCP_VERTEX_LOCATION=global
+# The provider key selects Vertex; no AGENT_API_KEY is needed or used.
+```
+
+**Ollama (local server):**
+
+```bash
+export AGENT_PROVIDER=ollama
+export AGENT_MODEL=gemma4:2b
+export OLLAMA_BASE_URL=http://localhost:11434/v1
+```
+
+## Adding a provider
+
+To add your own provider — including the adapter file-naming convention and how
+aliases resolve — see [Add a model provider](../how-to/add-a-model-provider.md).

--- a/docs/components/model_providers.md
+++ b/docs/components/model_providers.md
@@ -5,7 +5,9 @@ and it does so through one small interface. Every provider implements the same
 `LLMClient` contract (`devops_bench/models/base.py`), and a single factory,
 `get_model()`, constructs the right adapter at runtime. Add a provider by
 dropping a file in `devops_bench/models/`; nothing else in the tree needs to
-change.
+change, unless it also needs an alias, a distinct backend, a non-default
+API-key variable, or keyless auth — those belong to the provider contract in
+`devops_bench/core/model_providers.py`.
 
 > [!IMPORTANT]
 > This page is about the **LLM** that powers the agent under test and the judge

--- a/docs/how-to/add-a-model-provider.md
+++ b/docs/how-to/add-a-model-provider.md
@@ -13,10 +13,13 @@ For background on the layer this plugs into, see
 
 ### 1. Create the adapter module
 
-Create `devops_bench/models/<key>.py`, where `<key>` is the canonical provider
-key — by convention the model-family name. Guard the SDK import so the module
-imports cleanly even when the SDK isn't installed, then register your adapter
-class under the key:
+Create `devops_bench/models/<family>.py`, where `<family>` is the **adapter
+family** the provider contract maps onto — the model-family name, which is not
+always the canonical provider key. Several canonical providers can share one
+family: `anthropic`, `anthropic-vertex`, and `anthropic-bedrock` all resolve to
+the `claude` family, and `google` and `google-vertex` both resolve to `gemini`.
+Guard the SDK import so the module imports cleanly even when the SDK isn't
+installed, then register your adapter class under that same family key:
 
 ```python
 try:
@@ -155,5 +158,12 @@ export AGENT_MODEL=<your-model-id>
 Run a no-infra task with your provider set and confirm the agent (and judge)
 construct without error. If `get_model()` builds your adapter and the run starts
 talking to the model, the registration and SDK wiring are correct. A missing SDK
-surfaces as `MissingDependencyError` naming the pip package; an unknown key
-surfaces as a `NotRegisteredError`.
+surfaces as `MissingDependencyError` naming the pip package.
+
+The two lookup stages fail differently, which tells you where to look:
+
+- A provider name that is not in the contract raises `ConfigError` from
+  `resolve_provider` — the alias is unknown.
+- A provider that resolves fine but whose adapter family has no module in
+  `devops_bench/models/` raises `NotRegisteredError` from `get_model` — the
+  contract entry exists, the adapter does not.

--- a/docs/how-to/add-a-model-provider.md
+++ b/docs/how-to/add-a-model-provider.md
@@ -1,0 +1,159 @@
+# Add a model provider
+
+Adding a new LLM provider to devops-bench is intentionally small. The contract is:
+**implement `LLMClient` and self-register.** The factory `get_model()` lazily
+imports `devops_bench/models/<key>.py` by name and lets the module register
+itself, so there is no central registry to edit and no `cli.py` / `run.py` change
+to make.
+
+For background on the layer this plugs into, see
+[Model providers](../components/model_providers.md).
+
+## Steps
+
+### 1. Create the adapter module
+
+Create `devops_bench/models/<key>.py`, where `<key>` is the canonical provider
+key — by convention the model-family name. Guard the SDK import so the module
+imports cleanly even when the SDK isn't installed, then register your adapter
+class under the key:
+
+```python
+try:
+    import yourprovider_sdk
+except ImportError:  # pragma: no cover - exercised only without the SDK
+    yourprovider_sdk = None
+
+@MODELS.register("<key>")
+class YourProviderClientAdapter(LLMClient):
+    def __init__(self, model_name: str | None = None, **kwargs):
+        ...
+```
+
+### 2. Implement the four `LLMClient` methods
+
+The interface lives in `devops_bench/models/base.py`. An adapter's job is to
+translate between the agent runner's **neutral** message and tool shapes and your
+provider's SDK. Neutral messages are dicts with `role` and `content` keys, plus
+`tool_calls` on assistant turns and `tool_call_id` on tool-result turns.
+
+| Method | Responsibility |
+| --- | --- |
+| `async generate_content(contents, tools, system_instruction)` | Convert neutral `contents` to your SDK's message shape, call the model, and return the raw provider response. |
+| `format_tools(mcp_tools)` | Convert MCP tool objects (with `name`, `description`, `inputSchema`) into your provider's tool spec. |
+| `extract_function_calls(response) -> list[dict]` | Pull tool calls out of a response as dicts with `name`, `args`, and (where available) `id`. |
+| `get_text_content(response) -> str` | Return the response's text, or `""` when there is none. |
+
+Read any overrides through the helpers in `devops_bench.core.config` — use
+`get_env` for string variables (for example, `get_env("AGENT_MODEL", "<default>")`).
+If the SDK is missing, raise `MissingDependencyError` with a description and the
+pip package name:
+
+```python
+if yourprovider_sdk is None:
+    raise MissingDependencyError("the YourProvider model adapter", "yourprovider-sdk")
+```
+
+### 3. Add the install extra
+
+In `pyproject.toml`, add an optional-dependency extra **named after the PyPI
+package** (not the provider key), so callers can install just the SDK they need:
+
+```toml
+[project.optional-dependencies]
+yourprovider-sdk = ["yourprovider-sdk>=1.0.0"]
+```
+
+Keep the import lazy (step 1) so the package still imports when the extra is
+absent.
+
+### 4. (Optional) register it in the provider contract
+
+`AGENT_PROVIDER` resolves through the shared contract in
+`devops_bench/core/model_providers.py` — the one place every harness (the `api`
+runner and the `gemini`/`openclaw` CLIs) reads. If your provider needs aliases, a
+distinct backend, a non-default API-key env var, or keyless (ADC-style) auth, add
+a `ProviderSpec` row to `_SPECS` and its alias(es) to `_ALIASES` there:
+
+```python
+_SPECS["your-key"] = ProviderSpec(
+    canonical="your-key",
+    adapter_family="<key>",          # the MODELS.get() key from step 1
+    oc_provider="your-key",          # openclaw wire-provider id
+    api_key_envs=("YOURPROVIDER_API_KEY",),  # () if keyless
+    keyless_ok=False,
+    backend=None,                    # or a backend hint your adapter reads
+)
+_ALIASES["your-alt-name"] = "your-key"
+```
+
+A provider whose `adapter_family` maps to your new module's registered key works
+through `get_model()` automatically. An unknown provider raises `ConfigError`
+listing the known ones.
+
+### 5. Nothing else to wire up
+
+You do **not** edit `cli.py` or `run.py`. Because `get_model()` imports the
+module by name on demand, registration happens the first time your provider is
+selected. The same mechanism means an external package can register an adapter
+without editing this tree at all — as long as its module is importable as
+`devops_bench.models.<key>`.
+
+## Skeleton
+
+```python
+"""YourProvider adapter for the LLM client interface."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from devops_bench.core.config import get_env
+from devops_bench.core.errors import MissingDependencyError
+from devops_bench.models.base import MODELS, LLMClient
+
+try:
+    import yourprovider_sdk
+except ImportError:  # pragma: no cover - exercised only without the SDK
+    yourprovider_sdk = None
+
+
+@MODELS.register("<key>")
+class YourProviderClientAdapter(LLMClient):
+    """Adapter for the YourProvider SDK."""
+
+    def __init__(self, model_name: str | None = None, **kwargs: Any) -> None:
+        if yourprovider_sdk is None:
+            raise MissingDependencyError("the YourProvider model adapter", "yourprovider-sdk")
+        self.model_name = model_name or get_env("AGENT_MODEL", "<default-model>")
+        self.client = yourprovider_sdk.Client(**kwargs)
+
+    async def generate_content(self, contents, tools, system_instruction) -> Any:
+        ...
+
+    def format_tools(self, mcp_tools) -> Any:
+        ...
+
+    def extract_function_calls(self, response) -> list[dict]:
+        ...
+
+    def get_text_content(self, response) -> str:
+        ...
+```
+
+## Select it
+
+Point the agent under test at your provider with the env var:
+
+```bash
+export AGENT_PROVIDER=<key>
+export AGENT_MODEL=<your-model-id>
+```
+
+## Test it
+
+Run a no-infra task with your provider set and confirm the agent (and judge)
+construct without error. If `get_model()` builds your adapter and the run starts
+talking to the model, the registration and SDK wiring are correct. A missing SDK
+surfaces as `MissingDependencyError` naming the pip package; an unknown key
+surfaces as a `NotRegisteredError`.


### PR DESCRIPTION
Documents the two layers a task author configures before anything runs: the deployer /
cloud-provider layer that provisions a cluster, and the model provider layer that backs
agents and judges. This is the first content under `docs/`.

- `docs/components/infra.md` — the `tofu` / `noop` deployers, how the cloud provider is
  deduced from an in-repo stack path, the OpenTofu stack layout, the `infrastructure:`
  block in a `task.yaml`, and the parallel-safety rules for stack authors.
- `docs/components/model_providers.md` — the provider keys, their aliases, auth modes
  (API key vs ADC vs AWS credentials), and how a model is resolved.
- `docs/how-to/add-a-model-provider.md` — the steps to wire up a new LLM backend.

## Adjusted to describe this repository

The source these were written against configures a few things differently, so the content
was corrected rather than copied verbatim:

- **Install extras.** `google-genai` is a base dependency here, not an optional extra, so
  only the `anthropic` and `openai` extras exist and `gemini` needs no extra. The install
  snippets and the "add the install extra" step were rewritten to match; the `all` extra
  is not referenced because it is not defined here.
- **Stack examples.** The `infrastructure:` example and the `stack` field now name
  `prebuilt/kind`, the stack that exists in this repository, instead of stacks that have
  not landed.
- **Module layout.** The `tf/modules/` description matches the actual tree
  (`cluster/gke`, `cluster/kind`, `bastion`).

Every relative link and every `devops_bench/**` and `tf/**` path referenced by these three
files resolves in this repository; every environment variable named is read somewhere in
`devops_bench/`, and the documented provider keys match the registered ones.

/kind documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on infrastructure provisioning, provider selection, configuration, prerequisites, and parallel execution.
  * Documented model provider configuration, authentication options, defaults, and role-specific settings.
  * Added a step-by-step guide for developing, registering, configuring, and testing new model providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->