### PR TITLE
Add the bastion matrix runner scripts and the tf README

### DIFF
--- a/scripts/bastion/_matrix_lib.sh
+++ b/scripts/bastion/_matrix_lib.sh
@@ -70,7 +70,7 @@ SKILLS_PATHS="${SKILLS_PATHS:-\$HOME/mcp-skills/skills}"
 DRY_RUN="${DRY_RUN:-}"
 BENCH_REMOTE="${BENCH_REMOTE:-}"  # empty = run locally on this host; set = ssh to the bastion
 
-STAMP="$(date +%Y%m%d_%H%M%S)"
+STAMP="$(date +%Y%m%d_%H%M%S)-$$"
 # Pulled results land in ${RESULTS_DIR}/${STAMP} (the pull re-creates the
 # stamped dir), so the default deliberately omits the stamp.
 RESULTS_DIR="${RESULTS_DIR:-results/matrix}"
@@ -169,7 +169,7 @@ _poll_until_done() {
     fi
     if [ "${waited}" -ge "${max_wait}" ]; then
       echo "    giving up after ${waited}s (MATRIX_POLL_TIMEOUT_SEC); pulling whatever finished" >&2
-      break
+      return 124
     fi
     echo "    ${done_n}/${expected} finished... ($(date +%H:%M:%S))"
     sleep 60
@@ -221,9 +221,10 @@ matrix_dispatch() {
       || { echo "ERROR: no run at ~/${REMOTE_OUT} on ${where}" >&2; exit 2; }
     local exp
     exp="$(host_exec "ls -d \$HOME/${REMOTE_OUT}/*/ 2>/dev/null | wc -l" 2>/dev/null | tr -d '[:space:]' || echo '?')"
-    _poll_until_done "${exp}"
-    _pull_and_summarize
-    return $?
+    local poll_rc=0
+    _poll_until_done "${exp}" || poll_rc=$?
+    _pull_and_summarize || return $?
+    return "${poll_rc}"
   fi
 
   echo "==> ${label} matrix: ${#COMBOS[@]} combo(s), MAX_PARALLEL=${MAX_PARALLEL}"
@@ -336,6 +337,8 @@ matrix_dispatch() {
   fi
   echo "    (to re-attach if this exits: RESUME_STAMP=${STAMP} re-run the same command)"
 
-  _poll_until_done "${#COMBOS[@]}"
-  _pull_and_summarize
+  local poll_rc=0
+  _poll_until_done "${#COMBOS[@]}" || poll_rc=$?
+  _pull_and_summarize || return $?
+  return "${poll_rc}"
 }

--- a/scripts/bastion/_matrix_lib.sh
+++ b/scripts/bastion/_matrix_lib.sh
@@ -51,9 +51,7 @@ REMOTE_DIR="${REMOTE_DIR:-devops-bench}"
 MATRIX_TASKS="${MATRIX_TASKS:-tasks/common/opa-remediation/task.yaml}"
 MATRIX_MODELS="${MATRIX_MODELS:-gemini-3.1-pro}"
 
-# PROJECT_ID is the name the harness reads; GCP_PROJECT_ID is accepted as an
-# alias so an existing bench.env keeps working.
-PROJECT_ID="${PROJECT_ID:-${GCP_PROJECT_ID:-}}"
+PROJECT_ID="${PROJECT_ID:-}"
 CLUSTER_NAME="${CLUSTER_NAME:-eval}"
 GCP_LOCATION="${GCP_LOCATION:-us-central1-a}"
 AGENT_PROVIDER="${AGENT_PROVIDER:-google}"

--- a/scripts/bastion/_matrix_lib.sh
+++ b/scripts/bastion/_matrix_lib.sh
@@ -28,7 +28,7 @@
 # either the default IAP tunnel, or direct SSH via BASTION_SSH_HOST / BASTION_SSH_USER.
 # Run config: PROJECT_ID (req unless DRY_RUN), CLUSTER_NAME, GCP_LOCATION,
 # AGENT_PROVIDER, JUDGE_PROVIDER, JUDGE_MODEL, MAX_PARALLEL, RESULTS_DIR,
-# GKE_MCP_BIN, SKILLS_PATHS, SKIP_SYNC, DRY_RUN, MATRIX_TASKS, MATRIX_MODELS.
+# MCP_SERVER_BIN, SKILLS_PATHS, SKIP_SYNC, DRY_RUN, MATRIX_TASKS, MATRIX_MODELS.
 # RESUME_STAMP=<stamp>: skip launching; re-poll + pull an existing remote run
 #   (use the stamp printed by the original invocation) — survives a dead local
 #   process. SSH keepalive + a retrying pull keep brief drops from aborting.
@@ -64,8 +64,8 @@ MAX_PARALLEL="${MAX_PARALLEL:-3}"
 # infra-bearing tasks (e.g. deploy-hello-app timed out); give matrix runs more
 # headroom. Override by exporting AGENT_TIMEOUT_SEC before launch.
 AGENT_TIMEOUT_SEC="${AGENT_TIMEOUT_SEC:-1200}"
-GKE_MCP_BIN="${GKE_MCP_BIN:-\$HOME/gke-mcp}"     # expanded on the bastion
-# Agent +skills source: the 19 operational gke-mcp skills (SKILL.md form), cloned
+MCP_SERVER_BIN="${MCP_SERVER_BIN:-\$HOME/gke-mcp}"     # expanded on the bastion
+# Agent +skills source: the MCP server's operational skills (SKILL.md form), cloned
 # by vm-setup.sh. NOT ~/oc-skills, which holds the judge rubric markdown (the
 # grader's criteria), not operational agent skills. Expanded on the bastion.
 SKILLS_PATHS="${SKILLS_PATHS:-\$HOME/gke-mcp-repo/skills}"

--- a/scripts/bastion/_matrix_lib.sh
+++ b/scripts/bastion/_matrix_lib.sh
@@ -219,8 +219,12 @@ matrix_dispatch() {
     echo "==> RESUME: attaching to existing run ~/${REMOTE_OUT} on ${where}"
     host_exec "test -d \$HOME/${REMOTE_OUT}" 2>/dev/null \
       || { echo "ERROR: no run at ~/${REMOTE_OUT} on ${where}" >&2; exit 2; }
+    # run_one mkdirs each combo dir lazily, so counting dirs undercounts a run
+    # still in flight; the staged runner has one run_one line per combo.
     local exp
-    exp="$(host_exec "ls -d \$HOME/${REMOTE_OUT}/*/ 2>/dev/null | wc -l" 2>/dev/null | tr -d '[:space:]' || echo '?')"
+    exp="$(host_exec "grep -c '^run_one ' \$HOME/.matrix-runner-${STAMP}.sh" 2>/dev/null | tr -d '[:space:]')"
+    [ "${exp:-0}" -gt 0 ] 2>/dev/null \
+      || { echo "ERROR: no staged runner for ${STAMP}; cannot resume" >&2; return 2; }
     local poll_rc=0
     _poll_until_done "${exp}" || poll_rc=$?
     _pull_and_summarize || return $?

--- a/scripts/bastion/_matrix_lib.sh
+++ b/scripts/bastion/_matrix_lib.sh
@@ -62,11 +62,11 @@ MAX_PARALLEL="${MAX_PARALLEL:-3}"
 # infra-bearing tasks (e.g. deploy-hello-app timed out); give matrix runs more
 # headroom. Override by exporting AGENT_TIMEOUT_SEC before launch.
 AGENT_TIMEOUT_SEC="${AGENT_TIMEOUT_SEC:-1200}"
-MCP_SERVER_BIN="${MCP_SERVER_BIN:-\$HOME/gke-mcp}"     # expanded on the bastion
+MCP_SERVER_BIN="${MCP_SERVER_BIN:-/usr/local/bin/gke-mcp}"   # where startup.sh installs it
 # Agent +skills source: the MCP server's operational skills (SKILL.md form), cloned
 # by vm-setup.sh. NOT ~/oc-skills, which holds the judge rubric markdown (the
 # grader's criteria), not operational agent skills. Expanded on the bastion.
-SKILLS_PATHS="${SKILLS_PATHS:-\$HOME/gke-mcp-repo/skills}"
+SKILLS_PATHS="${SKILLS_PATHS:-\$HOME/mcp-skills/skills}"
 DRY_RUN="${DRY_RUN:-}"
 BENCH_REMOTE="${BENCH_REMOTE:-}"  # empty = run locally on this host; set = ssh to the bastion
 

--- a/scripts/bastion/_matrix_lib.sh
+++ b/scripts/bastion/_matrix_lib.sh
@@ -26,7 +26,7 @@
 #
 # Connection env (same as sync-to-bastion.sh): BASTION_VM/ZONE/PROJECT, and
 # either the default IAP tunnel, or direct SSH via BASTION_SSH_HOST / BASTION_SSH_USER.
-# Run config: GCP_PROJECT_ID (req unless DRY_RUN), GKE_CLUSTER_NAME, GCP_LOCATION,
+# Run config: PROJECT_ID (req unless DRY_RUN), CLUSTER_NAME, GCP_LOCATION,
 # AGENT_PROVIDER, JUDGE_PROVIDER, JUDGE_MODEL, MAX_PARALLEL, RESULTS_DIR,
 # GKE_MCP_BIN, SKILLS_PATHS, SKIP_SYNC, DRY_RUN, MATRIX_TASKS, MATRIX_MODELS.
 # RESUME_STAMP=<stamp>: skip launching; re-poll + pull an existing remote run
@@ -48,10 +48,13 @@ BASTION_ZONE="${BASTION_ZONE:-us-central1-a}"
 BASTION_PROJECT="${BASTION_PROJECT:-$(gcloud config get-value project 2>/dev/null || true)}"
 REMOTE_DIR="${REMOTE_DIR:-devops-bench}"
 
-MATRIX_TASKS="${MATRIX_TASKS:-tasks/gcp/secret-rotation/task.yaml}"
+MATRIX_TASKS="${MATRIX_TASKS:-tasks/common/opa-remediation/task.yaml}"
 MATRIX_MODELS="${MATRIX_MODELS:-gemini-3.1-pro}"
 
-GKE_CLUSTER_NAME="${GKE_CLUSTER_NAME:-eval}"
+# PROJECT_ID is the name the harness reads; GCP_PROJECT_ID is accepted as an
+# alias so an existing bench.env keeps working.
+PROJECT_ID="${PROJECT_ID:-${GCP_PROJECT_ID:-}}"
+CLUSTER_NAME="${CLUSTER_NAME:-eval}"
 GCP_LOCATION="${GCP_LOCATION:-us-central1-a}"
 AGENT_PROVIDER="${AGENT_PROVIDER:-google}"
 JUDGE_PROVIDER="${JUDGE_PROVIDER:-google}"
@@ -241,7 +244,7 @@ matrix_dispatch() {
   fi
 
   [ "${#COMBOS[@]}" -gt 0 ] || { echo "ERROR: empty matrix" >&2; exit 2; }
-  [ -n "${GCP_PROJECT_ID:-}" ] || { echo "ERROR: set GCP_PROJECT_ID" >&2; exit 2; }
+  [ -n "${PROJECT_ID:-}" ] || { echo "ERROR: set PROJECT_ID" >&2; exit 2; }
 
   if [ -n "${BENCH_REMOTE}" ] && [ -z "${SKIP_SYNC:-}" ]; then
     echo "==> syncing working tree to ${BASTION_VM}"
@@ -271,10 +274,14 @@ matrix_dispatch() {
       # gemini CLI and the google-genai judge ignore it (they pick ADC from
       # GOOGLE_GENAI_USE_VERTEXAI + project/location).
       echo 'export GOOGLE_CLOUD_API_KEY=gcp-vertex-credentials'
-      echo "export GOOGLE_GENAI_USE_VERTEXAI=true GOOGLE_CLOUD_PROJECT='${GCP_PROJECT_ID}' GOOGLE_CLOUD_LOCATION='${GOOGLE_CLOUD_LOCATION:-global}' GCP_VERTEX_LOCATION='${GCP_VERTEX_LOCATION:-global}'"
+      echo "export GOOGLE_GENAI_USE_VERTEXAI=true GOOGLE_CLOUD_PROJECT='${PROJECT_ID}' GOOGLE_CLOUD_LOCATION='${GOOGLE_CLOUD_LOCATION:-global}' GCP_VERTEX_LOCATION='${GCP_VERTEX_LOCATION:-global}'"
     fi
     echo "OUT=\"\$HOME/${REMOTE_OUT}\"; mkdir -p \"\$OUT\""
-    echo "export GCP_PROJECT_ID='${GCP_PROJECT_ID}' GKE_CLUSTER_NAME='${GKE_CLUSTER_NAME}' GCP_LOCATION='${GCP_LOCATION}'"
+    # PROJECT_ID / CLUSTER_NAME are what the harness reads (run.py). GCP_PROJECT_ID
+    # and GCP_LOCATION are additionally exported because the GCP provider and the
+    # Vertex model auth resolve those directly.
+    echo "export PROJECT_ID='${PROJECT_ID}' CLUSTER_NAME='${CLUSTER_NAME}'"
+    echo "export GCP_PROJECT_ID='${PROJECT_ID}' GCP_LOCATION='${GCP_LOCATION}'"
     echo "export AGENT_PROVIDER='${AGENT_PROVIDER}' JUDGE_PROVIDER='${JUDGE_PROVIDER}' JUDGE_MODEL='${JUDGE_MODEL}'"
     echo "export AGENT_TIMEOUT_SEC='${AGENT_TIMEOUT_SEC}'"
     echo "export BENCH_PARALLEL=true"
@@ -292,7 +299,7 @@ matrix_dispatch() {
     echo '      [ -n "$rdir" ] && cp -a "$rdir/." "$d/" 2>/dev/null || true'
     echo '    else'
     echo '      python3 -m devops_bench --parallel --run-id "$rid" \'
-    echo '        --project "$GCP_PROJECT_ID" --cluster "$GKE_CLUSTER_NAME" \'
+    echo '        --project "$PROJECT_ID" --cluster "$CLUSTER_NAME" \'
     echo '        --results-root "$d" "$task"; rc=$?'
     echo '    fi'
     echo '    echo "exit=$rc" >"$d/status"'

--- a/scripts/bastion/_matrix_lib.sh
+++ b/scripts/bastion/_matrix_lib.sh
@@ -153,13 +153,26 @@ task_extra_env() {
 # read as "not finished yet" and retried next tick, so brief drops don't abort
 # (the run itself is detached via nohup and unaffected). Arg: expected combo count.
 _poll_until_done() {
-  local expected="$1" done_n
+  local expected="$1" done_n waited=0
+  local max_wait="${MATRIX_POLL_TIMEOUT_SEC:-86400}"
   echo "==> waiting for ${expected} run(s) (poll 60s; runs continue if this exits)"
   while true; do
     if host_exec "test -f \$HOME/${REMOTE_OUT}/.done" 2>/dev/null; then break; fi
     done_n="$(host_exec "ls \$HOME/${REMOTE_OUT}/*/status 2>/dev/null | wc -l" 2>/dev/null | tr -d '[:space:]' || echo 0)"
+    # The runner only writes .done after `wait`, so if it dies (reboot, OOM,
+    # manual kill) the marker never lands. Every combo having a status file
+    # means the work is finished either way, so stop rather than block forever.
+    if [ "${done_n}" -ge "${expected}" ]; then
+      echo "    all ${expected} combos have a status file but no .done marker; the runner likely died"
+      break
+    fi
+    if [ "${waited}" -ge "${max_wait}" ]; then
+      echo "    giving up after ${waited}s (MATRIX_POLL_TIMEOUT_SEC); pulling whatever finished" >&2
+      break
+    fi
     echo "    ${done_n}/${expected} finished... ($(date +%H:%M:%S))"
     sleep 60
+    waited=$((waited + 60))
   done
 }
 
@@ -296,20 +309,23 @@ matrix_dispatch() {
     echo "echo ALL_DONE >\"\$HOME/${REMOTE_OUT}/.done\""
   } >"${runner}"
 
-  # Per-stamp runner path so two matrices (e.g. refactored + legacy) can be
-  # launched in parallel without clobbering each other's runner script.
-  local staged_runner="/tmp/matrix-runner-${STAMP}.sh"
+  # Staged under $HOME, not /tmp: the runner is executed, and a shared /tmp lets
+  # any other local user pre-create the path (or symlink it) and hijack what
+  # runs. Per-stamp so two matrices can be launched in parallel without
+  # clobbering each other's runner script.
+  local staged_runner="\$HOME/.matrix-runner-${STAMP}.sh"
+  local local_staged_runner="${HOME}/.matrix-runner-${STAMP}.sh"
   # Create the output dir (and its parent) BEFORE the nohup redirect — the
   # ``>...${REMOTE_OUT}.out`` target dir must exist or the job never starts.
   if [ -n "${BENCH_REMOTE}" ]; then
     echo "==> uploading + launching remote runner (detached)"
-    push_file "${runner}" "${staged_runner}"
-    remote_exec "mkdir -p \$HOME/${REMOTE_OUT}; chmod +x ${staged_runner}; nohup ${staged_runner} >\$HOME/${REMOTE_OUT}.out 2>&1 & echo launched pid=\$!"
+    push_file "${runner}" ".matrix-runner-${STAMP}.sh"
+    remote_exec "mkdir -p \$HOME/${REMOTE_OUT}; chmod 700 ${staged_runner}; nohup ${staged_runner} >\$HOME/${REMOTE_OUT}.out 2>&1 & echo launched pid=\$!"
   else
     echo "==> launching local runner (detached)"
-    cp "${runner}" "${staged_runner}"; chmod +x "${staged_runner}"
+    install -m 700 "${runner}" "${local_staged_runner}"
     mkdir -p "$HOME/${REMOTE_OUT}"
-    nohup "${staged_runner}" >"$HOME/${REMOTE_OUT}.out" 2>&1 & echo "launched pid=$!"
+    nohup "${local_staged_runner}" >"$HOME/${REMOTE_OUT}.out" 2>&1 & echo "launched pid=$!"
   fi
   echo "    (to re-attach if this exits: RESUME_STAMP=${STAMP} re-run the same command)"
 

--- a/scripts/bastion/_matrix_lib.sh
+++ b/scripts/bastion/_matrix_lib.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Shared library for the bastion eval-matrix orchestrators:
+#   run_matrix.sh         (refactored arm: Task x Model x AgentConfig)
+#   run_matrix_legacy.sh  (legacy arm:     Task x Model)
+#
+# Not run directly. A wrapper sources this, sets the MATRIX_* / run config, then
+# builds the global COMBOS array (each entry "run_id|task|kvs|arm", where kvs is
+# a ';'-joined KEY=VALUE list of per-combo env, e.g.
+# "AGENT_MODEL=gemini-3.1-pro;BENCH_AGENT_TYPE=openclaw;...") and calls
+# `matrix_dispatch "<label>"`. Each combo runs as an isolated --parallel run on
+# the bastion (its own cluster); results are copied back to RESULTS_DIR.
+#
+# Connection env (same as sync-to-bastion.sh): BASTION_VM/ZONE/PROJECT, and
+# either default IAP or BASTION_USE_GCPNODE=1 / BASTION_SSH_HOST / BASTION_SSH_USER.
+# Run config: GCP_PROJECT_ID (req unless DRY_RUN), GKE_CLUSTER_NAME, GCP_LOCATION,
+# AGENT_PROVIDER, JUDGE_PROVIDER, JUDGE_MODEL, MAX_PARALLEL, RESULTS_DIR,
+# GKE_MCP_BIN, SKILLS_PATHS, SKIP_SYNC, DRY_RUN, MATRIX_TASKS, MATRIX_MODELS.
+# RESUME_STAMP=<stamp>: skip launching; re-poll + pull an existing remote run
+#   (use the stamp printed by the original invocation) — survives a dead local
+#   process. SSH keepalive + a retrying pull keep brief drops from aborting.
+# BENCH_VERTEX=1: run agents + judges against Vertex AI via the bastion VM SA's
+#   ADC instead of the API-key endpoints. The runner unsets every API key from
+#   secrets.env and exports GOOGLE_GENAI_USE_VERTEXAI/GOOGLE_CLOUD_*/
+#   GCP_VERTEX_LOCATION (default location 'global'; override GOOGLE_CLOUD_LOCATION
+#   / GCP_VERTEX_LOCATION). For the legacy oc arm also set AGENT_PROVIDER=
+#   google-vertex so the model id becomes 'google-vertex/<model>'. Prereq: the oc
+#   google-vertex provider must be auth'd once (see docs/components/bastion.md).
+# BENCH_REMOTE=1: run the matrix ON the bastion over ssh (sync + remote nohup +
+#   pull). Default (unset) runs every combo LOCALLY on this host (no ssh/sync;
+#   outputs in ~/matrix-runs/<stamp>, no pull). BASTION_* matter only when set.
+
+BASTION_VM="${BASTION_VM:-bench-bastion}"
+BASTION_ZONE="${BASTION_ZONE:-us-central1-a}"
+BASTION_PROJECT="${BASTION_PROJECT:-$(gcloud config get-value project 2>/dev/null || true)}"
+REMOTE_DIR="${REMOTE_DIR:-devops-bench}"
+
+MATRIX_TASKS="${MATRIX_TASKS:-tasks/gcp/secret-rotation/task.yaml}"
+MATRIX_MODELS="${MATRIX_MODELS:-gemini-3.1-pro}"
+
+GKE_CLUSTER_NAME="${GKE_CLUSTER_NAME:-eval}"
+GCP_LOCATION="${GCP_LOCATION:-us-central1-a}"
+AGENT_PROVIDER="${AGENT_PROVIDER:-google}"
+JUDGE_PROVIDER="${JUDGE_PROVIDER:-google}"
+JUDGE_MODEL="${JUDGE_MODEL:-gemini-3.1-pro}"
+MAX_PARALLEL="${MAX_PARALLEL:-3}"
+# Per-subprocess agent timeout. The 600s harness default is too low for
+# infra-bearing tasks (e.g. deploy-hello-app timed out); give matrix runs more
+# headroom. Override by exporting AGENT_TIMEOUT_SEC before launch.
+AGENT_TIMEOUT_SEC="${AGENT_TIMEOUT_SEC:-1200}"
+GKE_MCP_BIN="${GKE_MCP_BIN:-\$HOME/gke-mcp}"     # expanded on the bastion
+# Agent +skills source: the 19 operational gke-mcp skills (SKILL.md form), cloned
+# by vm-setup.sh. NOT ~/oc-skills, which holds the judge rubric markdown (the
+# grader's criteria), not operational agent skills. Expanded on the bastion.
+SKILLS_PATHS="${SKILLS_PATHS:-\$HOME/gke-mcp-repo/skills}"
+DRY_RUN="${DRY_RUN:-}"
+BENCH_REMOTE="${BENCH_REMOTE:-}"  # empty = run locally on this host; set = ssh to the bastion
+
+STAMP="$(date +%Y%m%d_%H%M%S)"
+# Pulled results land in ${RESULTS_DIR}/${STAMP} (the pull re-creates the
+# stamped dir), so the default deliberately omits the stamp.
+RESULTS_DIR="${RESULTS_DIR:-results/matrix}"
+REMOTE_OUT="matrix-runs/${STAMP}"  # relative to the bastion user's $HOME
+
+_MATRIX_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${_MATRIX_LIB_DIR}/../.." && pwd)"
+
+# --- SSH transport (mirrors sync-to-bastion.sh) ----------------------------- #
+# Keepalive so sessions ride out brief network blips instead of dropping.
+_SSH_KA=(-o ServerAliveInterval=30 -o ServerAliveCountMax=4 -o ConnectTimeout=30)
+if [ -n "${BASTION_SSH_HOST:-}" ] || [ "${BASTION_USE_GCPNODE:-}" = "1" ]; then
+  SSH_HOST="${BASTION_SSH_HOST:-nic0.${BASTION_VM}.${BASTION_ZONE}.c.${BASTION_PROJECT}.internal.gcpnode.com}"
+  SSH_USER="${BASTION_SSH_USER:-$(id -un)_google_com}"
+  SSH_TARGET="${SSH_USER}@${SSH_HOST}"
+  remote_exec() { ssh -o BatchMode=yes "${_SSH_KA[@]}" "${SSH_TARGET}" "$1"; }
+  push_file()   { scp -o BatchMode=yes "${_SSH_KA[@]}" "$1" "${SSH_TARGET}:$2"; }
+  pull_dir()    { scp -o BatchMode=yes "${_SSH_KA[@]}" -r "${SSH_TARGET}:$1" "$2"; }
+else
+  _GKA=(--ssh-flag="-o ServerAliveInterval=30" --ssh-flag="-o ServerAliveCountMax=4")
+  _GKA_SCP=(--scp-flag="-o ServerAliveInterval=30" --scp-flag="-o ServerAliveCountMax=4")
+  remote_exec() { gcloud compute ssh "${BASTION_VM}" --tunnel-through-iap --zone "${BASTION_ZONE}" --project "${BASTION_PROJECT}" "${_GKA[@]}" --command "$1"; }
+  push_file()   { gcloud compute scp --tunnel-through-iap --zone "${BASTION_ZONE}" --project "${BASTION_PROJECT}" "${_GKA_SCP[@]}" "$1" "${BASTION_VM}:$2"; }
+  pull_dir()    { gcloud compute scp --tunnel-through-iap --recurse --zone "${BASTION_ZONE}" --project "${BASTION_PROJECT}" "${_GKA_SCP[@]}" "${BASTION_VM}:$1" "$2"; }
+fi
+
+# Run a check/command on the runner host: locally by default, on the bastion when
+# BENCH_REMOTE is set. (The detached matrix runner itself is launched separately.)
+host_exec() { if [ -n "${BENCH_REMOTE}" ]; then remote_exec "$1"; else bash -c "$1"; fi; }
+
+# Pull with a few retries — a drop during the final copy is otherwise fatal.
+pull_dir_retry() {
+  local src="$1" dst="$2" i
+  for i in 1 2 3 4 5; do
+    if pull_dir "${src}" "${dst}"; then return 0; fi
+    echo "    pull attempt ${i} failed; retrying in 15s..." >&2
+    sleep 15
+  done
+  echo "ERROR: could not pull ${src} after retries; results remain on the bastion at ~/${src}" >&2
+  return 1
+}
+
+sanitize() { echo "$1" | tr '/.+ ' '----' | tr -cd 'A-Za-z0-9_-'; }
+
+# ALL -> enumerate every task.yaml under tasks/; else the list.
+resolve_tasks() {
+  if [ "${MATRIX_TASKS}" = "ALL" ]; then
+    ( cd "${REPO_ROOT}" && find tasks -name task.yaml 2>/dev/null | sort )
+  else
+    printf '%s\n' ${MATRIX_TASKS}
+  fi
+}
+
+# Per-task extra env, ';'-prefixed so it appends onto an existing KVS list.
+# Some tasks need the harness integration contract (TARGET_DEPLOYMENT_NAME /
+# NAMESPACE) pinned so the prompt / chaos service_url / verification placeholders
+# match what the task's stack actually deployed. The harness reads these from the
+# environment and its defaults DIFFER across arms (refactored namespace "default"
+# vs legacy "production"), so they must be set explicitly here, not left to the
+# per-arm default. Emits nothing for tasks that don't need it.
+task_extra_env() {
+  case "$1" in
+    */optimize-scale/*) echo ";TARGET_DEPLOYMENT_NAME=scale-target;NAMESPACE=default" ;;
+    # Pre-seeded fixtures: pin NAMESPACE so the prompt's {{NAMESPACE}} resolves to
+    # the same namespace the stack deploys the fixture into, on BOTH arms (the
+    # harness default differs: refactored "default" vs legacy "production"). The
+    # value matches each stack's own namespace default.
+    */multi-region-failover/*)      echo ";NAMESPACE=storefront" ;;
+    */secret-rotation/*)            echo ";NAMESPACE=secret-rotation" ;;
+    */cp-recovery/*)                echo ";NAMESPACE=cp-recovery" ;;
+    */troubleshoot-unhealthy-pod/*) echo ";NAMESPACE=default" ;;
+    */gitops-auto-revert/*)         echo ";NAMESPACE=default" ;;
+    # No stack fixture (agent-created), but pin so legacy doesn't target a
+    # non-existent "production" namespace.
+    */deploy-postgres-web-app/*)    echo ";NAMESPACE=default" ;;
+    */debug-crashloop/*)            echo ";NAMESPACE=default" ;;
+  esac
+}
+
+# Poll until the remote .done marker appears. Resilient: a failed SSH check is
+# read as "not finished yet" and retried next tick, so brief drops don't abort
+# (the run itself is detached via nohup and unaffected). Arg: expected combo count.
+_poll_until_done() {
+  local expected="$1" done_n
+  echo "==> waiting for ${expected} run(s) (poll 60s; runs continue if this exits)"
+  while true; do
+    if host_exec "test -f \$HOME/${REMOTE_OUT}/.done" 2>/dev/null; then break; fi
+    done_n="$(host_exec "ls \$HOME/${REMOTE_OUT}/*/status 2>/dev/null | wc -l" 2>/dev/null | tr -d '[:space:]' || echo 0)"
+    echo "    ${done_n}/${expected} finished... ($(date +%H:%M:%S))"
+    sleep 60
+  done
+}
+
+# Pull results (with retry) and summarize from the pulled dirs. Reads the local
+# <rid> subdirs rather than COMBOS, so it also serves RESUME_STAMP attach.
+_pull_and_summarize() {
+  mkdir -p "${RESULTS_DIR}"
+  local LOCAL_OUT
+  if [ -n "${BENCH_REMOTE}" ]; then
+    echo "==> pulling results -> ${RESULTS_DIR}/${STAMP}"
+    pull_dir_retry "${REMOTE_OUT}" "${RESULTS_DIR}" || return 1
+    LOCAL_OUT="${RESULTS_DIR}/${STAMP}"
+  else
+    LOCAL_OUT="$HOME/${REMOTE_OUT}"
+    echo "==> local results at ${LOCAL_OUT}"
+  fi
+
+  echo "==> summary"
+  printf '%-56s %-8s %s\n' "COMBO" "EXIT" "results.json"
+  local d rid st rj
+  for d in "${LOCAL_OUT}"/*/; do
+    [ -d "$d" ] || continue
+    rid="$(basename "$d")"
+    st="$(cat "${d%/}/status" 2>/dev/null || echo '?')"
+    rj="$(find "${d}" -name results.json 2>/dev/null | head -1)"
+    printf '%-56s %-8s %s\n' "${rid}" "${st}" "${rj:-<none>}"
+  done
+  echo "==> done. results under ${LOCAL_OUT} (each combo provisioned + tore down its own cluster)"
+}
+
+# Run the COMBOS matrix. Arg: a human label for logging.
+#
+# Resume/attach: set RESUME_STAMP=<stamp> (from an earlier run's output) to skip
+# launching and just re-poll + pull an existing remote run — for when the local
+# process died after the bastion runner was already launched.
+matrix_dispatch() {
+  local label="$1"
+
+  if [ -n "${RESUME_STAMP:-}" ]; then
+    STAMP="${RESUME_STAMP}"
+    REMOTE_OUT="matrix-runs/${STAMP}"
+    local where; where="localhost"; [ -n "${BENCH_REMOTE}" ] && where="${BASTION_VM}"
+    echo "==> RESUME: attaching to existing run ~/${REMOTE_OUT} on ${where}"
+    host_exec "test -d \$HOME/${REMOTE_OUT}" 2>/dev/null \
+      || { echo "ERROR: no run at ~/${REMOTE_OUT} on ${where}" >&2; exit 2; }
+    local exp
+    exp="$(host_exec "ls -d \$HOME/${REMOTE_OUT}/*/ 2>/dev/null | wc -l" 2>/dev/null | tr -d '[:space:]' || echo '?')"
+    _poll_until_done "${exp}"
+    _pull_and_summarize
+    return $?
+  fi
+
+  echo "==> ${label} matrix: ${#COMBOS[@]} combo(s), MAX_PARALLEL=${MAX_PARALLEL}"
+  printf '    %s\n' "${COMBOS[@]%%|*}"
+
+  if [ -n "${DRY_RUN}" ]; then
+    echo "==> DRY_RUN: per-combo env (not executing):"
+    local c rid task kvs arm
+    for c in "${COMBOS[@]}"; do
+      IFS='|' read -r rid task kvs arm <<<"$c"
+      echo "  [${rid}] arm=${arm} task=${task}"
+      echo "      ${kvs}"
+    done
+    echo "==> DRY_RUN: results would land in ${RESULTS_DIR}/${STAMP}"
+    return 0
+  fi
+
+  [ "${#COMBOS[@]}" -gt 0 ] || { echo "ERROR: empty matrix" >&2; exit 2; }
+  [ -n "${GCP_PROJECT_ID:-}" ] || { echo "ERROR: set GCP_PROJECT_ID" >&2; exit 2; }
+
+  if [ -n "${BENCH_REMOTE}" ] && [ -z "${SKIP_SYNC:-}" ]; then
+    echo "==> syncing working tree to ${BASTION_VM}"
+    "${REPO_ROOT}/scripts/bastion/sync-to-bastion.sh"
+  fi
+
+  local runner; runner="$(mktemp -t matrix-runner-XXXXXX.sh)"
+  trap 'rm -f "${runner}"' RETURN
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'set -uo pipefail'
+    if [ -n "${BENCH_REMOTE}" ]; then echo "cd ~/${REMOTE_DIR}"; else echo "cd '${REPO_ROOT}'"; fi
+    echo '[ -f .venv/bin/activate ] && source .venv/bin/activate || true'
+    echo 'set -a; [ -f ~/secrets.env ] && . ~/secrets.env; set +a'
+    if [ -n "${BENCH_VERTEX:-}" ]; then
+      # Vertex mode: drop every API key secrets.env exported so agents AND judges
+      # fall back to ADC (the bastion VM SA via the metadata server), then point
+      # everything at Vertex. Location is global — the gemini-3.x *-preview models
+      # 404 on regional endpoints (us-central1). The legacy judge defaults to
+      # us-central1, so GCP_VERTEX_LOCATION must override it too.
+      echo 'unset AGENT_API_KEY GEMINI_API_KEY GOOGLE_API_KEY JUDGE_API_KEY GOOGLE_GENAI_API_KEY'
+      # The literal marker tells oc's google-vertex provider "use ADC". Passing it
+      # via env (not `oc models auth paste-api-key`) is what makes it PORTABLE
+      # across oc's isolated per-run OPENCLAW_STATE_DIRs — a pasted profile lives
+      # only in the global agent sqlite store, which parallel runs don't share, so
+      # they'd fail with `No API key found for provider "google-vertex"`. The
+      # gemini CLI and the google-genai judge ignore it (they pick ADC from
+      # GOOGLE_GENAI_USE_VERTEXAI + project/location).
+      echo 'export GOOGLE_CLOUD_API_KEY=gcp-vertex-credentials'
+      echo "export GOOGLE_GENAI_USE_VERTEXAI=true GOOGLE_CLOUD_PROJECT='${GCP_PROJECT_ID}' GOOGLE_CLOUD_LOCATION='${GOOGLE_CLOUD_LOCATION:-global}' GCP_VERTEX_LOCATION='${GCP_VERTEX_LOCATION:-global}'"
+    fi
+    echo "OUT=\"\$HOME/${REMOTE_OUT}\"; mkdir -p \"\$OUT\""
+    echo "export GCP_PROJECT_ID='${GCP_PROJECT_ID}' GKE_CLUSTER_NAME='${GKE_CLUSTER_NAME}' GCP_LOCATION='${GCP_LOCATION}'"
+    echo "export AGENT_PROVIDER='${AGENT_PROVIDER}' JUDGE_PROVIDER='${JUDGE_PROVIDER}' JUDGE_MODEL='${JUDGE_MODEL}'"
+    echo "export AGENT_TIMEOUT_SEC='${AGENT_TIMEOUT_SEC}'"
+    echo "export BENCH_PARALLEL=true"
+    echo 'run_one() {'
+    echo '  local rid="$1" task="$2" kvs="$3" arm="$4" kv rc rdir'
+    echo '  local d="$OUT/$rid"; mkdir -p "$d"'
+    echo '  ('
+    echo '    export RUN_ID="$rid"'
+    echo '    # eval so values like AGENT_MCP_SERVER=$HOME/gke-mcp expand on the bastion'
+    echo '    IFS=";"; for kv in $kvs; do eval "export ${kv}"; done'
+    echo '    if [ "$arm" = "legacy" ]; then'
+    echo '      python3 pkg/evaluator/evaluate.py "$task"; rc=$?'
+    echo '      # legacy writes results/run_<ts>_<rid>; copy it into the combo dir'
+    echo '      rdir="$(ls -dt results/run_*_"$rid" 2>/dev/null | head -1)"'
+    echo '      [ -n "$rdir" ] && cp -a "$rdir/." "$d/" 2>/dev/null || true'
+    echo '    else'
+    echo '      python3 -m devops_bench --parallel --run-id "$rid" \'
+    echo '        --project "$GCP_PROJECT_ID" --cluster "$GKE_CLUSTER_NAME" \'
+    echo '        --results-root "$d" "$task"; rc=$?'
+    echo '    fi'
+    echo '    echo "exit=$rc" >"$d/status"'
+    echo '  ) >"$d/run.log" 2>&1'
+    echo '}'
+    echo "SEM=${MAX_PARALLEL}"
+    local c rid task kvs arm
+    for c in "${COMBOS[@]}"; do
+      IFS='|' read -r rid task kvs arm <<<"$c"
+      printf 'run_one %q %q %q %q &\n' "$rid" "$task" "$kvs" "$arm"
+      echo 'while [ "$(jobs -r | wc -l)" -ge "$SEM" ]; do wait -n; done'
+    done
+    echo 'wait'
+    echo "echo ALL_DONE >\"\$HOME/${REMOTE_OUT}/.done\""
+  } >"${runner}"
+
+  # Per-stamp runner path so two matrices (e.g. refactored + legacy) can be
+  # launched in parallel without clobbering each other's runner script.
+  local staged_runner="/tmp/matrix-runner-${STAMP}.sh"
+  # Create the output dir (and its parent) BEFORE the nohup redirect — the
+  # ``>...${REMOTE_OUT}.out`` target dir must exist or the job never starts.
+  if [ -n "${BENCH_REMOTE}" ]; then
+    echo "==> uploading + launching remote runner (detached)"
+    push_file "${runner}" "${staged_runner}"
+    remote_exec "mkdir -p \$HOME/${REMOTE_OUT}; chmod +x ${staged_runner}; nohup ${staged_runner} >\$HOME/${REMOTE_OUT}.out 2>&1 & echo launched pid=\$!"
+  else
+    echo "==> launching local runner (detached)"
+    cp "${runner}" "${staged_runner}"; chmod +x "${staged_runner}"
+    mkdir -p "$HOME/${REMOTE_OUT}"
+    nohup "${staged_runner}" >"$HOME/${REMOTE_OUT}.out" 2>&1 & echo "launched pid=$!"
+  fi
+  echo "    (to re-attach if this exits: RESUME_STAMP=${STAMP} re-run the same command)"
+
+  _poll_until_done "${#COMBOS[@]}"
+  _pull_and_summarize
+}

--- a/scripts/bastion/_matrix_lib.sh
+++ b/scripts/bastion/_matrix_lib.sh
@@ -25,7 +25,7 @@
 # the bastion (its own cluster); results are copied back to RESULTS_DIR.
 #
 # Connection env (same as sync-to-bastion.sh): BASTION_VM/ZONE/PROJECT, and
-# either default IAP or BASTION_USE_GCPNODE=1 / BASTION_SSH_HOST / BASTION_SSH_USER.
+# either the default IAP tunnel, or direct SSH via BASTION_SSH_HOST / BASTION_SSH_USER.
 # Run config: GCP_PROJECT_ID (req unless DRY_RUN), GKE_CLUSTER_NAME, GCP_LOCATION,
 # AGENT_PROVIDER, JUDGE_PROVIDER, JUDGE_MODEL, MAX_PARALLEL, RESULTS_DIR,
 # GKE_MCP_BIN, SKILLS_PATHS, SKIP_SYNC, DRY_RUN, MATRIX_TASKS, MATRIX_MODELS.
@@ -81,9 +81,9 @@ REPO_ROOT="$(cd "${_MATRIX_LIB_DIR}/../.." && pwd)"
 # --- SSH transport (mirrors sync-to-bastion.sh) ----------------------------- #
 # Keepalive so sessions ride out brief network blips instead of dropping.
 _SSH_KA=(-o ServerAliveInterval=30 -o ServerAliveCountMax=4 -o ConnectTimeout=30)
-if [ -n "${BASTION_SSH_HOST:-}" ] || [ "${BASTION_USE_GCPNODE:-}" = "1" ]; then
-  SSH_HOST="${BASTION_SSH_HOST:-nic0.${BASTION_VM}.${BASTION_ZONE}.c.${BASTION_PROJECT}.internal.gcpnode.com}"
-  SSH_USER="${BASTION_SSH_USER:-$(id -un)_google_com}"
+if [ -n "${BASTION_SSH_HOST:-}" ]; then
+  SSH_HOST="${BASTION_SSH_HOST}"
+  SSH_USER="${BASTION_SSH_USER:-$(id -un)}"
   SSH_TARGET="${SSH_USER}@${SSH_HOST}"
   remote_exec() { ssh -o BatchMode=yes "${_SSH_KA[@]}" "${SSH_TARGET}" "$1"; }
   push_file()   { scp -o BatchMode=yes "${_SSH_KA[@]}" "$1" "${SSH_TARGET}:$2"; }

--- a/scripts/bastion/_matrix_lib.sh
+++ b/scripts/bastion/_matrix_lib.sh
@@ -275,13 +275,15 @@ matrix_dispatch() {
       # GOOGLE_GENAI_USE_VERTEXAI + project/location).
       echo 'export GOOGLE_CLOUD_API_KEY=gcp-vertex-credentials'
       echo "export GOOGLE_GENAI_USE_VERTEXAI=true GOOGLE_CLOUD_PROJECT='${PROJECT_ID}' GOOGLE_CLOUD_LOCATION='${GOOGLE_CLOUD_LOCATION:-global}' GCP_VERTEX_LOCATION='${GCP_VERTEX_LOCATION:-global}'"
+      # Vertex model auth reads GCP_PROJECT_ID from the environment directly
+      # (models/gemini.py, models/claude.py), with no value passed in.
+      echo "export GCP_PROJECT_ID='${PROJECT_ID}'"
     fi
     echo "OUT=\"\$HOME/${REMOTE_OUT}\"; mkdir -p \"\$OUT\""
-    # PROJECT_ID / CLUSTER_NAME are what the harness reads (run.py). GCP_PROJECT_ID
-    # and GCP_LOCATION are additionally exported because the GCP provider and the
-    # Vertex model auth resolve those directly.
+    # PROJECT_ID / CLUSTER_NAME are what the harness reads (run.py). GCP_LOCATION
+    # is additionally exported because the deployer factory resolves it directly.
     echo "export PROJECT_ID='${PROJECT_ID}' CLUSTER_NAME='${CLUSTER_NAME}'"
-    echo "export GCP_PROJECT_ID='${PROJECT_ID}' GCP_LOCATION='${GCP_LOCATION}'"
+    echo "export GCP_LOCATION='${GCP_LOCATION}'"
     echo "export AGENT_PROVIDER='${AGENT_PROVIDER}' JUDGE_PROVIDER='${JUDGE_PROVIDER}' JUDGE_MODEL='${JUDGE_MODEL}'"
     echo "export AGENT_TIMEOUT_SEC='${AGENT_TIMEOUT_SEC}'"
     echo "export BENCH_PARALLEL=true"
@@ -290,7 +292,7 @@ matrix_dispatch() {
     echo '  local d="$OUT/$rid"; mkdir -p "$d"'
     echo '  ('
     echo '    export RUN_ID="$rid"'
-    echo '    # eval so values like AGENT_MCP_SERVER=$HOME/gke-mcp expand on the bastion'
+    echo '    # eval so values like AGENT_MCP_SERVER=$HOME/mcp-server expand on the bastion'
     echo '    IFS=";"; for kv in $kvs; do eval "export ${kv}"; done'
     echo '    if [ "$arm" = "legacy" ]; then'
     echo '      python3 pkg/evaluator/evaluate.py "$task"; rc=$?'

--- a/scripts/bastion/configure-oc.sh
+++ b/scripts/bastion/configure-oc.sh
@@ -90,8 +90,11 @@ if [ -f "${SECRETS_ENV}" ]; then
   . "${SECRETS_ENV}"
   KEY="${GEMINI_API_KEY:-${GOOGLE_API_KEY:-}}"
   if [ -n "${KEY}" ]; then
-    printf '%s\n' "${KEY}" | oc models auth paste-api-key --provider google >/dev/null \
-      && echo "==> oc model auth set (google)"
+    if printf '%s\n' "${KEY}" | oc models auth paste-api-key --provider google >/dev/null; then
+      echo "==> oc model auth set (google)"
+    else
+      echo "==> WARN: 'oc models auth paste-api-key --provider google' failed" >&2
+    fi
   else
     echo "==> WARN: no GEMINI_API_KEY/GOOGLE_API_KEY in ${SECRETS_ENV}; skipping oc auth"
   fi
@@ -104,6 +107,9 @@ fi
 # (google-genai) provider so the legacy arm can target `google/<model>`.
 # Idempotent; auth flows from the `oc models auth` paste above.
 if [ -n "${GENAI_MODELS}" ]; then
+  # oc is installed by the VM startup script but only writes its config on first
+  # use, so the directory can still be missing when this runs on a fresh bastion.
+  mkdir -p "${HOME}/.openclaw"
   OC_CONFIG="${HOME}/.openclaw/openclaw.json" GENAI_MODELS="${GENAI_MODELS}" \
   python3 - <<'PY'
 import json, os
@@ -175,14 +181,18 @@ if [ "${WANT_VERTEX}" = "1" ]; then
     && echo "==> oc google-vertex auth marker set (agent ${OPENCLAW_AGENT})"
   # Ensure the provider routes through the google-vertex transport (api field) and
   # the models are registered + allowlisted for the agent. Idempotent.
+  mkdir -p "${HOME}/.openclaw"
   OC_CONFIG="${HOME}/.openclaw/openclaw.json" VERTEX_MODELS="${VERTEX_MODELS}" \
   OPENCLAW_AGENT="${OPENCLAW_AGENT}" python3 - <<'PY'
 import json, os
 path = os.environ["OC_CONFIG"]
 models = os.environ["VERTEX_MODELS"].split()
 agent = os.environ["OPENCLAW_AGENT"]
-with open(path) as f:
-    cfg = json.load(f)
+try:
+    with open(path) as f:
+        cfg = json.load(f)
+except FileNotFoundError:
+    cfg = {}
 prov = cfg.setdefault("models", {}).setdefault("providers", {}).setdefault("google-vertex", {})
 prov["api"] = "google-vertex"
 prov["baseUrl"] = "https://{location}-aiplatform.googleapis.com"

--- a/scripts/bastion/configure-oc.sh
+++ b/scripts/bastion/configure-oc.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Configure the GLOBAL ~/.openclaw config for a run mode, on the bastion.
+#
+# Why this is separate from vm-setup.sh: only the LEGACY arm reads the global oc
+# config — the refactored arm wires MCP/skills per-run via env
+# (AGENT_MCP_SERVER / AGENT_SKILLS_PATHS / BENCH_USE_MCP). Keeping this out of
+# the one-time setup means MCP/skills are a per-run-mode choice: run this with
+# --mcp/--skills before a legacy "with capabilities" run, or with --no-mcp /
+# --no-skills (or just don't run it) for a clean "no capabilities" run.
+#
+# Idempotent. Also stores the agent model API key in oc (from ~/secrets.env), so
+# both arms authenticate without baking the key into oc during provisioning.
+#
+# Usage:
+#   scripts/bastion/configure-oc.sh [--mcp|--no-mcp] [--skills|--no-skills] [--vertex]
+#
+# --vertex registers oc's built-in ``google-vertex`` provider in the global
+# config so the legacy arm can target ``google-vertex/<model>`` via the bastion
+# VM SA's ADC (no API keys). It writes the provider's ``api``/``baseUrl``/model
+# entries (without ``api: google-vertex`` oc would route the provider through the
+# OpenAI transport), allowlists the models for the agent, and pastes the ADC
+# marker. At run time the matrix still exports
+# GOOGLE_CLOUD_API_KEY=gcp-vertex-credentials (see _matrix_lib.sh BENCH_VERTEX),
+# which is what makes auth portable across parallel runs' isolated state dirs.
+#
+# Env overrides:
+#   GKE_MCP_BIN    path to the gke-mcp binary    (default: ~/gke-mcp)
+#   SECRETS_ENV    file exporting GEMINI_API_KEY  (default: ~/secrets.env)
+#   SKILLS_SRC     dir of skill markdowns         (default: ~/devops-bench/skills)
+#   OC_SKILLS_DIR  staging dir for <name>/SKILL.md (default: ~/oc-skills)
+#   VERTEX_MODELS  space-separated model ids to register under google-vertex
+#                  (default: "gemini-3.1-pro-preview gemini-3-flash-preview
+#                            gemini-3.5-flash")
+#   GENAI_MODELS   space-separated model ids to register under the google
+#                  (google-genai) provider's catalog — only models oc doesn't
+#                  ship by default need listing (default: "gemini-3.5-flash")
+#   OPENCLAW_AGENT oc agent profile for the auth marker (default: main)
+set -euo pipefail
+
+WANT_MCP=1
+WANT_SKILLS=1
+WANT_VERTEX=0
+GKE_MCP_BIN="${GKE_MCP_BIN:-${HOME}/gke-mcp}"
+SECRETS_ENV="${SECRETS_ENV:-${HOME}/secrets.env}"
+SKILLS_SRC="${SKILLS_SRC:-${HOME}/devops-bench/skills}"
+OC_SKILLS_DIR="${OC_SKILLS_DIR:-${HOME}/oc-skills}"
+# VERTEX_MODELS and GENAI_MODELS differ on purpose: oc ships NO built-in
+# google-vertex catalog, so every Vertex model must be registered; for google
+# (google-genai) oc already ships most ids, so only the ones it lacks need
+# listing (the legacy-arm analogue of the harness's _CATALOG_OVERRIDES). The
+# refactored arm self-registers per-run and ignores these lists entirely.
+# TODO(deferred): supported-model-name maintenance is tracked separately (#147).
+VERTEX_MODELS="${VERTEX_MODELS:-gemini-3.1-pro-preview gemini-3-flash-preview gemini-3.5-flash}"
+GENAI_MODELS="${GENAI_MODELS:-gemini-3.5-flash}"
+OPENCLAW_AGENT="${OPENCLAW_AGENT:-main}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --mcp) WANT_MCP=1 ;;
+    --no-mcp) WANT_MCP=0 ;;
+    --skills) WANT_SKILLS=1 ;;
+    --no-skills) WANT_SKILLS=0 ;;
+    --vertex) WANT_VERTEX=1 ;;
+    --no-vertex) WANT_VERTEX=0 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+command -v oc >/dev/null 2>&1 || { echo "ERROR: oc not on PATH" >&2; exit 1; }
+
+# --- 1. Agent model API key -> oc auth (idempotent) ------------------------- #
+if [ -f "${SECRETS_ENV}" ]; then
+  # shellcheck disable=SC1090
+  . "${SECRETS_ENV}"
+  KEY="${GEMINI_API_KEY:-${GOOGLE_API_KEY:-}}"
+  if [ -n "${KEY}" ]; then
+    printf '%s\n' "${KEY}" | oc models auth paste-api-key --provider google >/dev/null \
+      && echo "==> oc model auth set (google)"
+  else
+    echo "==> WARN: no GEMINI_API_KEY/GOOGLE_API_KEY in ${SECRETS_ENV}; skipping oc auth"
+  fi
+else
+  echo "==> WARN: ${SECRETS_ENV} not found; skipping oc auth"
+fi
+
+# --- 1b. google-genai catalog overrides ------------------------------------- #
+# Register models oc doesn't ship (e.g. gemini-3.5-flash) under the google
+# (google-genai) provider so the legacy arm can target `google/<model>`.
+# Idempotent; auth flows from the `oc models auth` paste above.
+if [ -n "${GENAI_MODELS}" ]; then
+  OC_CONFIG="${HOME}/.openclaw/openclaw.json" GENAI_MODELS="${GENAI_MODELS}" \
+  python3 - <<'PY'
+import json, os
+path = os.environ["OC_CONFIG"]
+models = os.environ["GENAI_MODELS"].split()
+try:
+    with open(path) as f:
+        cfg = json.load(f)
+except FileNotFoundError:
+    cfg = {}
+prov = cfg.setdefault("models", {}).setdefault("providers", {}).setdefault("google", {})
+prov["api"] = "google-generative-ai"  # replaces built-in entry; pin transport
+prov.setdefault("models", [])
+existing = {m.get("id") for m in prov["models"] if isinstance(m, dict)}
+for m in models:
+    if m not in existing:
+        prov["models"].append({"id": m, "name": m})
+# Allowlist google/<model> for the agent's per-run --model override.
+allow = cfg.setdefault("agents", {}).setdefault("defaults", {}).setdefault("models", {})
+for m in models:
+    allow.setdefault(f"google/{m}", {})
+with open(path, "w") as f:
+    json.dump(cfg, f, indent=2)
+print(f"==> google (genai) catalog overrides registered: {', '.join(models)}")
+PY
+fi
+
+# --- 2. GKE MCP server ------------------------------------------------------ #
+oc mcp unset gke-mcp >/dev/null 2>&1 || true   # idempotent: clear any prior entry
+if [ "${WANT_MCP}" = "1" ]; then
+  [ -x "${GKE_MCP_BIN}" ] || { echo "ERROR: gke-mcp not executable at ${GKE_MCP_BIN}" >&2; exit 1; }
+  oc mcp add gke-mcp --command "${GKE_MCP_BIN}" --no-probe >/dev/null
+  echo "==> gke-mcp registered (global oc config)"
+else
+  echo "==> gke-mcp NOT registered (--no-mcp)"
+fi
+
+# --- 3. Skills (reshape *.md -> <name>/SKILL.md, install --global) ---------- #
+managed_skills_dir="${HOME}/.openclaw/skills"
+if [ "${WANT_SKILLS}" = "1" ]; then
+  [ -d "${SKILLS_SRC}" ] || { echo "ERROR: skills source ${SKILLS_SRC} not found" >&2; exit 1; }
+  mkdir -p "${OC_SKILLS_DIR}"
+  for f in "${SKILLS_SRC}"/*.md; do
+    [ -f "$f" ] || continue
+    name="$(awk -F': ' '/^name:/{print $2; exit}' "$f" | tr -d '\r')"
+    [ -n "${name}" ] || name="$(basename "$f" .md)"
+    mkdir -p "${OC_SKILLS_DIR}/${name}"
+    cp "$f" "${OC_SKILLS_DIR}/${name}/SKILL.md"
+    oc skills install "${OC_SKILLS_DIR}/${name}" --global --force >/dev/null
+    echo "==> skill installed: ${name}"
+  done
+else
+  # Remove any skills this script previously installed, leaving oc's bundled ones.
+  if [ -d "${OC_SKILLS_DIR}" ]; then
+    for d in "${OC_SKILLS_DIR}"/*/; do
+      [ -d "$d" ] || continue
+      rm -rf "${managed_skills_dir}/$(basename "$d")"
+    done
+  fi
+  echo "==> skills NOT installed (--no-skills)"
+fi
+
+# --- 4. Vertex provider (optional) ------------------------------------------ #
+if [ "${WANT_VERTEX}" = "1" ]; then
+  # Paste the ADC marker so `oc agent` works even outside the matrix (the matrix
+  # itself relies on the GOOGLE_CLOUD_API_KEY env marker for parallel-safe auth).
+  printf 'gcp-vertex-credentials\n' \
+    | oc models auth --agent "${OPENCLAW_AGENT}" paste-api-key --provider google-vertex >/dev/null \
+    && echo "==> oc google-vertex auth marker set (agent ${OPENCLAW_AGENT})"
+  # Ensure the provider routes through the google-vertex transport (api field) and
+  # the models are registered + allowlisted for the agent. Idempotent.
+  OC_CONFIG="${HOME}/.openclaw/openclaw.json" VERTEX_MODELS="${VERTEX_MODELS}" \
+  OPENCLAW_AGENT="${OPENCLAW_AGENT}" python3 - <<'PY'
+import json, os
+path = os.environ["OC_CONFIG"]
+models = os.environ["VERTEX_MODELS"].split()
+agent = os.environ["OPENCLAW_AGENT"]
+with open(path) as f:
+    cfg = json.load(f)
+prov = cfg.setdefault("models", {}).setdefault("providers", {}).setdefault("google-vertex", {})
+prov["api"] = "google-vertex"
+prov["baseUrl"] = "https://{location}-aiplatform.googleapis.com"
+existing = {m.get("id") for m in prov.get("models", []) if isinstance(m, dict)}
+prov.setdefault("models", [])
+for m in models:
+    if m not in existing:
+        prov["models"].append({"id": m, "name": m})
+# Allowlist google-vertex/<model> for the agent's per-run --model override.
+allow = cfg.setdefault("agents", {}).setdefault("defaults", {}).setdefault("models", {})
+for m in models:
+    allow.setdefault(f"google-vertex/{m}", {})
+with open(path, "w") as f:
+    json.dump(cfg, f, indent=2)
+print(f"==> google-vertex provider registered + allowlisted: {', '.join(models)}")
+PY
+else
+  echo "==> google-vertex provider NOT registered (use --vertex for Vertex/ADC runs)"
+fi
+
+echo "==> oc configured (mcp=${WANT_MCP} skills=${WANT_SKILLS} vertex=${WANT_VERTEX}). 'oc mcp list' / 'oc skills list' to verify."

--- a/scripts/bastion/configure-oc.sh
+++ b/scripts/bastion/configure-oc.sh
@@ -38,7 +38,8 @@
 # which is what makes auth portable across parallel runs' isolated state dirs.
 #
 # Env overrides:
-#   GKE_MCP_BIN    path to the gke-mcp binary    (default: ~/gke-mcp)
+#   MCP_SERVER_BIN path to the MCP server binary  (default: ~/gke-mcp, the
+#                  server this bastion installs)
 #   SECRETS_ENV    file exporting GEMINI_API_KEY  (default: ~/secrets.env)
 #   SKILLS_SRC     dir of skill markdowns         (default: ~/devops-bench/skills)
 #   OC_SKILLS_DIR  staging dir for <name>/SKILL.md (default: ~/oc-skills)
@@ -54,7 +55,7 @@ set -euo pipefail
 WANT_MCP=1
 WANT_SKILLS=1
 WANT_VERTEX=0
-GKE_MCP_BIN="${GKE_MCP_BIN:-${HOME}/gke-mcp}"
+MCP_SERVER_BIN="${MCP_SERVER_BIN:-${HOME}/gke-mcp}"
 SECRETS_ENV="${SECRETS_ENV:-${HOME}/secrets.env}"
 SKILLS_SRC="${SKILLS_SRC:-${HOME}/devops-bench/skills}"
 OC_SKILLS_DIR="${OC_SKILLS_DIR:-${HOME}/oc-skills}"
@@ -140,8 +141,8 @@ fi
 # --- 2. GKE MCP server ------------------------------------------------------ #
 oc mcp unset gke-mcp >/dev/null 2>&1 || true   # idempotent: clear any prior entry
 if [ "${WANT_MCP}" = "1" ]; then
-  [ -x "${GKE_MCP_BIN}" ] || { echo "ERROR: gke-mcp not executable at ${GKE_MCP_BIN}" >&2; exit 1; }
-  oc mcp add gke-mcp --command "${GKE_MCP_BIN}" --no-probe >/dev/null
+  [ -x "${MCP_SERVER_BIN}" ] || { echo "ERROR: gke-mcp not executable at ${MCP_SERVER_BIN}" >&2; exit 1; }
+  oc mcp add gke-mcp --command "${MCP_SERVER_BIN}" --no-probe >/dev/null
   echo "==> gke-mcp registered (global oc config)"
 else
   echo "==> gke-mcp NOT registered (--no-mcp)"

--- a/scripts/bastion/configure-oc.sh
+++ b/scripts/bastion/configure-oc.sh
@@ -141,7 +141,7 @@ fi
 # --- 2. GKE MCP server ------------------------------------------------------ #
 oc mcp unset gke-mcp >/dev/null 2>&1 || true   # idempotent: clear any prior entry
 if [ "${WANT_MCP}" = "1" ]; then
-  [ -x "${MCP_SERVER_BIN}" ] || { echo "ERROR: gke-mcp not executable at ${MCP_SERVER_BIN}" >&2; exit 1; }
+  [ -x "${MCP_SERVER_BIN}" ] || { echo "ERROR: MCP server binary not executable at ${MCP_SERVER_BIN}" >&2; exit 1; }
   oc mcp add gke-mcp --command "${MCP_SERVER_BIN}" --no-probe >/dev/null
   echo "==> gke-mcp registered (global oc config)"
 else

--- a/scripts/bastion/configure-oc.sh
+++ b/scripts/bastion/configure-oc.sh
@@ -38,8 +38,8 @@
 # which is what makes auth portable across parallel runs' isolated state dirs.
 #
 # Env overrides:
-#   MCP_SERVER_BIN path to the MCP server binary  (default: ~/gke-mcp, the
-#                  server this bastion installs)
+#   MCP_SERVER_BIN path to the MCP server binary  (default: the server this
+#                  bastion installs, at /usr/local/bin/gke-mcp)
 #   SECRETS_ENV    file exporting GEMINI_API_KEY  (default: ~/secrets.env)
 #   SKILLS_SRC     dir of skill markdowns         (default: ~/devops-bench/skills)
 #   OC_SKILLS_DIR  staging dir for <name>/SKILL.md (default: ~/oc-skills)
@@ -55,7 +55,7 @@ set -euo pipefail
 WANT_MCP=1
 WANT_SKILLS=1
 WANT_VERTEX=0
-MCP_SERVER_BIN="${MCP_SERVER_BIN:-${HOME}/gke-mcp}"
+MCP_SERVER_BIN="${MCP_SERVER_BIN:-/usr/local/bin/gke-mcp}"
 SECRETS_ENV="${SECRETS_ENV:-${HOME}/secrets.env}"
 SKILLS_SRC="${SKILLS_SRC:-${HOME}/devops-bench/skills}"
 OC_SKILLS_DIR="${OC_SKILLS_DIR:-${HOME}/oc-skills}"
@@ -138,7 +138,7 @@ print(f"==> google (genai) catalog overrides registered: {', '.join(models)}")
 PY
 fi
 
-# --- 2. GKE MCP server ------------------------------------------------------ #
+# --- 2. MCP server ---------------------------------------------------------- #
 oc mcp unset gke-mcp >/dev/null 2>&1 || true   # idempotent: clear any prior entry
 if [ "${WANT_MCP}" = "1" ]; then
   [ -x "${MCP_SERVER_BIN}" ] || { echo "ERROR: MCP server binary not executable at ${MCP_SERVER_BIN}" >&2; exit 1; }

--- a/scripts/bastion/run_matrix.sh
+++ b/scripts/bastion/run_matrix.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Parallel eval matrix — REFACTORED arm (python -m devops_bench). Runs locally by
+# default; set BENCH_REMOTE=1 to sync + run on the bastion over ssh.
+# Dimensions: Task x Model x AgentConfig. Run from your workstation; results are
+# copied back locally. (Legacy arm: scripts/bastion/run_matrix_legacy.sh.)
+#
+# Agent-config presets: "<oc|gcli>[+mcp][+skills]" (oc=openclaw, gcli=gemini).
+# The refactored arm wires MCP/skills per-run via env, so every combo is fully
+# independent. CUJs:
+#
+#   1) one task, many models, one config
+#      MATRIX_TASKS="tasks/gcp/secret-rotation/task.yaml" \
+#      MATRIX_MODELS="gemini-3.1-pro gemini-3.5-flash" \
+#      MATRIX_AGENT_CONFIGS="gcli+mcp+skills" GCP_PROJECT_ID=<proj> run_matrix.sh
+#
+#   2) one task, one model, many configs
+#      MATRIX_AGENT_CONFIGS="oc oc+mcp+skills gcli gcli+mcp+skills" ... run_matrix.sh
+#
+#   3) all tasks, one model, one config
+#      MATRIX_TASKS=ALL MATRIX_MODELS="gemini-3.1-pro" MATRIX_AGENT_CONFIGS="oc+mcp+skills" ... run_matrix.sh
+#
+# DRY_RUN=1 prints the expanded matrix + per-combo env without provisioning.
+# See _matrix_lib.sh for the full connection/run-config env and docs/components/bastion.md.
+set -euo pipefail
+
+# shellcheck source=scripts/bastion/_matrix_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_matrix_lib.sh"
+
+MATRIX_AGENT_CONFIGS="${MATRIX_AGENT_CONFIGS:-oc+mcp+skills}"
+
+# Translate an agent-config preset into the refactored arm's env (';'-joined).
+# <type> is oc|gcli; +mcp / +skills toggle capabilities.
+agent_config_env() {
+  local preset="$1" type feat want_mcp=0 want_skills=0 out=()
+  type="${preset%%+*}"
+  case "$type" in
+    oc)   out+=("BENCH_AGENT_TYPE=openclaw" "AGENT_TARGET=oc" "OPENCLAW_BIN=oc" "OPENCLAW_AGENT=main") ;;
+    gcli) out+=("BENCH_AGENT_TYPE=cli" "AGENT_TARGET=gemini") ;;
+    *) echo "ERROR: unknown agent type '${type}' in preset '${preset}'" >&2; return 1 ;;
+  esac
+  for feat in $(echo "${preset}" | tr '+' ' '); do
+    case "$feat" in mcp) want_mcp=1 ;; skills) want_skills=1 ;; esac
+  done
+  if [ "${want_mcp}" = 1 ]; then out+=("BENCH_USE_MCP=true" "AGENT_MCP_SERVER=${GKE_MCP_BIN}"); else out+=("BENCH_USE_MCP=false"); fi
+  [ "${want_skills}" = 1 ] && out+=("AGENT_SKILLS_PATHS=${SKILLS_PATHS}")
+  ( IFS=';'; echo "${out[*]}" )
+}
+
+COMBOS=()
+while IFS= read -r task; do
+  [ -n "${task}" ] || continue
+  tname="$(basename "$(dirname "${task}")")"
+  for model in ${MATRIX_MODELS}; do
+    for preset in ${MATRIX_AGENT_CONFIGS}; do
+      cfg="$(agent_config_env "${preset}")" || exit 1
+      kvs="AGENT_MODEL=${model};AGENT_PROVIDER=${AGENT_PROVIDER};${cfg}$(task_extra_env "${task}")"
+      rid="$(sanitize "${tname}")__$(sanitize "${model}")__$(sanitize "${preset}")"
+      COMBOS+=("${rid}|${task}|${kvs}|refactored")
+    done
+  done
+done < <(resolve_tasks)
+
+matrix_dispatch "refactored (Task x Model x AgentConfig)"

--- a/scripts/bastion/run_matrix.sh
+++ b/scripts/bastion/run_matrix.sh
@@ -49,7 +49,9 @@ agent_config_env() {
   type="${preset%%+*}"
   case "$type" in
     oc)   out+=("BENCH_AGENT_TYPE=openclaw" "AGENT_TARGET=oc" "OPENCLAW_BIN=oc" "OPENCLAW_AGENT=main") ;;
-    gcli) out+=("BENCH_AGENT_TYPE=cli" "AGENT_TARGET=gemini") ;;
+    # "gemini" is the registered agent key; "cli" matches neither a registered
+    # agent nor the gemini-cli alias, so it fails at agent resolution.
+    gcli) out+=("BENCH_AGENT_TYPE=gemini" "AGENT_TARGET=gemini") ;;
     *) echo "ERROR: unknown agent type '${type}' in preset '${preset}'" >&2; return 1 ;;
   esac
   for feat in $(echo "${preset}" | tr '+' ' '); do

--- a/scripts/bastion/run_matrix.sh
+++ b/scripts/bastion/run_matrix.sh
@@ -57,7 +57,7 @@ agent_config_env() {
   for feat in $(echo "${preset}" | tr '+' ' '); do
     case "$feat" in mcp) want_mcp=1 ;; skills) want_skills=1 ;; esac
   done
-  if [ "${want_mcp}" = 1 ]; then out+=("BENCH_USE_MCP=true" "AGENT_MCP_SERVER=${GKE_MCP_BIN}"); else out+=("BENCH_USE_MCP=false"); fi
+  if [ "${want_mcp}" = 1 ]; then out+=("BENCH_USE_MCP=true" "AGENT_MCP_SERVER=${MCP_SERVER_BIN}"); else out+=("BENCH_USE_MCP=false"); fi
   [ "${want_skills}" = 1 ] && out+=("AGENT_SKILLS_PATHS=${SKILLS_PATHS}")
   ( IFS=';'; echo "${out[*]}" )
 }

--- a/scripts/bastion/run_matrix.sh
+++ b/scripts/bastion/run_matrix.sh
@@ -23,9 +23,9 @@
 # independent. CUJs:
 #
 #   1) one task, many models, one config
-#      MATRIX_TASKS="tasks/gcp/secret-rotation/task.yaml" \
+#      MATRIX_TASKS="tasks/common/opa-remediation/task.yaml" \
 #      MATRIX_MODELS="gemini-3.1-pro gemini-3.5-flash" \
-#      MATRIX_AGENT_CONFIGS="gcli+mcp+skills" GCP_PROJECT_ID=<proj> run_matrix.sh
+#      MATRIX_AGENT_CONFIGS="gcli+mcp+skills" PROJECT_ID=<proj> run_matrix.sh
 #
 #   2) one task, one model, many configs
 #      MATRIX_AGENT_CONFIGS="oc oc+mcp+skills gcli gcli+mcp+skills" ... run_matrix.sh

--- a/scripts/bastion/run_matrix_legacy.sh
+++ b/scripts/bastion/run_matrix_legacy.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Parallel eval matrix — LEGACY arm (pkg/evaluator/evaluate.py). Runs locally by
+# default; set BENCH_REMOTE=1 to sync + run on the bastion over ssh.
+# Dimensions: Task x Model ONLY (no AgentConfig — the legacy arm reads MCP/skills
+# from the GLOBAL ~/.openclaw config, so capabilities are fixed for the whole
+# matrix; set them once with scripts/bastion/configure-oc.sh).
+#
+# This is a thin, throwaway companion to run_matrix.sh (the refactored matrix);
+# delete it when the legacy arm is retired — the shared _matrix_lib.sh stays.
+#
+# OpenClaw-only BY DESIGN, not just by default: the legacy Gemini runner reads
+# its trajectory from the shared ~/.gemini/tmp/.../chats dir keyed by a short
+# session id, which is NOT safe under concurrent runs. For parallel Gemini use
+# the refactored matrix (run_matrix.sh, MATRIX_AGENT_CONFIGS="gcli..."). See
+# docs/components/bastion.md "Parallel agent support".
+#
+# CUJs supported: one task x many models, and all tasks x one model. E.g.:
+#   MATRIX_TASKS="tasks/gcp/secret-rotation/task.yaml" \
+#   MATRIX_MODELS="gemini-3.1-pro gemini-3.5-flash" \
+#   GCP_PROJECT_ID=<proj> run_matrix_legacy.sh
+#
+#   MATRIX_TASKS=ALL MATRIX_MODELS="gemini-3.1-pro" GCP_PROJECT_ID=<proj> run_matrix_legacy.sh
+#
+# Prereq: run `scripts/bastion/configure-oc.sh --mcp --skills` (or --no-*) once
+# to set the global oc config the legacy arm uses. DRY_RUN=1 previews the matrix.
+set -euo pipefail
+
+# shellcheck source=scripts/bastion/_matrix_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_matrix_lib.sh"
+
+# Legacy openclaw (local) env — fixed; capabilities come from the global oc config.
+LEGACY_KVS="BENCH_AGENT_TYPE=cli;AGENT_TARGET=oc;OPENCLAW_BIN=oc;OPENCLAW_LOCAL=true;OPENCLAW_AGENT=main"
+
+COMBOS=()
+while IFS= read -r task; do
+  [ -n "${task}" ] || continue
+  tname="$(basename "$(dirname "${task}")")"
+  for model in ${MATRIX_MODELS}; do
+    kvs="AGENT_MODEL=${model};AGENT_PROVIDER=${AGENT_PROVIDER};${LEGACY_KVS}$(task_extra_env "${task}")"
+    rid="$(sanitize "${tname}")__$(sanitize "${model}")__legacy"
+    COMBOS+=("${rid}|${task}|${kvs}|legacy")
+  done
+done < <(resolve_tasks)
+
+matrix_dispatch "legacy (Task x Model)"

--- a/scripts/bastion/run_matrix_legacy.sh
+++ b/scripts/bastion/run_matrix_legacy.sh
@@ -29,11 +29,11 @@
 # docs/components/bastion.md "Parallel agent support".
 #
 # CUJs supported: one task x many models, and all tasks x one model. E.g.:
-#   MATRIX_TASKS="tasks/gcp/secret-rotation/task.yaml" \
+#   MATRIX_TASKS="tasks/common/opa-remediation/task.yaml" \
 #   MATRIX_MODELS="gemini-3.1-pro gemini-3.5-flash" \
-#   GCP_PROJECT_ID=<proj> run_matrix_legacy.sh
+#   PROJECT_ID=<proj> run_matrix_legacy.sh
 #
-#   MATRIX_TASKS=ALL MATRIX_MODELS="gemini-3.1-pro" GCP_PROJECT_ID=<proj> run_matrix_legacy.sh
+#   MATRIX_TASKS=ALL MATRIX_MODELS="gemini-3.1-pro" PROJECT_ID=<proj> run_matrix_legacy.sh
 #
 # Prereq: run `scripts/bastion/configure-oc.sh --mcp --skills` (or --no-*) once
 # to set the global oc config the legacy arm uses. DRY_RUN=1 previews the matrix.

--- a/scripts/bastion/sync-to-bastion.sh
+++ b/scripts/bastion/sync-to-bastion.sh
@@ -94,17 +94,14 @@ COPYFILE_DISABLE=1 tar \
 
 # Transport selection. Default: gcloud IAP tunnel (works on a standard GCP
 # project). Override for special environments (e.g. Google corp hosts reachable
-# at nic0.<vm>.<zone>.c.<project>.internal.gcpnode.com) WITHOUT changing the
-# default by setting either:
-#   BASTION_SSH_HOST   explicit host to ssh/scp to (raw ssh, no gcloud), or
-#   BASTION_USE_GCPNODE=1   auto-build the gcpnode host from VM/zone/project.
-# BASTION_SSH_USER overrides the login user (default for the gcpnode form is
-# "<localuser>_google_com", matching that environment's convention).
+# reachable directly over SSH) WITHOUT changing the default by setting:
+#   BASTION_SSH_HOST   explicit host to ssh/scp to (raw ssh, no gcloud)
+#   BASTION_SSH_USER   login user for that host (defaults to the local user)
 upload_archive() { :; }
 remote_exec() { :; }
-if [ -n "${BASTION_SSH_HOST:-}" ] || [ "${BASTION_USE_GCPNODE:-}" = "1" ]; then
-  SSH_HOST="${BASTION_SSH_HOST:-nic0.${BASTION_VM}.${BASTION_ZONE}.c.${BASTION_PROJECT}.internal.gcpnode.com}"
-  SSH_USER="${BASTION_SSH_USER:-$(id -un)_google_com}"
+if [ -n "${BASTION_SSH_HOST:-}" ]; then
+  SSH_HOST="${BASTION_SSH_HOST}"
+  SSH_USER="${BASTION_SSH_USER:-$(id -un)}"
   SSH_TARGET="${SSH_USER}@${SSH_HOST}"
   echo "==> transport: direct ssh to ${SSH_TARGET}"
   upload_archive() { scp "${ARCHIVE}" "${SSH_TARGET}:${REMOTE_ARCHIVE}"; }

--- a/scripts/bastion/sync-to-bastion.sh
+++ b/scripts/bastion/sync-to-bastion.sh
@@ -103,9 +103,12 @@ if [ -n "${BASTION_SSH_HOST:-}" ]; then
   SSH_HOST="${BASTION_SSH_HOST}"
   SSH_USER="${BASTION_SSH_USER:-$(id -un)}"
   SSH_TARGET="${SSH_USER}@${SSH_HOST}"
+  # Same options as _matrix_lib.sh: no interactive prompts, and keepalive so the
+  # transfer rides out brief network blips instead of hanging.
+  _SSH_KA=(-o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=4 -o ConnectTimeout=30)
   echo "==> transport: direct ssh to ${SSH_TARGET}"
-  upload_archive() { scp "${ARCHIVE}" "${SSH_TARGET}:${REMOTE_ARCHIVE}"; }
-  remote_exec() { ssh "${SSH_TARGET}" "$1"; }
+  upload_archive() { scp "${_SSH_KA[@]}" "${ARCHIVE}" "${SSH_TARGET}:${REMOTE_ARCHIVE}"; }
+  remote_exec() { ssh "${_SSH_KA[@]}" "${SSH_TARGET}" "$1"; }
 else
   echo "==> transport: gcloud compute ssh over IAP"
   upload_archive() {

--- a/scripts/bastion/sync-to-bastion.sh
+++ b/scripts/bastion/sync-to-bastion.sh
@@ -103,9 +103,10 @@ if [ -n "${BASTION_SSH_HOST:-}" ]; then
   SSH_HOST="${BASTION_SSH_HOST}"
   SSH_USER="${BASTION_SSH_USER:-$(id -un)}"
   SSH_TARGET="${SSH_USER}@${SSH_HOST}"
-  # Same options as _matrix_lib.sh: no interactive prompts, and keepalive so the
-  # transfer rides out brief network blips instead of hanging.
-  _SSH_KA=(-o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=4 -o ConnectTimeout=30)
+  # Bound the connection so a stalled network cannot hang the sync. No BatchMode
+  # here (unlike _matrix_lib.sh's detached poller): this step is run by hand and
+  # must still be able to prompt for a host key on the first connection.
+  _SSH_KA=(-o ServerAliveInterval=30 -o ServerAliveCountMax=4 -o ConnectTimeout=30)
   echo "==> transport: direct ssh to ${SSH_TARGET}"
   upload_archive() { scp "${_SSH_KA[@]}" "${ARCHIVE}" "${SSH_TARGET}:${REMOTE_ARCHIVE}"; }
   remote_exec() { ssh "${_SSH_KA[@]}" "${SSH_TARGET}" "$1"; }

--- a/scripts/bastion/sync-to-bastion.sh
+++ b/scripts/bastion/sync-to-bastion.sh
@@ -27,7 +27,7 @@
 # Env overrides:
 #   BASTION_VM       VM name        (default: bench-bastion)
 #   BASTION_ZONE     VM zone        (default: us-central1-a)
-#   BASTION_PROJECT  GCP project    (default: gcloud's active project)
+#   BASTION_PROJECT  cloud project    (default: gcloud's active project)
 #   REMOTE_DIR       dir on the VM  (default: ~/devops-bench)
 set -euo pipefail
 

--- a/scripts/bastion/sync-to-bastion.sh
+++ b/scripts/bastion/sync-to-bastion.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Push the LOCAL working tree (including uncommitted/unpushed changes) to the
+# bastion, so the harness on the VM runs exactly the code you have locally.
+#
+# Only the subset the harness needs is shipped (python + task + infra + docker
+# entrypoint); .git, virtualenvs, tofu state, caches and results are excluded.
+# It tars the subset, scps the single archive over IAP, and extracts it into
+# ~/devops-bench on the VM.
+#
+# Usage (from anywhere in the repo):
+#   scripts/bastion/sync-to-bastion.sh
+#
+# Env overrides:
+#   BASTION_VM       VM name        (default: bench-bastion)
+#   BASTION_ZONE     VM zone        (default: us-central1-a)
+#   BASTION_PROJECT  GCP project    (default: gcloud's active project)
+#   REMOTE_DIR       dir on the VM  (default: ~/devops-bench)
+set -euo pipefail
+
+BASTION_VM="${BASTION_VM:-bench-bastion}"
+BASTION_ZONE="${BASTION_ZONE:-us-central1-a}"
+BASTION_PROJECT="${BASTION_PROJECT:-$(gcloud config get-value project 2>/dev/null)}"
+REMOTE_DIR="${REMOTE_DIR:-devops-bench}" # relative to the SSH user's $HOME
+
+if [ -z "${BASTION_PROJECT}" ]; then
+  echo "ERROR: no project. Set BASTION_PROJECT or run 'gcloud config set project <id>'." >&2
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+# The subset the harness needs on the VM. Missing paths are skipped silently.
+PATHS=(
+  devops_bench
+  pkg               # legacy arm (pkg/evaluator/evaluate.py etc.) for comparison runs
+  deployers         # legacy top-level deployers used by the legacy arm
+  skills            # judge/agent skill markdowns (legacy metrics read skills/*.md)
+  pyproject.toml
+  README.md         # required by `pip install .` (pyproject readme = README.md)
+  LICENSE
+  tasks
+  tf
+  scripts
+  Dockerfile.harness
+)
+PRESENT=()
+for p in "${PATHS[@]}"; do
+  [ -e "${p}" ] && PRESENT+=("${p}")
+done
+
+ARCHIVE="$(mktemp -t bench-sync-XXXXXX).tgz"
+trap 'rm -f "${ARCHIVE}"' EXIT
+
+echo "==> packing $(printf '%s ' "${PRESENT[@]}")"
+# COPYFILE_DISABLE=1 stops macOS bsdtar from emitting AppleDouble (``._*``) entries
+# that extract as junk files on Linux and break manifest globs (e.g. kubectl
+# parsing ``._policy.yaml``). Harmless on Linux hosts.
+# NOTE: do NOT add `--exclude='results'` — the eval-output `results/` dir lives at
+# the repo root and is already excluded by not being in the synced path allowlist
+# (PATHS). A bare `results` pattern matches ANY path component, so it also strips
+# the `devops_bench/results/` SOURCE module (the rows.json/manifest.json builder),
+# which silently disables leaderboard-row generation on the bastion.
+COPYFILE_DISABLE=1 tar \
+  --exclude='.git' \
+  --exclude='.venv' \
+  --exclude='__pycache__' \
+  --exclude='.terraform' \
+  --exclude='*.tfstate' \
+  --exclude='*.tfstate.*' \
+  --exclude='.pytest_cache' \
+  --exclude='.ruff_cache' \
+  -czf "${ARCHIVE}" "${PRESENT[@]}"
+
+# Transport selection. Default: gcloud IAP tunnel (works on a standard GCP
+# project). Override for special environments (e.g. Google corp hosts reachable
+# at nic0.<vm>.<zone>.c.<project>.internal.gcpnode.com) WITHOUT changing the
+# default by setting either:
+#   BASTION_SSH_HOST   explicit host to ssh/scp to (raw ssh, no gcloud), or
+#   BASTION_USE_GCPNODE=1   auto-build the gcpnode host from VM/zone/project.
+# BASTION_SSH_USER overrides the login user (default for the gcpnode form is
+# "<localuser>_google_com", matching that environment's convention).
+upload_archive() { :; }
+remote_exec() { :; }
+if [ -n "${BASTION_SSH_HOST:-}" ] || [ "${BASTION_USE_GCPNODE:-}" = "1" ]; then
+  SSH_HOST="${BASTION_SSH_HOST:-nic0.${BASTION_VM}.${BASTION_ZONE}.c.${BASTION_PROJECT}.internal.gcpnode.com}"
+  SSH_USER="${BASTION_SSH_USER:-$(id -un)_google_com}"
+  SSH_TARGET="${SSH_USER}@${SSH_HOST}"
+  echo "==> transport: direct ssh to ${SSH_TARGET}"
+  upload_archive() { scp "${ARCHIVE}" "${SSH_TARGET}:/tmp/bench-sync.tgz"; }
+  remote_exec() { ssh "${SSH_TARGET}" "$1"; }
+else
+  echo "==> transport: gcloud compute ssh over IAP"
+  upload_archive() {
+    gcloud compute scp --tunnel-through-iap --zone "${BASTION_ZONE}" \
+      --project "${BASTION_PROJECT}" "${ARCHIVE}" "${BASTION_VM}:/tmp/bench-sync.tgz"
+  }
+  remote_exec() {
+    gcloud compute ssh "${BASTION_VM}" --tunnel-through-iap --zone "${BASTION_ZONE}" \
+      --project "${BASTION_PROJECT}" --command "$1"
+  }
+fi
+
+echo "==> uploading archive to ${BASTION_VM}"
+upload_archive
+
+echo "==> extracting into ~/${REMOTE_DIR} on the VM"
+remote_exec "set -e; mkdir -p ~/${REMOTE_DIR}; tar --no-xattrs -xzf /tmp/bench-sync.tgz -C ~/${REMOTE_DIR}; rm -f /tmp/bench-sync.tgz; echo 'synced to ~/${REMOTE_DIR}'"
+
+echo "==> done. Next: SSH in and run scripts/bastion/vm-setup.sh"

--- a/scripts/bastion/sync-to-bastion.sh
+++ b/scripts/bastion/sync-to-bastion.sh
@@ -66,6 +66,12 @@ done
 ARCHIVE="$(mktemp -t bench-sync-XXXXXX).tgz"
 trap 'rm -f "${ARCHIVE}"' EXIT
 
+# Upload into the login user's home, not the shared /tmp: a fixed /tmp name lets
+# any other local user on the VM pre-create the path (or symlink it elsewhere)
+# and swap what gets extracted. Per-invocation suffix so two concurrent syncs
+# do not collide.
+REMOTE_ARCHIVE=".bench-sync-$$-$(date +%s).tgz"
+
 echo "==> packing $(printf '%s ' "${PRESENT[@]}")"
 # COPYFILE_DISABLE=1 stops macOS bsdtar from emitting AppleDouble (``._*``) entries
 # that extract as junk files on Linux and break manifest globs (e.g. kubectl
@@ -101,13 +107,13 @@ if [ -n "${BASTION_SSH_HOST:-}" ] || [ "${BASTION_USE_GCPNODE:-}" = "1" ]; then
   SSH_USER="${BASTION_SSH_USER:-$(id -un)_google_com}"
   SSH_TARGET="${SSH_USER}@${SSH_HOST}"
   echo "==> transport: direct ssh to ${SSH_TARGET}"
-  upload_archive() { scp "${ARCHIVE}" "${SSH_TARGET}:/tmp/bench-sync.tgz"; }
+  upload_archive() { scp "${ARCHIVE}" "${SSH_TARGET}:${REMOTE_ARCHIVE}"; }
   remote_exec() { ssh "${SSH_TARGET}" "$1"; }
 else
   echo "==> transport: gcloud compute ssh over IAP"
   upload_archive() {
     gcloud compute scp --tunnel-through-iap --zone "${BASTION_ZONE}" \
-      --project "${BASTION_PROJECT}" "${ARCHIVE}" "${BASTION_VM}:/tmp/bench-sync.tgz"
+      --project "${BASTION_PROJECT}" "${ARCHIVE}" "${BASTION_VM}:${REMOTE_ARCHIVE}"
   }
   remote_exec() {
     gcloud compute ssh "${BASTION_VM}" --tunnel-through-iap --zone "${BASTION_ZONE}" \
@@ -119,6 +125,6 @@ echo "==> uploading archive to ${BASTION_VM}"
 upload_archive
 
 echo "==> extracting into ~/${REMOTE_DIR} on the VM"
-remote_exec "set -e; mkdir -p ~/${REMOTE_DIR}; tar --no-xattrs -xzf /tmp/bench-sync.tgz -C ~/${REMOTE_DIR}; rm -f /tmp/bench-sync.tgz; echo 'synced to ~/${REMOTE_DIR}'"
+remote_exec "set -e; mkdir -p ~/${REMOTE_DIR}; tar --no-xattrs -xzf ~/${REMOTE_ARCHIVE} -C ~/${REMOTE_DIR}; rm -f ~/${REMOTE_ARCHIVE}; echo 'synced to ~/${REMOTE_DIR}'"
 
 echo "==> done. Next: SSH in and run scripts/bastion/vm-setup.sh"

--- a/scripts/bastion/sync-to-bastion.sh
+++ b/scripts/bastion/sync-to-bastion.sh
@@ -93,8 +93,8 @@ COPYFILE_DISABLE=1 tar \
   -czf "${ARCHIVE}" "${PRESENT[@]}"
 
 # Transport selection. Default: gcloud IAP tunnel (works on a standard GCP
-# project). Override for special environments (e.g. Google corp hosts reachable
-# reachable directly over SSH) WITHOUT changing the default by setting:
+# project). Override for an environment where the host is reachable directly
+# over SSH, WITHOUT changing the default, by setting:
 #   BASTION_SSH_HOST   explicit host to ssh/scp to (raw ssh, no gcloud)
 #   BASTION_SSH_USER   login user for that host (defaults to the local user)
 upload_archive() { :; }

--- a/scripts/bastion/vm-setup.sh
+++ b/scripts/bastion/vm-setup.sh
@@ -191,11 +191,15 @@ if [ ! -f "${ENV_FILE}" ]; then
   install -m 600 /dev/null "${ENV_FILE}"
   cat > "${ENV_FILE}" <<'EOF'
 # DevOps Bench harness environment. Fill in, then: source ~/bench.env
-# --- GCP target ---
-export GCP_PROJECT_ID=""
-export GKE_CLUSTER_NAME="secret-rotation-cluster"
+# --- Target infrastructure ---
+# PROJECT_ID and CLUSTER_NAME are what the harness reads.
+export PROJECT_ID=""
+export CLUSTER_NAME="bench-cluster"
+export NAMESPACE="bench-run-1"
+# The GCP provider and Vertex model auth resolve these directly; set them only
+# when running against GCP.
+export GCP_PROJECT_ID="$PROJECT_ID"
 export GCP_LOCATION="us-central1-a"
-export NAMESPACE="secret-rotation-run-1"
 
 # --- Agent (openclaw / oc) ---
 export BENCH_AGENT_TYPE="openclaw"
@@ -219,4 +223,4 @@ echo ""
 echo "==> setup complete. To run the secret-rotation eval:"
 echo "    source ~/bench.env   # after filling in project + keys"
 echo "    cd ${REPO_DIR} && source .venv/bin/activate"
-echo "    devops-bench tasks/gcp/secret-rotation/task.yaml"
+echo "    devops-bench tasks/common/opa-remediation/task.yaml"

--- a/scripts/bastion/vm-setup.sh
+++ b/scripts/bastion/vm-setup.sh
@@ -198,10 +198,10 @@ if [ ! -f "${ENV_FILE}" ]; then
 export PROJECT_ID=""
 export CLUSTER_NAME="bench-cluster"
 export NAMESPACE="bench-run-1"
-# The GCP provider and Vertex model auth resolve these directly; set them only
-# when running against GCP.
-export GCP_PROJECT_ID="$PROJECT_ID"
+# GCP only. GCP_LOCATION is read by the deployer factory; GCP_PROJECT_ID is read
+# by Vertex model auth. Leave both unset when running against another provider.
 export GCP_LOCATION="us-central1-a"
+export GCP_PROJECT_ID="$PROJECT_ID"
 
 # --- Agent (openclaw / oc) ---
 export BENCH_AGENT_TYPE="openclaw"

--- a/scripts/bastion/vm-setup.sh
+++ b/scripts/bastion/vm-setup.sh
@@ -145,12 +145,11 @@ fi
 # bastion installs GoogleCloudPlatform/gke-mcp; point MCP_SKILLS_REPO at another
 # server's checkout to use different skills.
 # (oc/gcli). The refactored matrix points AGENT_SKILLS_PATHS at this repo's
-# skills/ dir (19 SKILL.md skills: gke-compute-class-creator, gke-workload-scaling,
-# gke-networking-edge, gke-productionize, ...). These are operational skills, NOT
-# the judge rubric markdown under ~/oc-skills. Clone to a stable path OUTSIDE the
-# synced ~/devops-bench tree so sync-to-bastion never clobbers it. Idempotent.
+# skills/ dir. These are operational skills, NOT the judge rubric markdown under
+# ~/oc-skills. Clone to a stable path OUTSIDE the synced ~/devops-bench tree so
+# sync-to-bastion never clobbers it. Idempotent.
 echo "==> gke-mcp skills check (agent +skills source)"
-MCP_SKILLS_REPO="${MCP_SKILLS_REPO:-${HOME}/gke-mcp-repo}"
+MCP_SKILLS_REPO="${MCP_SKILLS_REPO:-${HOME}/mcp-skills}"
 if [ -d "${MCP_SKILLS_REPO}/skills" ]; then
   echo "    present: ${MCP_SKILLS_REPO}/skills ($(find "${MCP_SKILLS_REPO}/skills" -name SKILL.md 2>/dev/null | wc -l) skills)"
 else

--- a/scripts/bastion/vm-setup.sh
+++ b/scripts/bastion/vm-setup.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Per-user setup, run ONCE on the bastion after the first sync-to-bastion.sh.
+#
+# The system toolchain (tofu, gcloud, kubectl, node, oc) is already installed by
+# the VM startup script. This finishes the user-scoped pieces: a Python venv with
+# the harness installed, an openclaw API key, and a ~/bench.env template.
+#
+# Usage (on the VM):
+#   ~/devops-bench/scripts/bastion/vm-setup.sh
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-${HOME}/devops-bench}"
+ENV_FILE="${HOME}/bench.env"
+
+if [ ! -f "${REPO_DIR}/pyproject.toml" ]; then
+  echo "ERROR: ${REPO_DIR}/pyproject.toml not found. Run sync-to-bastion.sh from your laptop first." >&2
+  exit 1
+fi
+
+# Wait for the startup-script toolchain in case the VM only just booted.
+if [ ! -f /var/lib/bench-bastion-ready ]; then
+  echo "==> waiting for VM startup toolchain (/var/lib/bench-bastion-ready)..."
+  for _ in $(seq 1 60); do
+    [ -f /var/lib/bench-bastion-ready ] && break
+    sleep 5
+  done
+  # The loop falls through on timeout; fail loudly instead of proceeding
+  # against a half-provisioned VM (toolchain not yet installed).
+  if [ ! -f /var/lib/bench-bastion-ready ]; then
+    echo "ERROR: VM startup toolchain not ready after ~5m; aborting." >&2
+    exit 1
+  fi
+fi
+
+cd "${REPO_DIR}"
+
+echo "==> creating venv + installing the harness (uv sync --extra all)"
+# uv is installed system-wide by the VM startup script. It creates/manages .venv
+# from the lockfile, so we don't hand-roll a venv or use pip here.
+uv sync --frozen --extra all
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+echo "==> openclaw key check"
+# The harness does NOT pass an API key to oc; openclaw must hold the agent
+# model's key itself. Persist it once with the interactive wizard:
+#     openclaw onboard
+# or export the provider key (e.g. GEMINI_API_KEY / ANTHROPIC_API_KEY) before
+# running the harness. We don't store the key here to keep it off disk in plain
+# text beyond openclaw's own config.
+if oc models list >/dev/null 2>&1; then
+  echo "    oc reachable."
+else
+  echo "    NOTE: run 'openclaw onboard' to configure the agent model API key."
+fi
+
+# Gemini CLI (the 'gemini' agent target for gcli runs). oc is installed
+# system-wide by startup.sh; this finishes the other agent CLI. Node's global
+# prefix is root-owned, so install with sudo. Idempotent.
+echo "==> gemini CLI check"
+if command -v gemini >/dev/null 2>&1; then
+  echo "    gemini present: $(gemini --version 2>/dev/null | head -1)"
+else
+  echo "    installing @google/gemini-cli (sudo npm -g)..."
+  sudo npm install -g @google/gemini-cli \
+    && echo "    gemini installed: $(gemini --version 2>/dev/null | head -1)" \
+    || echo "    WARN: gemini CLI install failed; gcli agent runs will not work until it's installed."
+fi
+
+# fortio — the load generator the chaos agent shells out to for `generate_load`
+# faults (e.g. the optimize-scale load spike). The chaos system instruction tells
+# the agent to use the `fortio` binary; without it on PATH the spike is a silent
+# no-op (the run can still "pass" via the agent's HPA minReplicas, but the load is
+# never actually applied). Install to ~/bin (idempotent).
+echo "==> fortio check (chaos load generator)"
+if command -v fortio >/dev/null 2>&1; then
+  echo "    fortio present: $(fortio version 2>/dev/null | head -1)"
+else
+  echo "    installing fortio to ~/bin..."
+  FORTIO_VERSION="${FORTIO_VERSION:-1.66.4}"
+  mkdir -p "${HOME}/bin"
+  if curl -fsSL -o /tmp/fortio.tgz \
+       "https://github.com/fortio/fortio/releases/download/v${FORTIO_VERSION}/fortio-linux_amd64-${FORTIO_VERSION}.tgz" \
+     && tar -xzf /tmp/fortio.tgz -C /tmp 2>/dev/null \
+     && cp "$(find /tmp -maxdepth 4 -name fortio -type f 2>/dev/null | head -1)" "${HOME}/bin/fortio" \
+     && chmod +x "${HOME}/bin/fortio"; then
+    echo "    fortio installed: $("${HOME}/bin/fortio" version 2>/dev/null | head -1)"
+  else
+    echo "    WARN: fortio install failed; chaos generate_load faults (optimize-scale) will no-op."
+  fi
+fi
+
+# node on a stable PATH — the oc trajectory extraction (`oc sessions` /
+# `export-trajectory`) runs oc as a direct, non-login subprocess, so an
+# nvm-managed Node that's only on the *login* PATH isn't found → `oc sessions`
+# exits 127 and the trajectory is silently emptied (deflating every score).
+# Symlink the nvm Node into ~/bin (already on the runner PATH) so the direct
+# subprocess resolves it. Idempotent; no-op when Node is already system-wide.
+echo "==> node-on-PATH check (oc trajectory extraction)"
+if PATH="${HOME}/bin:${PATH}" command -v node >/dev/null 2>&1; then
+  echo "    node resolvable on the runner PATH: $(PATH="${HOME}/bin:${PATH}" command -v node)"
+else
+  export NVM_DIR="${NVM_DIR:-${HOME}/.nvm}"; [ -s "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh"
+  NODE_BIN="$(command -v node 2>/dev/null)"
+  if [ -n "${NODE_BIN}" ]; then
+    mkdir -p "${HOME}/bin"; ln -sf "${NODE_BIN}" "${HOME}/bin/node"
+    echo "    linked ${HOME}/bin/node -> ${NODE_BIN}"
+  else
+    echo "    WARN: node not found; oc trajectory extraction will exit 127 and empty trajectories."
+  fi
+fi
+# The chaos agent runs `fortio` via run_command in a NON-login shell, whose PATH
+# does NOT include ~/bin — so symlink fortio into /usr/local/bin (which IS on the
+# default PATH). Without this the optimize-scale load spike silently no-ops even
+# though fortio is installed. Idempotent.
+if [ -x "${HOME}/bin/fortio" ] && [ ! -e /usr/local/bin/fortio ]; then
+  echo "==> symlinking fortio into /usr/local/bin (non-login PATH)"
+  sudo ln -sf "${HOME}/bin/fortio" /usr/local/bin/fortio \
+    && echo "    linked: $(command -v fortio)" \
+    || echo "    WARN: could not symlink fortio to /usr/local/bin; chaos may not find it."
+fi
+
+# gke-mcp operational skills — the source for the AGENT's +skills capability
+# (oc/gcli). The refactored matrix points AGENT_SKILLS_PATHS at this repo's
+# skills/ dir (19 SKILL.md skills: gke-compute-class-creator, gke-workload-scaling,
+# gke-networking-edge, gke-productionize, ...). These are operational skills, NOT
+# the judge rubric markdown under ~/oc-skills. Clone to a stable path OUTSIDE the
+# synced ~/devops-bench tree so sync-to-bastion never clobbers it. Idempotent.
+echo "==> gke-mcp skills check (agent +skills source)"
+GKE_MCP_REPO="${GKE_MCP_REPO:-${HOME}/gke-mcp-repo}"
+if [ -d "${GKE_MCP_REPO}/skills" ]; then
+  echo "    present: ${GKE_MCP_REPO}/skills ($(find "${GKE_MCP_REPO}/skills" -name SKILL.md 2>/dev/null | wc -l) skills)"
+else
+  echo "    cloning gke-mcp -> ${GKE_MCP_REPO}..."
+  if git clone --depth 1 https://github.com/GoogleCloudPlatform/gke-mcp "${GKE_MCP_REPO}"; then
+    echo "    gke-mcp skills ready ($(find "${GKE_MCP_REPO}/skills" -name SKILL.md 2>/dev/null | wc -l) skills)"
+  else
+    echo "    WARN: gke-mcp clone failed; agent +skills will be empty until it is cloned."
+  fi
+fi
+
+# Disable Gemini CLI folder-trust gating at the USER level. The gcli agent runs
+# in a fresh, untrusted per-run temp cwd; untrusted folders have their MCP
+# servers (e.g. gke-mcp) suppressed, and a workspace-level setting can't lift it
+# (untrusted folders ignore their own settings.json) — nor does the --skip-trust
+# flag. Setting it here lets gke-mcp connect for every run. Merge-preserving +
+# idempotent.
+echo "==> gemini folder-trust (~/.gemini/settings.json: security.folderTrust.enabled=false)"
+mkdir -p "${HOME}/.gemini"
+python3 - "${HOME}/.gemini/settings.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+try:
+    with open(path) as f:
+        cfg = json.load(f)
+    if not isinstance(cfg, dict):
+        cfg = {}
+except (FileNotFoundError, ValueError):
+    cfg = {}
+cfg.setdefault("security", {}).setdefault("folderTrust", {})["enabled"] = False
+with open(path, "w") as f:
+    json.dump(cfg, f, indent=2)
+print(f"    wrote {path}")
+PY
+
+if [ ! -f "${ENV_FILE}" ]; then
+  echo "==> writing ${ENV_FILE} template (fill in values, then 'source ~/bench.env')"
+  cat > "${ENV_FILE}" <<'EOF'
+# DevOps Bench harness environment. Fill in, then: source ~/bench.env
+# --- GCP target ---
+export GCP_PROJECT_ID=""
+export GKE_CLUSTER_NAME="secret-rotation-cluster"
+export GCP_LOCATION="us-central1-a"
+export NAMESPACE="secret-rotation-run-1"
+
+# --- Agent (openclaw / oc) ---
+export BENCH_AGENT_TYPE="openclaw"
+export AGENT_TARGET="oc"
+export AGENT_PROVIDER="google"
+export AGENT_MODEL="gemini-3.1-pro-preview"
+# Agent model key: prefer 'openclaw onboard'. If your provider reads an env key,
+# set it here too (e.g. GEMINI_API_KEY / ANTHROPIC_API_KEY).
+# export GEMINI_API_KEY=""
+
+# --- Judge ---
+export JUDGE_PROVIDER="google"
+export JUDGE_MODEL="gemini-3.1-pro-preview"
+export JUDGE_API_KEY=""
+EOF
+else
+  echo "==> ${ENV_FILE} already exists; leaving it untouched"
+fi
+
+echo ""
+echo "==> setup complete. To run the secret-rotation eval:"
+echo "    source ~/bench.env   # after filling in project + keys"
+echo "    cd ${REPO_DIR} && source .venv/bin/activate"
+echo "    devops-bench tasks/gcp/secret-rotation/task.yaml"

--- a/scripts/bastion/vm-setup.sh
+++ b/scripts/bastion/vm-setup.sh
@@ -48,10 +48,12 @@ fi
 
 cd "${REPO_DIR}"
 
-echo "==> creating venv + installing the harness (uv sync --extra all)"
+echo "==> creating venv + installing the harness"
 # uv is installed system-wide by the VM startup script. It creates/manages .venv
-# from the lockfile, so we don't hand-roll a venv or use pip here.
-uv sync --frozen --extra all
+# from the lockfile, so we don't hand-roll a venv or use pip here. The dev group
+# already pulls devops-bench[anthropic,openai], so a plain sync covers every
+# provider adapter.
+uv sync --frozen
 # shellcheck disable=SC1091
 source .venv/bin/activate
 
@@ -93,15 +95,20 @@ else
   echo "    installing fortio to ~/bin..."
   FORTIO_VERSION="${FORTIO_VERSION:-1.66.4}"
   mkdir -p "${HOME}/bin"
-  if curl -fsSL -o /tmp/fortio.tgz \
+  # Unpack in a private mktemp dir: the shared /tmp is writable by every local
+  # user, so a fixed download path can be pre-created and the `find` below could
+  # otherwise pick up a planted binary and install it as ~/bin/fortio.
+  FORTIO_TMP="$(mktemp -d)"
+  if curl -fsSL -o "${FORTIO_TMP}/fortio.tgz" \
        "https://github.com/fortio/fortio/releases/download/v${FORTIO_VERSION}/fortio-linux_amd64-${FORTIO_VERSION}.tgz" \
-     && tar -xzf /tmp/fortio.tgz -C /tmp 2>/dev/null \
-     && cp "$(find /tmp -maxdepth 4 -name fortio -type f 2>/dev/null | head -1)" "${HOME}/bin/fortio" \
+     && tar -xzf "${FORTIO_TMP}/fortio.tgz" -C "${FORTIO_TMP}" 2>/dev/null \
+     && cp "$(find "${FORTIO_TMP}" -maxdepth 4 -name fortio -type f 2>/dev/null | head -1)" "${HOME}/bin/fortio" \
      && chmod +x "${HOME}/bin/fortio"; then
     echo "    fortio installed: $("${HOME}/bin/fortio" version 2>/dev/null | head -1)"
   else
     echo "    WARN: fortio install failed; chaos generate_load faults (optimize-scale) will no-op."
   fi
+  rm -rf "${FORTIO_TMP}"
 fi
 
 # node on a stable PATH — the oc trajectory extraction (`oc sessions` /
@@ -179,6 +186,9 @@ PY
 
 if [ ! -f "${ENV_FILE}" ]; then
   echo "==> writing ${ENV_FILE} template (fill in values, then 'source ~/bench.env')"
+  # Mode 600 before the write: the template invites provider API keys and
+  # JUDGE_API_KEY, which the default umask would leave world-readable.
+  install -m 600 /dev/null "${ENV_FILE}"
   cat > "${ENV_FILE}" <<'EOF'
 # DevOps Bench harness environment. Fill in, then: source ~/bench.env
 # --- GCP target ---

--- a/scripts/bastion/vm-setup.sh
+++ b/scripts/bastion/vm-setup.sh
@@ -141,20 +141,22 @@ if [ -x "${HOME}/bin/fortio" ] && [ ! -e /usr/local/bin/fortio ]; then
     || echo "    WARN: could not symlink fortio to /usr/local/bin; chaos may not find it."
 fi
 
-# gke-mcp operational skills — the source for the AGENT's +skills capability
+# MCP server skills — the source for the AGENT's +skills capability. This
+# bastion installs GoogleCloudPlatform/gke-mcp; point MCP_SKILLS_REPO at another
+# server's checkout to use different skills.
 # (oc/gcli). The refactored matrix points AGENT_SKILLS_PATHS at this repo's
 # skills/ dir (19 SKILL.md skills: gke-compute-class-creator, gke-workload-scaling,
 # gke-networking-edge, gke-productionize, ...). These are operational skills, NOT
 # the judge rubric markdown under ~/oc-skills. Clone to a stable path OUTSIDE the
 # synced ~/devops-bench tree so sync-to-bastion never clobbers it. Idempotent.
 echo "==> gke-mcp skills check (agent +skills source)"
-GKE_MCP_REPO="${GKE_MCP_REPO:-${HOME}/gke-mcp-repo}"
-if [ -d "${GKE_MCP_REPO}/skills" ]; then
-  echo "    present: ${GKE_MCP_REPO}/skills ($(find "${GKE_MCP_REPO}/skills" -name SKILL.md 2>/dev/null | wc -l) skills)"
+MCP_SKILLS_REPO="${MCP_SKILLS_REPO:-${HOME}/gke-mcp-repo}"
+if [ -d "${MCP_SKILLS_REPO}/skills" ]; then
+  echo "    present: ${MCP_SKILLS_REPO}/skills ($(find "${MCP_SKILLS_REPO}/skills" -name SKILL.md 2>/dev/null | wc -l) skills)"
 else
-  echo "    cloning gke-mcp -> ${GKE_MCP_REPO}..."
-  if git clone --depth 1 https://github.com/GoogleCloudPlatform/gke-mcp "${GKE_MCP_REPO}"; then
-    echo "    gke-mcp skills ready ($(find "${GKE_MCP_REPO}/skills" -name SKILL.md 2>/dev/null | wc -l) skills)"
+  echo "    cloning gke-mcp -> ${MCP_SKILLS_REPO}..."
+  if git clone --depth 1 https://github.com/GoogleCloudPlatform/gke-mcp "${MCP_SKILLS_REPO}"; then
+    echo "    gke-mcp skills ready ($(find "${MCP_SKILLS_REPO}/skills" -name SKILL.md 2>/dev/null | wc -l) skills)"
   else
     echo "    WARN: gke-mcp clone failed; agent +skills will be empty until it is cloned."
   fi

--- a/tf/README.md
+++ b/tf/README.md
@@ -66,7 +66,7 @@ INFRA_PROVIDER=kind devops-bench tasks/common/opa-remediation/task.yaml
 When defining a task in `task.yaml`, write it using the provider-neutral prebuilt stacks:
 
 ```yaml
-# tasks/gcp/my-task/task.yaml
+# tasks/common/my-task/task.yaml
 name: "my-generic-task"
 infrastructure:
   deployer: "tofu"

--- a/tf/README.md
+++ b/tf/README.md
@@ -1,0 +1,79 @@
+# OpenTofu/Terraform Infrastructure
+
+This directory contains the OpenTofu modules and prebuilt configurations used to provision infrastructure for the benchmarks.
+
+---
+
+## 1. Directory Structure
+
+- `modules/`: Reusable infrastructure components.
+  - **`cluster/`**: The provider-neutral cluster router. It conditionally delegates to:
+    - `cluster/gke/`: Google Kubernetes Engine (GCP) implementation.
+    - `cluster/kind/`: Local Kubernetes in Docker (KinD) implementation.
+- `prebuilt/`: Standard and task-specific environment configurations.
+  - **Provider-Neutral (GKE or KinD)**:
+    - `minimum/`: A basic cluster.
+    - `gpu-stress-test/`: A cluster configured with GPU node pools.
+    - `optimize-scale/`: Workload misconfigured for autoscaling.
+    - `opa-remediation/`: Pre-installed Kyverno policy engine and violating workloads.
+    - `migration-and-upgrade/`: Cluster at an older Kubernetes version with deprecated APIs.
+  - **GCP/GKE Zonal/Regional Specialized**:
+    - `hypercomputer-d1/`: Multi-node cluster with GCS FUSE and vLLM.
+    - `multi-region-failover/`: Dual regional clusters with Cloud SQL replication and Global HTTP LB.
+    - `secret-rotation/`: Cluster integrated with GCP Secret Manager and KMS keys.
+    - `lustre-csi/`: Cluster with Lustre parallel file system CSI driver.
+
+---
+
+## 2. The Provider-Neutral Cluster Abstraction
+
+To avoid duplicating stacks for different cloud or local environments, tasks call the unified **`cluster`** module. The target environment is determined at runtime by the `infra_provider` variable.
+
+### Inputs for `modules/cluster`
+
+| Variable | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `infra_provider` | `string` | **Required** | Target provider (`"gcp"` or `"kind"`) |
+| `cluster_name` | `string` | **Required** | Name of the cluster |
+| `location` | `string` | `""` | Region/zone (GCP) or `"local"` (KinD) |
+| `node_count` | `number` | `3` | Number of worker nodes |
+| `machine_type` | `string` | `""` | VM instance type (e.g., `e2-standard-2`, `g2-standard-4`) |
+| `gpu_type` | `string` | `""` | Abstract GPU type (`"l4"`, `"a100"`, `"t4"`, or `""` for no GPU) |
+| `gpu_count` | `number` | `1` | Number of GPUs per node (if `gpu_type` is set) |
+| `project_id` | `string` | `""` | GCP Project ID (GCP-only) |
+| `kubeconfig_path` | `string` | `"~/.kube/config"` | Local kubeconfig path (KinD-only) |
+
+---
+
+## 3. How to Run Stacks on Different Providers
+
+When executing a task via the `devops-bench` runner, you specify the target provider using the `INFRA_PROVIDER` environment variable.
+
+### Running on GCP (GKE)
+```bash
+INFRA_PROVIDER=gcp devops-bench tasks/gcp/deploy-hello-app/task.yaml
+```
+
+### Running Locally (KinD)
+```bash
+INFRA_PROVIDER=kind devops-bench tasks/common/opa-remediation/task.yaml
+```
+
+---
+
+## 4. Writing a New Task
+
+When defining a task in `task.yaml`, write it using the provider-neutral prebuilt stacks:
+
+```yaml
+# tasks/gcp/my-task/task.yaml
+name: "my-generic-task"
+infrastructure:
+  deployer: "tofu"
+  stack: "prebuilt/minimum"
+  teardown: true
+  variables:
+    node_count: 3
+    machine_type: "e2-standard-2"
+```
+This task can now be executed on any supported cloud or local provider without modification.


### PR DESCRIPTION
Adds the bastion-side tooling that drives evaluation matrices on a runner VM, plus the
README describing the OpenTofu tree.

- `scripts/bastion/run_matrix.sh` + `_matrix_lib.sh` — expand a Task x Model x AgentConfig
  matrix and drive the runs, with resumable run state under a run stamp.
- `scripts/bastion/vm-setup.sh`, `sync-to-bastion.sh`, `configure-oc.sh` — provision the
  runner VM, push a working tree to it, and configure the agent CLI.
- `scripts/bastion/run_matrix_legacy.sh` — still referenced by `run_matrix.sh` and
  `_matrix_lib.sh`, so it travels with them rather than being dropped.
- `tf/README.md` — the layout of `tf/modules` and `tf/prebuilt`.

These unblock the run and onboarding docs and the eval-run skills, which reference
`scripts/bastion/run_matrix.sh`.

## Changes from the source

- **License headers.** The shell scripts carried none; this repository's boilerplate check
  requires them, so an Apache header is inserted after each shebang.
- **Corrected doc path.** Three comments referenced `docs/bastion.md`, which is not where
  that document lives. They now name `docs/components/bastion.md` (arriving with the
  run/onboarding docs).

## Worth a reviewer's opinion

`sync-to-bastion.sh` and `_matrix_lib.sh` carry an opt-in SSH transport for Google corp
hosts: setting `BASTION_SSH_HOST` or `BASTION_USE_GCPNODE=1` builds a
`nic0.<vm>.<zone>.c.<project>.internal.gcpnode.com` host and defaults the login user to
`<localuser>_google_com`. The default path is the vendor-neutral gcloud IAP tunnel and the
escape hatch is documented inline, so I ported it as is rather than dropping a transport
people currently rely on. Happy to genericize or remove it if you would rather this
repository carried no vendor-specific host convention.

Usage examples in the scripts name task paths such as `tasks/gcp/secret-rotation/task.yaml`
that have not migrated yet; they become valid as the task definitions land.

/kind cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated benchmark matrix execution for local and remote environments, including refactored and legacy evaluation modes.
  * Added parallel runs with status tracking, logs, retries, and resume support.
  * Added bastion synchronization and setup with configurable SSH or IAP transport.
  * Added configurable OpenClaw, Gemini, MCP, skills, and Vertex AI provisioning.
  * Added dry-run validation and isolated task/model configurations.
  * Added automated prerequisite checks and environment setup.

* **Documentation**
  * Added infrastructure guidance for cluster setup, local environments, and task configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->