### PR TITLE
feat(verification): add the http_probe verifier and the run_pod helper

### DIFF
--- a/devops_bench/k8s/__init__.py
+++ b/devops_bench/k8s/__init__.py
@@ -20,6 +20,7 @@ from devops_bench.k8s.kubectl import (
     get_resource,
     port_forward,
     rollout_status,
+    run_pod,
     wait,
 )
 
@@ -29,5 +30,6 @@ __all__ = [
     "poll_until",
     "port_forward",
     "rollout_status",
+    "run_pod",
     "wait",
 ]

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -76,12 +76,27 @@ def _selector_args(selector: str | None) -> list[str]:
     return ["-l", selector] if selector else []
 
 
-def _run_kubectl(argv: list[str], kubeconfig: KubeconfigSource, **kwargs: Any) -> CompletedProcess:
+def _context_args(context: str | None) -> list[str]:
+    return ["--context", context] if context else []
+
+
+def _run_kubectl(
+    argv: list[str],
+    kubeconfig: KubeconfigSource,
+    *,
+    context: str | None = None,
+    **kwargs: Any,
+) -> CompletedProcess:
     """Run ``kubectl`` with the resolved kubeconfig overlaid on the environment.
 
     Args:
         argv: Full kubectl command and arguments, never a shell string.
         kubeconfig: Explicit path, a ``KubeconfigProvider``, or None.
+        context: Optional kubeconfig context to pin the call to (``--context``).
+            Pinning the file alone is not enough: a kubeconfig can carry
+            several contexts, or none selected as current, and an unpinned
+            context means the call silently reads whichever cluster the
+            ambient current-context happens to point at.
         **kwargs: Extra keyword arguments forwarded to ``core.subprocess.run``
             (e.g. ``timeout``).
 
@@ -93,7 +108,7 @@ def _run_kubectl(argv: list[str], kubeconfig: KubeconfigSource, **kwargs: Any) -
     """
     path = _resolve_kubeconfig(kubeconfig)
     extra_env = {"KUBECONFIG": path} if path else None
-    return run(argv, extra_env=extra_env, **kwargs)
+    return run([*argv, *_context_args(context)], extra_env=extra_env, **kwargs)
 
 
 def wait(
@@ -239,6 +254,7 @@ def run_pod(
     kubeconfig: KubeconfigSource = None,
     timeout: float | None = None,
     env: dict[str, str] | None = None,
+    context: str | None = None,
 ) -> str:
     """Run a one-shot ephemeral pod and return its captured stdout.
 
@@ -260,6 +276,9 @@ def run_pod(
         kubeconfig: Kubeconfig path or context-like object.
         timeout: Optional timeout in seconds forwarded to ``core.subprocess.run``.
         env: Optional env vars injected into the container via ``--env=K=V``.
+        context: Optional kubeconfig context to pin the call to. A probe pod
+            has to run against the cluster under test, not whichever cluster
+            the ambient current-context happens to point at.
 
     Returns:
         The pod's captured stdout.
@@ -285,7 +304,7 @@ def run_pod(
     extra_kwargs: dict[str, Any] = {}
     if timeout is not None:
         extra_kwargs["timeout"] = timeout
-    completed = _run_kubectl(argv, kubeconfig, **extra_kwargs)
+    completed = _run_kubectl(argv, kubeconfig, context=context, **extra_kwargs)
     return completed.stdout
 
 

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -31,6 +31,7 @@ __all__ = [
     "get_resource",
     "port_forward",
     "rollout_status",
+    "run_pod",
     "wait",
 ]
 
@@ -227,6 +228,65 @@ def rollout_status(
         *_namespace_args(namespace),
     ]
     return _run_kubectl(argv, kubeconfig)
+
+
+def run_pod(
+    name: str,
+    image: str,
+    command: list[str],
+    *,
+    namespace: str | None = None,
+    kubeconfig: KubeconfigSource = None,
+    timeout: float | None = None,
+    env: dict[str, str] | None = None,
+) -> str:
+    """Run a one-shot ephemeral pod and return its captured stdout.
+
+    Launches the pod with ``--rm -i --restart=Never`` so the pod is auto-deleted
+    after completion and ``kubectl`` attaches stdin, which is required to capture
+    the container's output. Cleanup depends on that ``kubectl`` process running
+    to completion, so a caller whose ``timeout`` kills it before the pod exits
+    should not assume the pod is gone. ``--command`` is required before the
+    ``--`` separator: without it, ``kubectl run`` treats the trailing argv as
+    args appended to the image's entrypoint rather than the container command,
+    so an image with its own entrypoint (e.g. ``curlimages/curl``, entrypoint
+    ``curl``) would run ``curl curl -s <url>`` instead of ``curl -s <url>``.
+
+    Args:
+        name: Pod name.
+        image: Container image to run.
+        command: Command and arguments passed after ``--`` to the container.
+        namespace: Optional namespace (``-n``).
+        kubeconfig: Kubeconfig path or context-like object.
+        timeout: Optional timeout in seconds forwarded to ``core.subprocess.run``.
+        env: Optional env vars injected into the container via ``--env=K=V``.
+
+    Returns:
+        The pod's captured stdout.
+
+    Raises:
+        SubprocessError: If kubectl exits non-zero or times out.
+    """
+    env_args = [f"--env={k}={v}" for k, v in (env or {}).items()]
+    argv = [
+        "kubectl",
+        "run",
+        name,
+        "--rm",
+        "-i",
+        "--restart=Never",
+        f"--image={image}",
+        *env_args,
+        *_namespace_args(namespace),
+        "--command",
+        "--",
+        *command,
+    ]
+    extra_kwargs: dict[str, Any] = {}
+    if timeout is not None:
+        extra_kwargs["timeout"] = timeout
+    completed = _run_kubectl(argv, kubeconfig, **extra_kwargs)
+    return completed.stdout
 
 
 @contextlib.contextmanager

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -80,6 +80,31 @@ def _context_args(context: str | None) -> list[str]:
     return ["--context", context] if context else []
 
 
+def _insert_context_args(argv: list[str], context: str | None) -> list[str]:
+    """Return argv with context flags placed before any ``--`` separator.
+
+    Everything after a bare ``--`` belongs to the container command, not to
+    kubectl, so appending there would hand the flag to the workload instead of
+    configuring the target cluster.
+
+    Args:
+        argv: Full kubectl command and arguments.
+        context: Optional kubeconfig context to pin the call to.
+
+    Returns:
+        A new argv list with the context flags inserted before the first
+        bare ``--`` element, or appended to the end when there is none.
+    """
+    context_args = _context_args(context)
+    if not context_args:
+        return list(argv)
+    try:
+        split = argv.index("--")
+    except ValueError:
+        return [*argv, *context_args]
+    return [*argv[:split], *context_args, *argv[split:]]
+
+
 def _run_kubectl(
     argv: list[str],
     kubeconfig: KubeconfigSource,
@@ -108,7 +133,7 @@ def _run_kubectl(
     """
     path = _resolve_kubeconfig(kubeconfig)
     extra_env = {"KUBECONFIG": path} if path else None
-    return run([*argv, *_context_args(context)], extra_env=extra_env, **kwargs)
+    return run(_insert_context_args(argv, context), extra_env=extra_env, **kwargs)
 
 
 def wait(

--- a/devops_bench/verification/base.py
+++ b/devops_bench/verification/base.py
@@ -161,6 +161,11 @@ class BaseVerifier(BaseModel, ABC):
         kubeconfig: Optional path to a kubeconfig file, forwarded to the
             ``devops_bench.k8s`` wrappers so a check can target a specific
             cluster. When ``None`` the wrappers use the ambient kubeconfig.
+        context: Optional kubeconfig context, forwarded alongside
+            ``kubeconfig`` so a check pins the exact cluster rather than
+            whichever context the kubeconfig file happens to have selected as
+            current (or none). When ``None`` the wrappers use the ambient
+            current-context.
     """
 
     # Reject any key the concrete verifier does not declare. A typo'd or
@@ -170,6 +175,7 @@ class BaseVerifier(BaseModel, ABC):
 
     name: str | None = None
     kubeconfig: str | None = None
+    context: str | None = None
 
     @abstractmethod
     def verify(self, timeout_sec: float) -> VerificationResult:

--- a/devops_bench/verification/verifiers/__init__.py
+++ b/devops_bench/verification/verifiers/__init__.py
@@ -14,6 +14,7 @@
 
 """Concrete single-condition verifiers."""
 
+from devops_bench.verification.verifiers.http_probe import HttpProbeVerifier
 from devops_bench.verification.verifiers.pod_healthy import PodHealthyVerifier
 from devops_bench.verification.verifiers.resource_property import (
     ResourcePropertyVerifier,
@@ -21,6 +22,7 @@ from devops_bench.verification.verifiers.resource_property import (
 from devops_bench.verification.verifiers.scaling_complete import ScalingCompleteVerifier
 
 __all__ = [
+    "HttpProbeVerifier",
     "PodHealthyVerifier",
     "ResourcePropertyVerifier",
     "ScalingCompleteVerifier",

--- a/devops_bench/verification/verifiers/http_probe.py
+++ b/devops_bench/verification/verifiers/http_probe.py
@@ -61,6 +61,10 @@ class HttpProbeVerifier(BaseVerifier):
         namespace: Namespace the ephemeral pod runs in; active context when None.
         probe_timeout: Seconds the curl command may run. The ``kubectl run``
             call is bounded by this value plus :data:`_KUBECTL_OVERHEAD_SEC`.
+        host: Optional ``Host`` header value. Set this to probe a host-routed
+            ingress path: ``url`` targets the edge/controller address while
+            this header selects the virtual host. ``None`` (default) omits
+            the header and preserves plain URL-based routing.
     """
 
     type: Literal["http_probe"] = "http_probe"
@@ -69,6 +73,7 @@ class HttpProbeVerifier(BaseVerifier):
     expect_body_matches: str | None = None
     namespace: str | None = None
     probe_timeout: int = 10
+    host: str | None = None
 
     def verify(self, timeout_sec: float) -> VerificationResult:
         """Probe the URL, retrying until it responds as expected or time runs out.
@@ -107,8 +112,10 @@ class HttpProbeVerifier(BaseVerifier):
             "-w",
             r"\n%{http_code}",
             f"--max-time={self.probe_timeout}",
-            self.url,
         ]
+        if self.host is not None:
+            curl_cmd += ["-H", f"Host: {self.host}"]
+        curl_cmd.append(self.url)
         # Bounded by probe_timeout plus overhead rather than single_call_timeout:
         # a converge-mode retry needs a bound tight to this one attempt so the
         # next attempt fires promptly, not single_call_timeout's near-zero floor

--- a/devops_bench/verification/verifiers/http_probe.py
+++ b/devops_bench/verification/verifiers/http_probe.py
@@ -59,6 +59,14 @@ _CURL_NETWORK_FAILURE_EXIT_CODES: dict[int, str] = {
 # returncode) meaningful as a curl exit code.
 _POD_TERMINATED_ERROR_MARKER = "terminated (Error)"
 
+# Upper bound on the response-body characters handed to ``re.search``. The
+# probed service is deployed by the agent under evaluation, so its body is
+# untrusted input: an adversarial body paired with a backtracking-prone
+# pattern could otherwise burn evaluator CPU well past the verification
+# budget. A match that only appears past this prefix is not seen; the
+# reported ``body_length`` is still the full observed length.
+_BODY_MATCH_LIMIT_CHARS = 64 * 1024
+
 
 @VERIFIERS.register("http_probe")
 class HttpProbeVerifier(BaseVerifier):
@@ -78,7 +86,9 @@ class HttpProbeVerifier(BaseVerifier):
         type: Discriminator literal, always ``"http_probe"``.
         url: URL to probe (must be reachable from inside the cluster).
         expect_status: Expected HTTP status code; default 200.
-        expect_body_matches: Optional regex applied to the response body.
+        expect_body_matches: Optional regex applied to the response body. Only
+            the first :data:`_BODY_MATCH_LIMIT_CHARS` characters are matched
+            against, since the body is untrusted input.
         namespace: Namespace the ephemeral pod runs in; active context when None.
         probe_timeout: Seconds the curl command may run. The ``kubectl run``
             call is bounded by this value plus :data:`_KUBECTL_OVERHEAD_SEC`.
@@ -207,6 +217,8 @@ class HttpProbeVerifier(BaseVerifier):
                 f"expected HTTP {self.expect_status}, got {status_code} from {self.url}",
                 raw,
             )
-        if self.expect_body_matches and not re.search(self.expect_body_matches, body):
+        if self.expect_body_matches and not re.search(
+            self.expect_body_matches, body[:_BODY_MATCH_LIMIT_CHARS]
+        ):
             return "fail", f"body did not match pattern {self.expect_body_matches!r}", raw
         return "pass", f"HTTP {status_code} from {self.url}", raw

--- a/devops_bench/verification/verifiers/http_probe.py
+++ b/devops_bench/verification/verifiers/http_probe.py
@@ -38,6 +38,27 @@ _log = get_logger("verification.http_probe")
 # request itself without leaving the call unbounded.
 _KUBECTL_OVERHEAD_SEC = 30
 
+# curl exit codes that mean the target was unreachable over the network (DNS
+# failure, connection refused, timeout, TLS connect failure, empty reply,
+# recv failure). These are observations, not evaluation errors: the probe pod
+# ran successfully and curl itself reported the target could not be reached.
+# See https://curl.se/libcurl/c/libcurl-errors.html.
+_CURL_NETWORK_FAILURE_EXIT_CODES: dict[int, str] = {
+    6: "could not resolve host",
+    7: "connection refused",
+    28: "operation timed out",
+    35: "TLS connect error",
+    52: "empty reply from server",
+    56: "failure in receiving network data",
+}
+
+# Substring kubectl's stderr carries when an ephemeral ``--rm`` pod's
+# container ran to completion and exited non-zero, as opposed to kubectl
+# itself failing before the pod ever ran (bad flags, API/auth errors). Only
+# in the former case is the container's exit code (surfaced as kubectl's own
+# returncode) meaningful as a curl exit code.
+_POD_TERMINATED_ERROR_MARKER = "terminated (Error)"
+
 
 @VERIFIERS.register("http_probe")
 class HttpProbeVerifier(BaseVerifier):
@@ -97,11 +118,50 @@ class HttpProbeVerifier(BaseVerifier):
             return self._run_probe()
         except SubprocessError as exc:
             stderr = (exc.stderr or "").strip()
+            unreachable = self._classify_unreachable(exc)
+            if unreachable is not None:
+                curl_exit, description = unreachable
+                _log.warning(
+                    "http_probe found %s unreachable: curl exit %d (%s)",
+                    self.url,
+                    curl_exit,
+                    description,
+                )
+                return (
+                    "fail",
+                    f"unreachable: curl exit {curl_exit} ({description})",
+                    {"curl_exit": curl_exit},
+                )
             _log.warning("http_probe kubectl run failed for %s: %s", self.url, stderr)
             return "error", f"kubectl run failed: {stderr}", None
         except Exception as exc:  # noqa: BLE001 - surface unexpected errors as check errors
             _log.warning("http_probe unexpected error for %s: %s", self.url, exc)
             return "error", f"unexpected error: {exc}", None
+
+    @staticmethod
+    def _classify_unreachable(exc: SubprocessError) -> tuple[int, str] | None:
+        """Return ``(curl_exit_code, description)`` when ``exc`` is a network-level probe miss.
+
+        Distinguishes the ephemeral pod's container exiting non-zero (curl
+        itself observed the target was unreachable) from kubectl failing to
+        even run the pod (bad flags, API/auth errors). Only the former is a
+        real observation the probe made; the latter stays an evaluation
+        error, since we cannot say anything about the target's reachability.
+
+        Args:
+            exc: The ``SubprocessError`` raised by ``run_pod``.
+
+        Returns:
+            The matched curl exit code and its description, or ``None`` if
+            ``exc`` does not represent a network-level unreachability.
+        """
+        stderr = exc.stderr or ""
+        if _POD_TERMINATED_ERROR_MARKER not in stderr:
+            return None
+        description = _CURL_NETWORK_FAILURE_EXIT_CODES.get(exc.returncode)
+        if description is None:
+            return None
+        return exc.returncode, description
 
     def _run_probe(self) -> tuple[VerificationStatus, str, dict[str, Any] | None]:
         """Launch an ephemeral curl pod and evaluate its output."""

--- a/devops_bench/verification/verifiers/http_probe.py
+++ b/devops_bench/verification/verifiers/http_probe.py
@@ -69,6 +69,14 @@ _POD_TERMINATED_ERROR_MARKER = "terminated (Error)"
 # reported ``body_length`` is still the full observed length.
 _BODY_MATCH_LIMIT_CHARS = 64 * 1024
 
+# Unique marker curl's ``-w`` write-out prefixes the HTTP status with, so the
+# status can be found by searching for the marker rather than trusting that
+# the final line of output is the status. ``kubectl run --rm`` sometimes
+# appends its own pod-deletion notice after curl's output, which would
+# otherwise be mistaken for the status line.
+_HTTP_STATUS_MARKER = "__HTTP_STATUS__:"
+_STATUS_MARKER_RE = re.compile(re.escape(_HTTP_STATUS_MARKER) + r"(\d{3})")
+
 
 @VERIFIERS.register("http_probe")
 class HttpProbeVerifier(BaseVerifier):
@@ -219,7 +227,7 @@ class HttpProbeVerifier(BaseVerifier):
             "curl",
             "-s",
             "-w",
-            r"\n%{http_code}",
+            "\n" + _HTTP_STATUS_MARKER + "%{http_code}",
             f"--max-time={self.probe_timeout}",
         ]
         if self.host is not None:
@@ -243,15 +251,14 @@ class HttpProbeVerifier(BaseVerifier):
             timeout=pod_timeout,
         ).rstrip()
 
-        lines = output.rsplit("\n", 1)
-        if len(lines) < 2:
-            return "error", f"unexpected curl output: {output!r}", None
-
-        body, status_line = lines
-        match = re.match(r"\s*(\d{3})", status_line)
+        match = _STATUS_MARKER_RE.search(output)
         if not match:
-            return "error", f"could not parse HTTP status from {status_line!r}", None
+            return "error", f"unexpected curl output: {output!r}", None
         status_code = int(match.group(1))
+
+        body = output[: match.start()]
+        if body.endswith("\n"):
+            body = body[:-1]
 
         raw: dict[str, Any] = {"status_code": status_code, "body_length": len(body)}
 

--- a/devops_bench/verification/verifiers/http_probe.py
+++ b/devops_bench/verification/verifiers/http_probe.py
@@ -24,7 +24,6 @@ from typing import Any, Literal
 from devops_bench.core import SubprocessError, get_logger
 from devops_bench.k8s import run_pod
 from devops_bench.verification.base import (
-    MIN_LEAF_BUDGET_SECONDS,
     VERIFIERS,
     BaseVerifier,
     VerificationResult,
@@ -131,11 +130,11 @@ class HttpProbeVerifier(BaseVerifier):
         Returns:
             The verification result carrying the last observed outcome.
         """
-        # Below the runner's real-budget floor, timeout_sec is the assert/hold
-        # sentinel (always exactly 0.0), not a shrinking converge deadline: the
-        # single attempt below keeps its full probe_timeout + overhead budget,
-        # unclamped, exactly as before this fix.
-        bounded = timeout_sec >= MIN_LEAF_BUDGET_SECONDS
+        # A positive timeout_sec, however small, is a shrinking converge
+        # deadline; only the assert/hold sentinel (always exactly 0.0) keeps
+        # the single attempt below at its full probe_timeout + overhead
+        # budget, unclamped.
+        bounded = timeout_sec > 0
         start = time.monotonic()
 
         def check() -> tuple[VerificationStatus, str, dict[str, Any] | None]:
@@ -251,9 +250,10 @@ class HttpProbeVerifier(BaseVerifier):
             timeout=pod_timeout,
         ).rstrip()
 
-        match = _STATUS_MARKER_RE.search(output)
-        if not match:
+        matches = list(_STATUS_MARKER_RE.finditer(output))
+        if not matches:
             return "error", f"unexpected curl output: {output!r}", None
+        match = matches[-1]
         status_code = int(match.group(1))
 
         body = output[: match.start()]

--- a/devops_bench/verification/verifiers/http_probe.py
+++ b/devops_bench/verification/verifiers/http_probe.py
@@ -180,7 +180,11 @@ class HttpProbeVerifier(BaseVerifier):
                     {"curl_exit": curl_exit},
                 )
             _log.warning("http_probe kubectl run failed for %s: %s", self.url, stderr)
-            return "error", f"kubectl run failed: {stderr}", None
+            return (
+                "error",
+                f"kubectl run failed (exit {exc.returncode}): {stderr}",
+                {"kubectl_returncode": exc.returncode, "kubectl_stdout": exc.stdout},
+            )
         except Exception as exc:  # noqa: BLE001 - surface unexpected errors as check errors
             _log.warning("http_probe unexpected error for %s: %s", self.url, exc)
             return "error", f"unexpected error: {exc}", None
@@ -241,12 +245,17 @@ class HttpProbeVerifier(BaseVerifier):
         pod_timeout = self.probe_timeout + _KUBECTL_OVERHEAD_SEC
         if remaining is not None:
             pod_timeout = min(pod_timeout, remaining)
+        # kubeconfig and context are both pinned to the run's cluster: the
+        # ambient current-context is a mutable global any run can rewrite, and
+        # an in-cluster probe pod has to launch against the cluster under
+        # test, not whichever one happens to be ambient.
         output = run_pod(
             pod_name,
             "curlimages/curl",
             curl_cmd,
             namespace=self.namespace,
             kubeconfig=self.kubeconfig,
+            context=self.context,
             timeout=pod_timeout,
         ).rstrip()
 

--- a/devops_bench/verification/verifiers/http_probe.py
+++ b/devops_bench/verification/verifiers/http_probe.py
@@ -1,0 +1,145 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verifier that issues an HTTP request from inside the cluster via an ephemeral pod."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Any, Literal
+
+from devops_bench.core import SubprocessError, get_logger
+from devops_bench.k8s import run_pod
+from devops_bench.verification.base import (
+    VERIFIERS,
+    BaseVerifier,
+    VerificationResult,
+    VerificationStatus,
+)
+
+__all__ = ["HttpProbeVerifier"]
+
+_log = get_logger("verification.http_probe")
+
+# Seconds of slack added to ``probe_timeout`` when bounding the ``kubectl run``
+# call, so the pod launch/attach/delete round trip has room beyond the curl
+# request itself without leaving the call unbounded.
+_KUBECTL_OVERHEAD_SEC = 30
+
+
+@VERIFIERS.register("http_probe")
+class HttpProbeVerifier(BaseVerifier):
+    """Verify HTTP reachability by curling the URL from inside the cluster.
+
+    Launches an ephemeral ``curlimages/curl`` pod per attempt via
+    ``kubectl run --rm`` and checks status code and, optionally, body content.
+    In converge mode it retries a fresh pod until the expected response appears
+    or the deadline passes; in assert and hold mode it fires exactly once. The
+    request originates from inside the cluster, so this verifier validates
+    ClusterIP/DNS reachability that a probe run from outside the cluster
+    cannot reach. Reach for it when the service is not externally accessible;
+    every use documents that the service can only be probed from inside the
+    cluster.
+
+    Attributes:
+        type: Discriminator literal, always ``"http_probe"``.
+        url: URL to probe (must be reachable from inside the cluster).
+        expect_status: Expected HTTP status code; default 200.
+        expect_body_matches: Optional regex applied to the response body.
+        namespace: Namespace the ephemeral pod runs in; active context when None.
+        probe_timeout: Seconds the curl command may run. The ``kubectl run``
+            call is bounded by this value plus :data:`_KUBECTL_OVERHEAD_SEC`.
+    """
+
+    type: Literal["http_probe"] = "http_probe"
+    url: str
+    expect_status: int = 200
+    expect_body_matches: str | None = None
+    namespace: str | None = None
+    probe_timeout: int = 10
+
+    def verify(self, timeout_sec: float) -> VerificationResult:
+        """Probe the URL, retrying until it responds as expected or time runs out.
+
+        In converge mode ``timeout_sec`` is the remaining budget, so a fresh
+        curl pod is launched per attempt until the expected status (and body)
+        is seen or the deadline passes. In assert and hold mode ``timeout_sec``
+        is ``0``, so the probe fires exactly once.
+
+        Args:
+            timeout_sec: Maximum seconds to keep retrying the probe.
+
+        Returns:
+            The verification result carrying the last observed outcome.
+        """
+        return self._poll_to_result(self._probe_check, timeout_sec)
+
+    def _probe_check(self) -> tuple[VerificationStatus, str, dict[str, Any] | None]:
+        """Run one probe attempt, folding kubectl/unexpected errors into an error status."""
+        try:
+            return self._run_probe()
+        except SubprocessError as exc:
+            stderr = (exc.stderr or "").strip()
+            _log.warning("http_probe kubectl run failed for %s: %s", self.url, stderr)
+            return "error", f"kubectl run failed: {stderr}", None
+        except Exception as exc:  # noqa: BLE001 - surface unexpected errors as check errors
+            _log.warning("http_probe unexpected error for %s: %s", self.url, exc)
+            return "error", f"unexpected error: {exc}", None
+
+    def _run_probe(self) -> tuple[VerificationStatus, str, dict[str, Any] | None]:
+        """Launch an ephemeral curl pod and evaluate its output."""
+        pod_name = f"http-probe-{uuid.uuid4().hex[:8]}"
+        curl_cmd = [
+            "curl",
+            "-s",
+            "-w",
+            r"\n%{http_code}",
+            f"--max-time={self.probe_timeout}",
+            self.url,
+        ]
+        # Bounded by probe_timeout plus overhead rather than single_call_timeout:
+        # a converge-mode retry needs a bound tight to this one attempt so the
+        # next attempt fires promptly, not single_call_timeout's near-zero floor
+        # meant only to protect an assert-mode call with no real budget.
+        output = run_pod(
+            pod_name,
+            "curlimages/curl",
+            curl_cmd,
+            namespace=self.namespace,
+            kubeconfig=self.kubeconfig,
+            timeout=self.probe_timeout + _KUBECTL_OVERHEAD_SEC,
+        ).rstrip()
+
+        lines = output.rsplit("\n", 1)
+        if len(lines) < 2:
+            return "error", f"unexpected curl output: {output!r}", None
+
+        body, status_line = lines
+        match = re.match(r"\s*(\d{3})", status_line)
+        if not match:
+            return "error", f"could not parse HTTP status from {status_line!r}", None
+        status_code = int(match.group(1))
+
+        raw: dict[str, Any] = {"status_code": status_code, "body_length": len(body)}
+
+        if status_code != self.expect_status:
+            return (
+                "fail",
+                f"expected HTTP {self.expect_status}, got {status_code} from {self.url}",
+                raw,
+            )
+        if self.expect_body_matches and not re.search(self.expect_body_matches, body):
+            return "fail", f"body did not match pattern {self.expect_body_matches!r}", raw
+        return "pass", f"HTTP {status_code} from {self.url}", raw

--- a/devops_bench/verification/verifiers/http_probe.py
+++ b/devops_bench/verification/verifiers/http_probe.py
@@ -17,12 +17,14 @@
 from __future__ import annotations
 
 import re
+import time
 import uuid
 from typing import Any, Literal
 
 from devops_bench.core import SubprocessError, get_logger
 from devops_bench.k8s import run_pod
 from devops_bench.verification.base import (
+    MIN_LEAF_BUDGET_SECONDS,
     VERIFIERS,
     BaseVerifier,
     VerificationResult,
@@ -91,7 +93,8 @@ class HttpProbeVerifier(BaseVerifier):
             against, since the body is untrusted input.
         namespace: Namespace the ephemeral pod runs in; active context when None.
         probe_timeout: Seconds the curl command may run. The ``kubectl run``
-            call is bounded by this value plus :data:`_KUBECTL_OVERHEAD_SEC`.
+            call is bounded by this value plus :data:`_KUBECTL_OVERHEAD_SEC`,
+            clamped further to whatever remains on the converge deadline.
         host: Optional ``Host`` header value. Set this to probe a host-routed
             ingress path: ``url`` targets the edge/controller address while
             this header selects the virtual host. ``None`` (default) omits
@@ -120,12 +123,39 @@ class HttpProbeVerifier(BaseVerifier):
         Returns:
             The verification result carrying the last observed outcome.
         """
-        return self._poll_to_result(self._probe_check, timeout_sec)
+        # Below the runner's real-budget floor, timeout_sec is the assert/hold
+        # sentinel (always exactly 0.0), not a shrinking converge deadline: the
+        # single attempt below keeps its full probe_timeout + overhead budget,
+        # unclamped, exactly as before this fix.
+        bounded = timeout_sec >= MIN_LEAF_BUDGET_SECONDS
+        start = time.monotonic()
 
-    def _probe_check(self) -> tuple[VerificationStatus, str, dict[str, Any] | None]:
-        """Run one probe attempt, folding kubectl/unexpected errors into an error status."""
+        def check() -> tuple[VerificationStatus, str, dict[str, Any] | None]:
+            if not bounded:
+                return self._probe_check(None)
+            remaining = timeout_sec - (time.monotonic() - start)
+            if remaining <= 0:
+                return (
+                    "error",
+                    "no time remaining for probe attempt before converge deadline",
+                    None,
+                )
+            return self._probe_check(remaining)
+
+        return self._poll_to_result(check, timeout_sec)
+
+    def _probe_check(
+        self, remaining: float | None
+    ) -> tuple[VerificationStatus, str, dict[str, Any] | None]:
+        """Run one probe attempt, folding kubectl/unexpected errors into an error status.
+
+        Args:
+            remaining: Seconds left on the converge deadline, used to clamp
+                this attempt's pod timeout; ``None`` in assert/hold mode,
+                where the attempt keeps its full unclamped budget.
+        """
         try:
-            return self._run_probe()
+            return self._run_probe(remaining)
         except SubprocessError as exc:
             stderr = (exc.stderr or "").strip()
             unreachable = self._classify_unreachable(exc)
@@ -173,8 +203,17 @@ class HttpProbeVerifier(BaseVerifier):
             return None
         return exc.returncode, description
 
-    def _run_probe(self) -> tuple[VerificationStatus, str, dict[str, Any] | None]:
-        """Launch an ephemeral curl pod and evaluate its output."""
+    def _run_probe(
+        self, remaining: float | None
+    ) -> tuple[VerificationStatus, str, dict[str, Any] | None]:
+        """Launch an ephemeral curl pod and evaluate its output.
+
+        Args:
+            remaining: Seconds left on the converge deadline; the pod's
+                timeout is clamped to this when it is smaller than
+                ``probe_timeout + _KUBECTL_OVERHEAD_SEC``. ``None`` leaves the
+                pod timeout unclamped (assert/hold mode).
+        """
         pod_name = f"http-probe-{uuid.uuid4().hex[:8]}"
         curl_cmd = [
             "curl",
@@ -189,14 +228,19 @@ class HttpProbeVerifier(BaseVerifier):
         # Bounded by probe_timeout plus overhead rather than single_call_timeout:
         # a converge-mode retry needs a bound tight to this one attempt so the
         # next attempt fires promptly, not single_call_timeout's near-zero floor
-        # meant only to protect an assert-mode call with no real budget.
+        # meant only to protect an assert-mode call with no real budget. Also
+        # clamped to whatever remains on the converge deadline, so this one
+        # attempt cannot itself run past the deadline the caller budgeted.
+        pod_timeout = self.probe_timeout + _KUBECTL_OVERHEAD_SEC
+        if remaining is not None:
+            pod_timeout = min(pod_timeout, remaining)
         output = run_pod(
             pod_name,
             "curlimages/curl",
             curl_cmd,
             namespace=self.namespace,
             kubeconfig=self.kubeconfig,
-            timeout=self.probe_timeout + _KUBECTL_OVERHEAD_SEC,
+            timeout=pod_timeout,
         ).rstrip()
 
         lines = output.rsplit("\n", 1)

--- a/tests/unit/k8s/test_k8s_kubectl.py
+++ b/tests/unit/k8s/test_k8s_kubectl.py
@@ -254,11 +254,20 @@ def test_run_pod_threads_context_into_argv(mocker: MockerFixture) -> None:
         "--restart=Never",
         "--image=busybox",
         "--command",
-        "--",
-        "true",
         "--context",
         "kind-devops-bench-kind",
+        "--",
+        "true",
     ]
+
+
+def test_run_pod_places_context_before_the_separator(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed(stdout=""))
+
+    kubectl.run_pod("p", "busybox", ["true"], context="kind-devops-bench-kind")
+
+    argv = mock_run.call_args.args[0]
+    assert argv.index("--context") < argv.index("--")
 
 
 def test_run_pod_without_context_omits_context_flag(mocker: MockerFixture) -> None:

--- a/tests/unit/k8s/test_k8s_kubectl.py
+++ b/tests/unit/k8s/test_k8s_kubectl.py
@@ -203,6 +203,62 @@ def test_run_context_without_cluster_omits_kubeconfig(mocker: MockerFixture) -> 
     assert mock_run.call_args.kwargs["extra_env"] is None
 
 
+def test_run_pod_builds_argv_and_returns_stdout(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch(
+        "devops_bench.k8s.kubectl.run", return_value=_completed(stdout="hello\n200")
+    )
+
+    out = kubectl.run_pod(
+        "http-probe-abc",
+        "curlimages/curl",
+        ["curl", "-s", "http://svc"],
+        namespace="hello-app",
+        kubeconfig="/tmp/kc",
+        timeout=40,
+    )
+
+    assert out == "hello\n200"
+    argv = mock_run.call_args.args[0]
+    assert argv == [
+        "kubectl",
+        "run",
+        "http-probe-abc",
+        "--rm",
+        "-i",
+        "--restart=Never",
+        "--image=curlimages/curl",
+        "-n",
+        "hello-app",
+        "--command",
+        "--",
+        "curl",
+        "-s",
+        "http://svc",
+    ]
+    assert mock_run.call_args.kwargs["extra_env"] == {"KUBECONFIG": "/tmp/kc"}
+    assert mock_run.call_args.kwargs["timeout"] == 40
+
+
+def test_run_pod_injects_env_args(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed(stdout=""))
+
+    kubectl.run_pod("p", "busybox", ["true"], env={"A": "1", "B": "2"})
+
+    argv = mock_run.call_args.args[0]
+    assert "--env=A=1" in argv and "--env=B=2" in argv
+    # No timeout supplied -> run is called without a timeout kwarg.
+    assert "timeout" not in mock_run.call_args.kwargs
+
+
+def test_run_pod_propagates_subprocess_error(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "devops_bench.k8s.kubectl.run",
+        side_effect=SubprocessError(["kubectl", "run"], returncode=1),
+    )
+    with pytest.raises(SubprocessError):
+        kubectl.run_pod("p", "busybox", ["true"])
+
+
 def test_get_resource_propagates_invalid_json(mocker: MockerFixture) -> None:
     mocker.patch(
         "devops_bench.k8s.kubectl.run",

--- a/tests/unit/k8s/test_k8s_kubectl.py
+++ b/tests/unit/k8s/test_k8s_kubectl.py
@@ -239,6 +239,37 @@ def test_run_pod_builds_argv_and_returns_stdout(mocker: MockerFixture) -> None:
     assert mock_run.call_args.kwargs["timeout"] == 40
 
 
+def test_run_pod_threads_context_into_argv(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed(stdout=""))
+
+    kubectl.run_pod("p", "busybox", ["true"], context="kind-devops-bench-kind")
+
+    argv = mock_run.call_args.args[0]
+    assert argv == [
+        "kubectl",
+        "run",
+        "p",
+        "--rm",
+        "-i",
+        "--restart=Never",
+        "--image=busybox",
+        "--command",
+        "--",
+        "true",
+        "--context",
+        "kind-devops-bench-kind",
+    ]
+
+
+def test_run_pod_without_context_omits_context_flag(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed(stdout=""))
+
+    kubectl.run_pod("p", "busybox", ["true"])
+
+    argv = mock_run.call_args.args[0]
+    assert "--context" not in argv
+
+
 def test_run_pod_injects_env_args(mocker: MockerFixture) -> None:
     mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed(stdout=""))
 

--- a/tests/unit/verification/test_http_probe.py
+++ b/tests/unit/verification/test_http_probe.py
@@ -1,0 +1,143 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the http_probe verifier. ``run_pod`` is patched throughout."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pytest_mock import MockerFixture
+
+from devops_bench.core import SubprocessError
+from devops_bench.k8s.conditions import poll_until as _real_poll_until
+from devops_bench.verification import VerificationSpec
+from devops_bench.verification.verifiers.http_probe import HttpProbeVerifier
+
+
+def _patch_run_pod(mocker: MockerFixture, output: str) -> Any:
+    return mocker.patch(
+        "devops_bench.verification.verifiers.http_probe.run_pod", return_value=output
+    )
+
+
+def test_registered_via_spec() -> None:
+    node = VerificationSpec({"type": "http_probe", "url": "http://svc"}).root
+    assert isinstance(node, HttpProbeVerifier)
+    assert node.expect_status == 200
+
+
+def test_probe_passes_on_expected_status(mocker: MockerFixture) -> None:
+    _patch_run_pod(mocker, "hello world\n200")
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    result = v.verify(30)
+    assert result.success is True
+    assert result.status == "pass"
+
+
+def test_probe_fails_on_wrong_status(mocker: MockerFixture) -> None:
+    _patch_run_pod(mocker, "not found\n404")
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    result = v.verify(0)
+    assert result.success is False
+    assert result.status == "fail"
+    assert "404" in result.reason
+
+
+def test_probe_body_match_required(mocker: MockerFixture) -> None:
+    _patch_run_pod(mocker, "unexpected\n200")
+    v = HttpProbeVerifier.model_validate(
+        {"type": "http_probe", "url": "http://svc", "expect_body_matches": "hello"}
+    )
+    result = v.verify(0)
+    assert result.success is False
+    assert result.status == "fail"
+
+
+def test_probe_body_match_passes(mocker: MockerFixture) -> None:
+    _patch_run_pod(mocker, "hello there\n200")
+    v = HttpProbeVerifier.model_validate(
+        {"type": "http_probe", "url": "http://svc", "expect_body_matches": "hello"}
+    )
+    result = v.verify(30)
+    assert result.success is True
+    assert result.status == "pass"
+
+
+def test_probe_subprocess_error_is_an_error_not_a_fail(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "devops_bench.verification.verifiers.http_probe.run_pod",
+        side_effect=SubprocessError(["kubectl", "run"], returncode=1, stderr="boom"),
+    )
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    result = v.verify(0)
+    assert result.success is False
+    assert result.status == "error"
+    assert "kubectl run failed" in result.reason
+
+
+def test_probe_parses_status_with_trailing_kubectl_noise(mocker: MockerFixture) -> None:
+    """kubectl's `pod ... deleted` notice glued onto the code must not break parsing."""
+    _patch_run_pod(
+        mocker, 'Hello from hello-app\n200pod "http-probe-6836fa7d" deleted from default namespace'
+    )
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    result = v.verify(0)
+    assert result.success is True
+    assert result.status == "pass"
+    assert result.raw["status_code"] == 200
+
+
+def test_probe_unparseable_output_is_an_error(mocker: MockerFixture) -> None:
+    _patch_run_pod(mocker, "no-status-line")
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    result = v.verify(0)
+    assert result.success is False
+    assert result.status == "error"
+
+
+def test_probe_polls_until_success(mocker: MockerFixture) -> None:
+    """Converge mode retries a fresh probe until the expected status appears."""
+    run_pod = mocker.patch(
+        "devops_bench.verification.verifiers.http_probe.run_pod",
+        side_effect=["down\n503", "down\n503", "hello world\n200"],
+    )
+
+    # Exercise the real poll loop but without real sleeping between attempts.
+    def _fast_poll(predicate: Any, *, timeout_sec: float, **_: Any) -> bool:
+        return _real_poll_until(
+            predicate,
+            timeout_sec=timeout_sec,
+            initial_delay=0.0,
+            max_delay=0.0,
+            sleep=lambda _s: None,
+        )
+
+    mocker.patch("devops_bench.verification.base.poll_until", side_effect=_fast_poll)
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    result = v.verify(30)
+    assert result.success is True
+    assert run_pod.call_count == 3
+
+
+def test_probe_assert_mode_is_single_shot(mocker: MockerFixture) -> None:
+    """With no budget (assert/hold), the probe fires exactly once and does not retry."""
+    run_pod = mocker.patch(
+        "devops_bench.verification.verifiers.http_probe.run_pod",
+        return_value="down\n503",
+    )
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    result = v.verify(0.0)
+    assert result.success is False
+    assert run_pod.call_count == 1

--- a/tests/unit/verification/test_http_probe.py
+++ b/tests/unit/verification/test_http_probe.py
@@ -25,9 +25,15 @@ from devops_bench.k8s.conditions import poll_until as _real_poll_until
 from devops_bench.verification import VerificationSpec
 from devops_bench.verification.verifiers.http_probe import (
     _BODY_MATCH_LIMIT_CHARS,
+    _HTTP_STATUS_MARKER,
     _KUBECTL_OVERHEAD_SEC,
     HttpProbeVerifier,
 )
+
+
+def _curl_output(body: str, status: int, trailer: str = "") -> str:
+    """Build a curl ``-w`` write-out string the way the verifier's real curl call does."""
+    return f"{body}\n{_HTTP_STATUS_MARKER}{status}{trailer}"
 
 
 def _patch_run_pod(mocker: MockerFixture, output: str) -> Any:
@@ -43,7 +49,7 @@ def test_registered_via_spec() -> None:
 
 
 def test_probe_passes_on_expected_status(mocker: MockerFixture) -> None:
-    _patch_run_pod(mocker, "hello world\n200")
+    _patch_run_pod(mocker, _curl_output("hello world", 200))
     v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
     result = v.verify(30)
     assert result.success is True
@@ -51,7 +57,7 @@ def test_probe_passes_on_expected_status(mocker: MockerFixture) -> None:
 
 
 def test_probe_fails_on_wrong_status(mocker: MockerFixture) -> None:
-    _patch_run_pod(mocker, "not found\n404")
+    _patch_run_pod(mocker, _curl_output("not found", 404))
     v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
     result = v.verify(0)
     assert result.success is False
@@ -60,7 +66,7 @@ def test_probe_fails_on_wrong_status(mocker: MockerFixture) -> None:
 
 
 def test_probe_body_match_required(mocker: MockerFixture) -> None:
-    _patch_run_pod(mocker, "unexpected\n200")
+    _patch_run_pod(mocker, _curl_output("unexpected", 200))
     v = HttpProbeVerifier.model_validate(
         {"type": "http_probe", "url": "http://svc", "expect_body_matches": "hello"}
     )
@@ -70,7 +76,7 @@ def test_probe_body_match_required(mocker: MockerFixture) -> None:
 
 
 def test_probe_body_match_passes(mocker: MockerFixture) -> None:
-    _patch_run_pod(mocker, "hello there\n200")
+    _patch_run_pod(mocker, _curl_output("hello there", 200))
     v = HttpProbeVerifier.model_validate(
         {"type": "http_probe", "url": "http://svc", "expect_body_matches": "hello"}
     )
@@ -161,13 +167,52 @@ def test_probe_kubectl_usage_error_stays_an_error(mocker: MockerFixture) -> None
 def test_probe_parses_status_with_trailing_kubectl_noise(mocker: MockerFixture) -> None:
     """kubectl's `pod ... deleted` notice glued onto the code must not break parsing."""
     _patch_run_pod(
-        mocker, 'Hello from hello-app\n200pod "http-probe-6836fa7d" deleted from default namespace'
+        mocker,
+        _curl_output(
+            "Hello from hello-app",
+            200,
+            trailer='pod "http-probe-6836fa7d" deleted from default namespace',
+        ),
     )
     v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
     result = v.verify(0)
     assert result.success is True
     assert result.status == "pass"
     assert result.raw["status_code"] == 200
+
+
+def test_probe_parses_status_with_trailing_kubectl_noise_on_its_own_line(
+    mocker: MockerFixture,
+) -> None:
+    """A deletion notice on its own line after the marker must not be read as the status line.
+
+    This is the regression the marker guards against: a naive "last line is the
+    status" parser would read the deletion notice as the status line and turn
+    this valid response into an error.
+    """
+    _patch_run_pod(
+        mocker,
+        _curl_output(
+            "hello world",
+            200,
+            trailer='\npod "http-probe-6836fa7d" deleted from default namespace',
+        ),
+    )
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    result = v.verify(0)
+    assert result.success is True
+    assert result.status == "pass"
+    assert result.raw["status_code"] == 200
+    assert result.raw["body_length"] == len("hello world")
+
+
+def test_probe_missing_marker_is_an_error(mocker: MockerFixture) -> None:
+    """Output with no status marker at all is an error, not a misread status."""
+    _patch_run_pod(mocker, "no-status-marker")
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    result = v.verify(0)
+    assert result.success is False
+    assert result.status == "error"
 
 
 def test_probe_unparseable_output_is_an_error(mocker: MockerFixture) -> None:
@@ -181,7 +226,7 @@ def test_probe_unparseable_output_is_an_error(mocker: MockerFixture) -> None:
 def test_probe_body_match_is_bounded(mocker: MockerFixture) -> None:
     """Only the leading slice of the body is matched, so a huge body cannot stall the regex."""
     body = ("a" * _BODY_MATCH_LIMIT_CHARS) + "needle"
-    _patch_run_pod(mocker, f"{body}\n200")
+    _patch_run_pod(mocker, _curl_output(body, 200))
     v = HttpProbeVerifier.model_validate(
         {"type": "http_probe", "url": "http://svc", "expect_body_matches": "needle"}
     )
@@ -196,7 +241,11 @@ def test_probe_polls_until_success(mocker: MockerFixture) -> None:
     """Converge mode retries a fresh probe until the expected status appears."""
     run_pod = mocker.patch(
         "devops_bench.verification.verifiers.http_probe.run_pod",
-        side_effect=["down\n503", "down\n503", "hello world\n200"],
+        side_effect=[
+            _curl_output("down", 503),
+            _curl_output("down", 503),
+            _curl_output("hello world", 200),
+        ],
     )
 
     # Exercise the real poll loop but without real sleeping between attempts.
@@ -224,7 +273,7 @@ def test_probe_assert_mode_is_single_shot(mocker: MockerFixture) -> None:
     """With no budget (assert/hold), the probe fires exactly once and does not retry."""
     run_pod = mocker.patch(
         "devops_bench.verification.verifiers.http_probe.run_pod",
-        return_value="down\n503",
+        return_value=_curl_output("down", 503),
     )
     v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
     result = v.verify(0.0)
@@ -234,7 +283,7 @@ def test_probe_assert_mode_is_single_shot(mocker: MockerFixture) -> None:
 
 def test_run_probe_clamps_pod_timeout_to_remaining_deadline(mocker: MockerFixture) -> None:
     """One probe attempt must not use more of the pod timeout than remains on the deadline."""
-    run_pod = _patch_run_pod(mocker, "hello world\n200")
+    run_pod = _patch_run_pod(mocker, _curl_output("hello world", 200))
     v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
     status, reason, raw = v._run_probe(3.0)
     assert status == "pass"
@@ -243,7 +292,7 @@ def test_run_probe_clamps_pod_timeout_to_remaining_deadline(mocker: MockerFixtur
 
 def test_run_probe_unclamped_when_remaining_is_none(mocker: MockerFixture) -> None:
     """``remaining=None`` (assert/hold mode) keeps the full probe_timeout + overhead budget."""
-    run_pod = _patch_run_pod(mocker, "hello world\n200")
+    run_pod = _patch_run_pod(mocker, _curl_output("hello world", 200))
     v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
     status, reason, raw = v._run_probe(None)
     assert status == "pass"
@@ -254,7 +303,7 @@ def test_probe_converge_check_clamps_pod_timeout_to_remaining_deadline(
     mocker: MockerFixture,
 ) -> None:
     """A converge attempt with little deadline left gets a clamped run_pod timeout."""
-    run_pod = _patch_run_pod(mocker, "hello world\n200")
+    run_pod = _patch_run_pod(mocker, _curl_output("hello world", 200))
     mocker.patch(
         "devops_bench.verification.verifiers.http_probe.time.monotonic",
         side_effect=[100.0, 100.0, 103.0, 103.0],
@@ -273,7 +322,7 @@ def test_probe_converge_check_skips_pod_when_deadline_exhausted(
     mocker: MockerFixture,
 ) -> None:
     """No pod is launched once the converge deadline has nothing left before an attempt."""
-    run_pod = _patch_run_pod(mocker, "hello world\n200")
+    run_pod = _patch_run_pod(mocker, _curl_output("hello world", 200))
     mocker.patch(
         "devops_bench.verification.verifiers.http_probe.time.monotonic",
         side_effect=[100.0, 100.0, 106.0, 106.0],
@@ -291,7 +340,7 @@ def test_probe_converge_check_skips_pod_when_deadline_exhausted(
 
 def test_probe_assert_mode_pod_timeout_stays_unclamped(mocker: MockerFixture) -> None:
     """Assert/hold mode keeps the full probe_timeout + overhead budget, unclamped."""
-    run_pod = _patch_run_pod(mocker, "hello world\n200")
+    run_pod = _patch_run_pod(mocker, _curl_output("hello world", 200))
     v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
     result = v.verify(0.0)
     assert result.success is True
@@ -299,7 +348,7 @@ def test_probe_assert_mode_pod_timeout_stays_unclamped(mocker: MockerFixture) ->
 
 
 def test_probe_host_header_added_when_set(mocker: MockerFixture) -> None:
-    run_pod = _patch_run_pod(mocker, "hello world\n200")
+    run_pod = _patch_run_pod(mocker, _curl_output("hello world", 200))
     v = HttpProbeVerifier.model_validate(
         {"type": "http_probe", "url": "http://1.2.3.4", "host": "app.example.com"}
     )
@@ -312,7 +361,7 @@ def test_probe_host_header_added_when_set(mocker: MockerFixture) -> None:
 
 
 def test_probe_no_host_header_when_unset(mocker: MockerFixture) -> None:
-    run_pod = _patch_run_pod(mocker, "hello world\n200")
+    run_pod = _patch_run_pod(mocker, _curl_output("hello world", 200))
     v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
     result = v.verify(0)
     assert result.success is True
@@ -322,7 +371,7 @@ def test_probe_no_host_header_when_unset(mocker: MockerFixture) -> None:
         "curl",
         "-s",
         "-w",
-        r"\n%{http_code}",
+        "\n" + _HTTP_STATUS_MARKER + "%{http_code}",
         "--max-time=10",
         "http://svc",
     ]

--- a/tests/unit/verification/test_http_probe.py
+++ b/tests/unit/verification/test_http_probe.py
@@ -206,6 +206,24 @@ def test_probe_parses_status_with_trailing_kubectl_noise_on_its_own_line(
     assert result.raw["body_length"] == len("hello world")
 
 
+def test_probe_marker_like_text_in_body_does_not_shadow_real_status(
+    mocker: MockerFixture,
+) -> None:
+    """A response body containing marker-like text must not shadow the real status.
+
+    curl's ``-w`` write-out always appends the real status last; a body that
+    happens to contain text shaped like the marker must not be mistaken for
+    it.
+    """
+    body = f"unexpected body content {_HTTP_STATUS_MARKER}200 embedded"
+    _patch_run_pod(mocker, _curl_output(body, 503))
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    result = v.verify(0)
+    assert result.success is False
+    assert result.status == "fail"
+    assert result.raw["status_code"] == 503
+
+
 def test_probe_missing_marker_is_an_error(mocker: MockerFixture) -> None:
     """Output with no status marker at all is an error, not a misread status."""
     _patch_run_pod(mocker, "no-status-marker")
@@ -285,7 +303,7 @@ def test_run_probe_clamps_pod_timeout_to_remaining_deadline(mocker: MockerFixtur
     """One probe attempt must not use more of the pod timeout than remains on the deadline."""
     run_pod = _patch_run_pod(mocker, _curl_output("hello world", 200))
     v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
-    status, reason, raw = v._run_probe(3.0)
+    status, _, _ = v._run_probe(3.0)
     assert status == "pass"
     assert run_pod.call_args.kwargs["timeout"] == 3.0
 
@@ -294,7 +312,7 @@ def test_run_probe_unclamped_when_remaining_is_none(mocker: MockerFixture) -> No
     """``remaining=None`` (assert/hold mode) keeps the full probe_timeout + overhead budget."""
     run_pod = _patch_run_pod(mocker, _curl_output("hello world", 200))
     v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
-    status, reason, raw = v._run_probe(None)
+    status, _, _ = v._run_probe(None)
     assert status == "pass"
     assert run_pod.call_args.kwargs["timeout"] == v.probe_timeout + _KUBECTL_OVERHEAD_SEC
 
@@ -316,6 +334,30 @@ def test_probe_converge_check_clamps_pod_timeout_to_remaining_deadline(
     result = v.verify(5.0)
     assert result.success is True
     assert run_pod.call_args.kwargs["timeout"] == 2.0
+
+
+def test_probe_converge_check_with_small_timeout_below_floor_still_clamps(
+    mocker: MockerFixture,
+) -> None:
+    """A small positive converge timeout, below any leaf-budget floor, is still bounded.
+
+    A positive timeout_sec must not be mistaken for the assert/hold sentinel
+    (always exactly 0.0) just because it is small; the pod timeout must still
+    clamp to the remaining deadline.
+    """
+    run_pod = _patch_run_pod(mocker, _curl_output("hello world", 200))
+    mocker.patch(
+        "devops_bench.verification.verifiers.http_probe.time.monotonic",
+        side_effect=[100.0, 100.0, 100.25, 100.25],
+    )
+    mocker.patch(
+        "devops_bench.verification.base.poll_until",
+        side_effect=lambda predicate, *, timeout_sec, **_: predicate(),
+    )
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    result = v.verify(0.5)
+    assert result.success is True
+    assert run_pod.call_args.kwargs["timeout"] == 0.25
 
 
 def test_probe_converge_check_skips_pod_when_deadline_exhausted(

--- a/tests/unit/verification/test_http_probe.py
+++ b/tests/unit/verification/test_http_probe.py
@@ -87,6 +87,73 @@ def test_probe_subprocess_error_is_an_error_not_a_fail(mocker: MockerFixture) ->
     assert "kubectl run failed" in result.reason
 
 
+def test_probe_connection_refused_is_a_fail_not_an_error(mocker: MockerFixture) -> None:
+    """Connection refused is an observation curl made, not an evaluation failure."""
+    mocker.patch(
+        "devops_bench.verification.verifiers.http_probe.run_pod",
+        side_effect=SubprocessError(
+            ["kubectl", "run"],
+            returncode=7,
+            stderr='pod default/http-probe-abc123 terminated (Error)',
+        ),
+    )
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    result = v.verify(0)
+    assert result.success is False
+    assert result.status == "fail"
+    assert "unreachable" in result.reason
+    assert "7" in result.reason
+
+
+def test_probe_connection_refused_classifies_as_fail_not_error(
+    mocker: MockerFixture,
+) -> None:
+    """A real outage returns status "fail", not "error".
+
+    A hold evaluator counts error samples in hold_error_count (which does not
+    trigger a violation) and counts fail samples as violations. Classifying
+    network unreachability as "fail" is therefore the property that prevents a
+    real outage from failing a hold open. The hold machinery itself is not
+    imported here because it lives outside this PR's scope, but the verifier's
+    output contract is the load-bearing assertion.
+    """
+    mocker.patch(
+        "devops_bench.verification.verifiers.http_probe.run_pod",
+        side_effect=SubprocessError(
+            ["kubectl", "run"],
+            returncode=7,
+            stderr='pod default/http-probe-abc123 terminated (Error)',
+        ),
+    )
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    result = v.verify(0.0)
+
+    assert result.success is False
+    assert result.status == "fail"
+    assert "unreachable" in result.reason
+
+
+def test_probe_kubectl_usage_error_stays_an_error(mocker: MockerFixture) -> None:
+    """A kubectl exit code that overlaps the curl network-failure set is still an error
+
+    when the pod never ran (no ``terminated (Error)`` marker in stderr), e.g. a bad
+    flag or an API/auth failure.
+    """
+    mocker.patch(
+        "devops_bench.verification.verifiers.http_probe.run_pod",
+        side_effect=SubprocessError(
+            ["kubectl", "run"],
+            returncode=1,
+            stderr="error: unable to connect to the server",
+        ),
+    )
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    result = v.verify(0)
+    assert result.success is False
+    assert result.status == "error"
+    assert "kubectl run failed" in result.reason
+
+
 def test_probe_parses_status_with_trailing_kubectl_noise(mocker: MockerFixture) -> None:
     """kubectl's `pod ... deleted` notice glued onto the code must not break parsing."""
     _patch_run_pod(

--- a/tests/unit/verification/test_http_probe.py
+++ b/tests/unit/verification/test_http_probe.py
@@ -141,3 +141,33 @@ def test_probe_assert_mode_is_single_shot(mocker: MockerFixture) -> None:
     result = v.verify(0.0)
     assert result.success is False
     assert run_pod.call_count == 1
+
+
+def test_probe_host_header_added_when_set(mocker: MockerFixture) -> None:
+    run_pod = _patch_run_pod(mocker, "hello world\n200")
+    v = HttpProbeVerifier.model_validate(
+        {"type": "http_probe", "url": "http://1.2.3.4", "host": "app.example.com"}
+    )
+    result = v.verify(0)
+    assert result.success is True
+    curl_cmd = run_pod.call_args.args[2]
+    assert "-H" in curl_cmd
+    assert curl_cmd[curl_cmd.index("-H") + 1] == "Host: app.example.com"
+    assert curl_cmd[-1] == "http://1.2.3.4"
+
+
+def test_probe_no_host_header_when_unset(mocker: MockerFixture) -> None:
+    run_pod = _patch_run_pod(mocker, "hello world\n200")
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    result = v.verify(0)
+    assert result.success is True
+    curl_cmd = run_pod.call_args.args[2]
+    assert "-H" not in curl_cmd
+    assert curl_cmd == [
+        "curl",
+        "-s",
+        "-w",
+        r"\n%{http_code}",
+        "--max-time=10",
+        "http://svc",
+    ]

--- a/tests/unit/verification/test_http_probe.py
+++ b/tests/unit/verification/test_http_probe.py
@@ -23,7 +23,10 @@ from pytest_mock import MockerFixture
 from devops_bench.core import SubprocessError
 from devops_bench.k8s.conditions import poll_until as _real_poll_until
 from devops_bench.verification import VerificationSpec
-from devops_bench.verification.verifiers.http_probe import HttpProbeVerifier
+from devops_bench.verification.verifiers.http_probe import (
+    _BODY_MATCH_LIMIT_CHARS,
+    HttpProbeVerifier,
+)
 
 
 def _patch_run_pod(mocker: MockerFixture, output: str) -> Any:
@@ -94,7 +97,7 @@ def test_probe_connection_refused_is_a_fail_not_an_error(mocker: MockerFixture) 
         side_effect=SubprocessError(
             ["kubectl", "run"],
             returncode=7,
-            stderr='pod default/http-probe-abc123 terminated (Error)',
+            stderr="pod default/http-probe-abc123 terminated (Error)",
         ),
     )
     v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
@@ -122,7 +125,7 @@ def test_probe_connection_refused_classifies_as_fail_not_error(
         side_effect=SubprocessError(
             ["kubectl", "run"],
             returncode=7,
-            stderr='pod default/http-probe-abc123 terminated (Error)',
+            stderr="pod default/http-probe-abc123 terminated (Error)",
         ),
     )
     v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
@@ -174,6 +177,20 @@ def test_probe_unparseable_output_is_an_error(mocker: MockerFixture) -> None:
     assert result.status == "error"
 
 
+def test_probe_body_match_is_bounded(mocker: MockerFixture) -> None:
+    """Only the leading slice of the body is matched, so a huge body cannot stall the regex."""
+    body = ("a" * _BODY_MATCH_LIMIT_CHARS) + "needle"
+    _patch_run_pod(mocker, f"{body}\n200")
+    v = HttpProbeVerifier.model_validate(
+        {"type": "http_probe", "url": "http://svc", "expect_body_matches": "needle"}
+    )
+    result = v.verify(0)
+    assert result.success is False
+    assert result.status == "fail"
+    # body_length still reports the full observed body, not the matched slice.
+    assert result.raw["body_length"] == len(body)
+
+
 def test_probe_polls_until_success(mocker: MockerFixture) -> None:
     """Converge mode retries a fresh probe until the expected status appears."""
     run_pod = mocker.patch(
@@ -196,6 +213,10 @@ def test_probe_polls_until_success(mocker: MockerFixture) -> None:
     result = v.verify(30)
     assert result.success is True
     assert run_pod.call_count == 3
+    # Each retry must launch a fresh pod name: reusing one would collide with a
+    # prior attempt's pod that has not finished terminating.
+    pod_names = [call.args[0] for call in run_pod.call_args_list]
+    assert len(set(pod_names)) == 3
 
 
 def test_probe_assert_mode_is_single_shot(mocker: MockerFixture) -> None:

--- a/tests/unit/verification/test_http_probe.py
+++ b/tests/unit/verification/test_http_probe.py
@@ -25,6 +25,7 @@ from devops_bench.k8s.conditions import poll_until as _real_poll_until
 from devops_bench.verification import VerificationSpec
 from devops_bench.verification.verifiers.http_probe import (
     _BODY_MATCH_LIMIT_CHARS,
+    _KUBECTL_OVERHEAD_SEC,
     HttpProbeVerifier,
 )
 
@@ -229,6 +230,72 @@ def test_probe_assert_mode_is_single_shot(mocker: MockerFixture) -> None:
     result = v.verify(0.0)
     assert result.success is False
     assert run_pod.call_count == 1
+
+
+def test_run_probe_clamps_pod_timeout_to_remaining_deadline(mocker: MockerFixture) -> None:
+    """One probe attempt must not use more of the pod timeout than remains on the deadline."""
+    run_pod = _patch_run_pod(mocker, "hello world\n200")
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    status, reason, raw = v._run_probe(3.0)
+    assert status == "pass"
+    assert run_pod.call_args.kwargs["timeout"] == 3.0
+
+
+def test_run_probe_unclamped_when_remaining_is_none(mocker: MockerFixture) -> None:
+    """``remaining=None`` (assert/hold mode) keeps the full probe_timeout + overhead budget."""
+    run_pod = _patch_run_pod(mocker, "hello world\n200")
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    status, reason, raw = v._run_probe(None)
+    assert status == "pass"
+    assert run_pod.call_args.kwargs["timeout"] == v.probe_timeout + _KUBECTL_OVERHEAD_SEC
+
+
+def test_probe_converge_check_clamps_pod_timeout_to_remaining_deadline(
+    mocker: MockerFixture,
+) -> None:
+    """A converge attempt with little deadline left gets a clamped run_pod timeout."""
+    run_pod = _patch_run_pod(mocker, "hello world\n200")
+    mocker.patch(
+        "devops_bench.verification.verifiers.http_probe.time.monotonic",
+        side_effect=[100.0, 100.0, 103.0, 103.0],
+    )
+    mocker.patch(
+        "devops_bench.verification.base.poll_until",
+        side_effect=lambda predicate, *, timeout_sec, **_: predicate(),
+    )
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    result = v.verify(5.0)
+    assert result.success is True
+    assert run_pod.call_args.kwargs["timeout"] == 2.0
+
+
+def test_probe_converge_check_skips_pod_when_deadline_exhausted(
+    mocker: MockerFixture,
+) -> None:
+    """No pod is launched once the converge deadline has nothing left before an attempt."""
+    run_pod = _patch_run_pod(mocker, "hello world\n200")
+    mocker.patch(
+        "devops_bench.verification.verifiers.http_probe.time.monotonic",
+        side_effect=[100.0, 100.0, 106.0, 106.0],
+    )
+    mocker.patch(
+        "devops_bench.verification.base.poll_until",
+        side_effect=lambda predicate, *, timeout_sec, **_: predicate(),
+    )
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    result = v.verify(5.0)
+    assert result.status == "error"
+    assert "no time remaining" in result.reason
+    run_pod.assert_not_called()
+
+
+def test_probe_assert_mode_pod_timeout_stays_unclamped(mocker: MockerFixture) -> None:
+    """Assert/hold mode keeps the full probe_timeout + overhead budget, unclamped."""
+    run_pod = _patch_run_pod(mocker, "hello world\n200")
+    v = HttpProbeVerifier.model_validate({"type": "http_probe", "url": "http://svc"})
+    result = v.verify(0.0)
+    assert result.success is True
+    assert run_pod.call_args.kwargs["timeout"] == v.probe_timeout + _KUBECTL_OVERHEAD_SEC
 
 
 def test_probe_host_header_added_when_set(mocker: MockerFixture) -> None:


### PR DESCRIPTION
This adds an `http_probe` verifier for in-cluster reachability: it launches an ephemeral curl pod (`kubectl run --rm`, fresh unique pod name per attempt) that requests the target URL from inside the cluster, so it validates ClusterIP, DNS, and NetworkPolicy paths that an external probe cannot see. Status code and an optional body regex are checked, and it polls through the verifier base's helper so slow-starting backends converge.

It also introduces the `run_pod` kubectl wrapper the verifier needs, since none of the existing wrappers can run a one-shot pod and capture its output. All I/O is bounded: curl carries `--max-time` and the kubectl call gets the probe timeout plus a documented overhead constant. One caveat is documented on `run_pod`: `--rm` cleanup is driven by the kubectl process, so a call that times out can leave the pod behind.

13 unit tests (10 verifier, 3 helper), all subprocess I/O mocked. No new dependencies.

Sibling to #54; together with a planned `git_repo_sync` verifier these back the deterministic verification specs in #47.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for running temporary Kubernetes pods with configurable namespaces, credentials, timeouts, and environment variables.
  - Added an HTTP probe verifier for in-cluster URLs, including expected status codes, response-body patterns, `Host` headers, and bounded response inspection.
  - Added deadline-aware probing for convergence checks and full-budget attempts for assertion and hold checks.
  - Improved probe results with clearer unreachable-endpoint handling and response body length reporting.

- **Tests**
  - Added comprehensive coverage for pod execution, timeout handling, output parsing, and HTTP probe outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->