### PR TITLE
feat(verification): add the git_repo_sync verifier

### DIFF
--- a/devops_bench/verification/verifiers/__init__.py
+++ b/devops_bench/verification/verifiers/__init__.py
@@ -14,6 +14,7 @@
 
 """Concrete single-condition verifiers."""
 
+from devops_bench.verification.verifiers.git_repo_sync import GitRepoSyncVerifier
 from devops_bench.verification.verifiers.pod_healthy import PodHealthyVerifier
 from devops_bench.verification.verifiers.resource_property import (
     ResourcePropertyVerifier,
@@ -21,6 +22,7 @@ from devops_bench.verification.verifiers.resource_property import (
 from devops_bench.verification.verifiers.scaling_complete import ScalingCompleteVerifier
 
 __all__ = [
+    "GitRepoSyncVerifier",
     "PodHealthyVerifier",
     "ResourcePropertyVerifier",
     "ScalingCompleteVerifier",

--- a/devops_bench/verification/verifiers/git_repo_sync.py
+++ b/devops_bench/verification/verifiers/git_repo_sync.py
@@ -1,0 +1,409 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Assert a property of a file, or the commit state, in a host-side bare git repo.
+
+This is ``resource_property``'s counterpart for the other half of a GitOps
+loop: where that verifier reads live Kubernetes API state, this one reads the
+repository that state is supposed to converge from. The two share one
+comparison vocabulary (``op``/``value``/``across_matches``) on purpose, so a
+task author only learns "eq/ne/gt/gte/lt/lte/contains/matches" and the
+fail-closed reduction rules once.
+
+Reads the bare repo directly with ``git -C <repo_path> show <ref>:<file>``
+rather than cloning it: the agent already owns a working clone (or pushes
+straight to the bare repo), so a second clone here would only add I/O and
+worktree management for a check that reads at most one file at one ref.
+``file`` content is parsed as one or more YAML documents (ruamel.yaml, the
+same library the task loader uses) and ``path`` (JSONPath, extended) is
+evaluated against the list of documents, so a filter predicate selects the
+right document out of a multi-document manifest.
+
+``require_new_commit`` asserts HEAD is not among the repo's root (seed)
+commits (``git rev-list --max-parents=0``). The repo is seeded with one
+commit before the task starts, so "HEAD is still a root commit" means the
+agent never committed anything, and a no-op agent fails this check even if
+the file it would otherwise assert on happens to already satisfy the rest of
+the check.
+
+``require_new_commit`` does not combine with a content assertion (``file``)
+in the same check: ``_check`` resolves the seed commit before it reads any
+file, so a transient ``git rev-list`` failure would short-circuit to
+``"error"`` and mask what the content assertion would otherwise have
+observed. Assert the new commit and the file's content as two separate
+``git_repo_sync`` entries instead, e.g. under one ``all`` node, as
+opa-remediation's ``repo-remediated`` objective does.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Literal
+
+from jsonpath_ng.exceptions import JSONPathError
+from pydantic import model_validator
+from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
+
+from devops_bench.core import SubprocessError, get_logger
+from devops_bench.core.subprocess import run
+from devops_bench.verification.base import (
+    VERIFIERS,
+    BaseVerifier,
+    VerificationResult,
+    VerificationStatus,
+)
+
+# The two verifiers share one comparison vocabulary on purpose (see the
+# module docstring); reuse resource_property's operator table, and its
+# element-wise across_matches machinery, instead of maintaining a second
+# copy here.
+from devops_bench.verification.verifiers.resource_property import (
+    _VALUE_OPS,
+    _apply_op,
+    _compile,
+    _render_path,
+    _split_at_last_wildcard,
+)
+
+__all__ = ["GitRepoSyncVerifier"]
+
+_log = get_logger("verification.git_repo_sync")
+
+# A fixed per-call cap, not a floor derived from the entry's own deadline:
+# every `_git()` call reads one already-committed ref out of a local bare
+# repo, so 30s is generous for that regardless of timeout_sec (including
+# timeout_sec=0.0 for an assert-mode entry, where "evaluate once" must not
+# mean "give up immediately"). This is what actually stops an unresponsive
+# filesystem or git process from hanging the whole benchmark run.
+_GIT_TIMEOUT_SEC = 30.0
+
+# YAML 1.2 semantics, matching devops_bench.tasks.loader: only `true`/`false`
+# parse as booleans, so `on`/`off`/`yes`/`no` in a manifest stay plain strings
+# rather than being coerced.
+_yaml = YAML(typ="safe")
+
+
+@VERIFIERS.register("git_repo_sync")
+class GitRepoSyncVerifier(BaseVerifier):
+    """Assert a property of a file, or the commit state, at a git ref in a bare repo.
+
+    Attributes:
+        type: Discriminator literal, always ``"git_repo_sync"``.
+        repo_path: Path to the bare repo (``~`` is expanded).
+        ref: Git ref to read; default ``"HEAD"``.
+        file: Path of a file within the repo tree; content is read at ``ref``.
+        path: Optional JSONPath into the file's YAML documents (a list).
+        op: Comparison operator; the same vocabulary as ``resource_property``.
+        value: Expected value for comparison ops.
+        across_matches: When ``path`` ends in a wildcard-like segment
+            (``[*]``, a slice, or a filter ``[?(...)]``), quantifies over the
+            ELEMENTS that segment selects, not over the flattened values the
+            path happens to resolve to: a document missing the target field
+            is a failing observation under ``every``, not an invisible one
+            that silently drops out of the match set. ``none`` treats a
+            document missing the field as trivially conforming. Unset means
+            exactly one match is expected. See ``resource_property``'s
+            docstring for the fail-closed rationale this mirrors.
+        require_new_commit: Also require HEAD to be past the root (seed) commit.
+    """
+
+    type: Literal["git_repo_sync"] = "git_repo_sync"
+    repo_path: str
+    ref: str = "HEAD"
+    file: str | None = None
+    path: str | None = None
+    op: Literal["eq", "ne", "gt", "gte", "lt", "lte", "exists", "absent", "contains", "matches"]
+    value: Any = None
+    across_matches: Literal["every", "none"] | None = None
+    require_new_commit: bool = False
+
+    @model_validator(mode="after")
+    def _check_shape(self) -> GitRepoSyncVerifier:
+        """Expand ``~`` in ``repo_path``; reject combinations meaningless at evaluation time."""
+        self.repo_path = os.path.expanduser(self.repo_path)
+        if self.op in _VALUE_OPS and self.file is None:
+            raise ValueError(f"op {self.op!r} requires 'file'")
+        if self.path is not None and self.file is None:
+            raise ValueError("'path' requires a 'file' to read from the repo")
+        if self.op == "absent" and self.across_matches:
+            msg = "op 'absent' already asserts emptiness and does not take 'across_matches'"
+            raise ValueError(msg)
+        # Scoped deliberately, mirroring resource_property: pathless `exists`
+        # checks the file's (or the ref's) mere presence and returns before
+        # any reduction runs, so accepting `across_matches` there would
+        # silently discard it. `exists` WITH a path is an ordinary per-match
+        # predicate and a reduction over it is meaningful; do not widen this.
+        if self.op == "exists" and not self.path and self.across_matches:
+            msg = (
+                "op 'exists' without 'path' applies to the file/ref itself "
+                "and does not take 'across_matches'"
+            )
+            raise ValueError(msg)
+        if self.op in _VALUE_OPS and self.value is None:
+            raise ValueError(f"op {self.op!r} requires 'value'")
+        if self.path is not None:
+            try:
+                _compile(self.path)
+            except JSONPathError as exc:
+                raise ValueError(f"invalid JSONPath {self.path!r}: {exc}") from exc
+        # Footgun guard: `_check` resolves the seed commit before it reads
+        # any file, so a transient `git rev-list` failure would short-circuit
+        # to `"error"` before a content assertion in the same check ever ran,
+        # masking what would otherwise have been an observable pass or fail.
+        # Reject the combination rather than let it silently mask a result;
+        # the author should split it into two `git_repo_sync` entries.
+        if self.require_new_commit and self.file is not None:
+            msg = (
+                "'require_new_commit' does not combine with a content assertion "
+                "('file') in the same check: a transient git failure while "
+                "resolving the seed commit would mask the content assertion's "
+                "own pass/fail; split them into two git_repo_sync entries"
+            )
+            raise ValueError(msg)
+        return self
+
+    def verify(self, timeout_sec: float) -> VerificationResult:
+        """Poll the git assertion to a result."""
+        return self._poll_to_result(self._check, timeout_sec)
+
+    def _git(self, *args: str) -> str:
+        return run(["git", "-C", self.repo_path, *args], timeout=_GIT_TIMEOUT_SEC).stdout
+
+    def _check(self) -> tuple[VerificationStatus, str, dict[str, Any] | None]:
+        """One evaluation pass: resolve ``ref``, optionally check for a new commit, compare."""
+        try:
+            head = self._git("rev-parse", self.ref).strip()
+        except SubprocessError as exc:
+            # Could not even resolve where to look: the repo itself was never
+            # observed, so this is an error, not an observed violation.
+            _log.debug("git rev-parse failed for %s:%s: %s", self.repo_path, self.ref, exc)
+            return (
+                "error",
+                f"git ref not resolvable at {self.repo_path}:{self.ref}: "
+                f"{(exc.stderr or '').strip()}",
+                None,
+            )
+        except Exception as exc:  # noqa: BLE001 - a git failure is a check error, never raise
+            _log.debug("unexpected git error resolving %s:%s: %s", self.repo_path, self.ref, exc)
+            return "error", f"unexpected git error: {exc}", None
+
+        if self.require_new_commit:
+            try:
+                roots = self._git("rev-list", "--max-parents=0", self.ref).split()
+            except SubprocessError as exc:
+                _log.debug("git rev-list failed for %s:%s: %s", self.repo_path, self.ref, exc)
+                return (
+                    "error",
+                    f"could not determine the seed root for {self.repo_path}:{self.ref}: "
+                    f"{(exc.stderr or '').strip()}",
+                    {"sha": head},
+                )
+            except Exception as exc:  # noqa: BLE001 - a git failure is a check error, never raise
+                _log.debug(
+                    "unexpected git error resolving the seed root for %s:%s: %s",
+                    self.repo_path,
+                    self.ref,
+                    exc,
+                )
+                return (
+                    "error",
+                    f"unexpected git error resolving the seed root: {exc}",
+                    {"sha": head},
+                )
+            if head in roots:
+                return "fail", f"no new commit since the seed root ({head[:8]})", {"sha": head}
+
+        if self.file is None:
+            if self.op == "absent":
+                return (
+                    "fail",
+                    f"repo ref present at {self.ref} (absent not satisfied)",
+                    {"sha": head},
+                )
+            return "pass", f"repo at {self.ref} ({head[:8]})", {"sha": head}
+
+        try:
+            content = self._git("show", f"{self.ref}:{self.file}")
+        except SubprocessError as exc:
+            # The ref itself resolved above, so a missing file at that ref is
+            # an observed fact about the repo's contents, not a check error.
+            if self.op == "absent" and self.path is None:
+                return "pass", f"{self.file} absent at {self.ref}", {"sha": head}
+            return (
+                "fail",
+                f"{self.file} not found at {self.ref}: {(exc.stderr or '').strip()}",
+                {"sha": head},
+            )
+        except Exception as exc:  # noqa: BLE001 - a git failure is a check error, never raise
+            _log.debug("unexpected git error reading %s:%s: %s", self.repo_path, self.ref, exc)
+            return "error", f"unexpected git error reading {self.file}: {exc}", {"sha": head}
+
+        if self.path is None:
+            if self.op == "exists":
+                return "pass", f"{self.file} exists at {self.ref}", {"sha": head}
+            if self.op == "absent":
+                return "fail", f"{self.file} present at {self.ref}", {"sha": head}
+            ok, why = _apply_op(self.op, content, self.value)
+            status: VerificationStatus = "pass" if ok else "fail"
+            return status, f"{self.file}: {why}", {"sha": head}
+
+        try:
+            docs = [doc for doc in _yaml.load_all(content) if doc is not None]
+        except YAMLError as exc:
+            return "fail", f"failed to parse YAML in {self.file}: {exc}", {"sha": head}
+
+        assert self.path is not None  # guaranteed by _check_shape at this point
+        compiled = _compile(self.path)
+
+        # `absent` never carries across_matches (rejected in _check_shape), so
+        # this only ever fires for a genuine element-wise reduction; `absent`
+        # and the plain exactly-one path below always take the value-wise
+        # `flat` branch further down.
+        wildcard_split = (
+            _split_at_last_wildcard(compiled) if self.across_matches is not None else None
+        )
+        if wildcard_split is not None:
+            prefix, suffix = wildcard_split
+            evaluations = self._evaluate_across_elements(prefix, suffix, docs)
+            raw = {"sha": head, "path_matches": len(evaluations)}
+            if not evaluations:
+                if self.across_matches == "none":
+                    return (
+                        "pass",
+                        f"path {self.path!r} resolved to nothing in {self.file} at {self.ref}, "
+                        "satisfying across_matches='none'",
+                        raw,
+                    )
+                # Deliberately fail closed rather than vacuously true: an
+                # unobservable predicate must not read as a satisfied one.
+                return (
+                    "fail",
+                    f"path {self.path!r} did not resolve in {self.file} at {self.ref}",
+                    raw,
+                )
+            success = all(ok for ok, _ in evaluations)
+            detail = "; ".join(reason for _, reason in evaluations)
+            reason = f"across_matches={self.across_matches}: {detail}"
+            return ("pass" if success else "fail"), reason, raw
+
+        found = compiled.find(docs)
+        flat: list[tuple[str, Any]] = [
+            (_render_path(match.full_path), match.value) for match in found
+        ]
+        raw: dict[str, Any] = {"sha": head, "path_matches": len(flat)}
+
+        if self.op == "absent":
+            if flat:
+                sample = [value for _, value in flat[:5]]
+                return (
+                    "fail",
+                    f"path {self.path!r} resolved to {len(flat)} value(s) in {self.file}, "
+                    f"expected none (e.g. {sample})",
+                    raw,
+                )
+            return (
+                "pass",
+                f"path {self.path!r} resolved to nothing in {self.file} at {self.ref}",
+                raw,
+            )
+
+        if not flat:
+            if self.across_matches == "none":
+                return (
+                    "pass",
+                    f"path {self.path!r} resolved to nothing in {self.file} at {self.ref}, "
+                    "satisfying across_matches='none'",
+                    raw,
+                )
+            # Deliberately fail closed rather than vacuously true: an
+            # unobservable predicate must not read as a satisfied one.
+            return (
+                "fail",
+                f"path {self.path!r} did not resolve in {self.file} at {self.ref}",
+                raw,
+            )
+
+        if len(flat) > 1 and self.across_matches is None:
+            flat_paths = [path for path, _ in flat]
+            flat_values = [value for _, value in flat]
+            reason = (
+                f"path {self.path!r} resolved to {len(flat)} value(s) in {self.file} at "
+                f"{flat_paths} ({flat_values}); set 'across_matches' to 'every' or 'none' to "
+                "apply the check across all of them"
+            )
+            return "fail", reason, raw
+
+        results = [self._apply_check(value) for _, value in flat]
+        if self.across_matches == "every":
+            success = all(ok for ok, _ in results)
+        elif self.across_matches == "none":
+            success = not any(ok for ok, _ in results)
+        else:
+            (success, _) = results[0]  # only reachable when len(flat) == 1
+
+        detail = "; ".join(
+            f"{path}: {why}" for (path, _value), (_ok, why) in zip(flat, results, strict=True)
+        )
+        reason = (
+            f"across_matches={self.across_matches}: {detail}" if self.across_matches else detail
+        )
+        status = "pass" if success else "fail"
+        return status, reason, raw
+
+    def _apply_check(self, value: Any) -> tuple[bool, str]:
+        """Apply the operator to one resolved value."""
+        if self.op == "exists":
+            return True, f"path {self.path!r} resolved to {value!r}"
+        return _apply_op(self.op, value, self.value)
+
+    def _evaluate_across_elements(
+        self,
+        prefix: Any,
+        suffix: Any,
+        docs: list[Any],
+    ) -> list[tuple[bool, str]]:
+        """Quantify ``across_matches`` over ``prefix``'s elements, not ``suffix``'s values.
+
+        Mirrors ``resource_property._evaluate_across_elements``: for every
+        element ``prefix`` selects out of ``docs``, resolve ``suffix``
+        relative to that element. ``every``: an element that does not
+        resolve ``suffix`` FAILS outright; every resolved value must also
+        satisfy ``op``. ``none``: an element that does not resolve
+        ``suffix`` trivially conforms; no resolved value may satisfy ``op``.
+        Returns one ``(ok, reason)`` pair per element, named by its jsonpath
+        ``full_path`` in ``file`` at ``ref`` so an element-wise failure is
+        never invisible.
+        """
+        suffix_str = _render_path(suffix)
+        evaluations: list[tuple[bool, str]] = []
+        for element in prefix.find(docs):
+            label = f"{_render_path(element.full_path)} in {self.file} at {self.ref}"
+            resolved = [match.value for match in suffix.find(element.value)]
+            if not resolved:
+                if self.across_matches == "every":
+                    evaluations.append((False, f"{label} did not resolve {suffix_str}"))
+                else:
+                    evaluations.append(
+                        (True, f"{label} did not resolve {suffix_str} (trivially conforms)")
+                    )
+                continue
+            op_results = [self._apply_check(value) for value in resolved]
+            if self.across_matches == "every":
+                ok = all(result for result, _ in op_results)
+            else:
+                ok = not any(result for result, _ in op_results)
+            detail = "; ".join(why for _, why in op_results)
+            evaluations.append((ok, f"{label}: {detail}"))
+        return evaluations

--- a/tests/unit/verification/test_git_repo_sync.py
+++ b/tests/unit/verification/test_git_repo_sync.py
@@ -1,0 +1,661 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the git_repo_sync verifier.
+
+Runs against real, temporary bare git repos under ``tmp_path`` (no ``git``
+mocking): more reliable than faking argv/stdout for a subprocess-heavy
+verifier. The verifier polls via ``_poll_to_result``; a single immediate
+result needs no sleep.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from devops_bench.core import SubprocessError
+from devops_bench.verification import VerificationSpec
+from devops_bench.verification.verifiers.git_repo_sync import GitRepoSyncVerifier
+
+_GIT_CFG = [
+    "-c",
+    "commit.gpgsign=false",
+    "-c",
+    "init.defaultBranch=main",
+    "-c",
+    "safe.bareRepository=all",
+    "-c",
+    "user.email=devops-bench-test@example.com",
+    "-c",
+    "user.name=devops-bench-test",
+]
+
+_WEB_SEED = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: web
+          image: nginx:1.21.6
+"""
+
+_WEB_FIXED = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: web
+          image: nginx:1.27.4
+"""
+
+_APP_SEED = """\
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web
+spec:
+  rules: []
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: web
+spec:
+  minAvailable: 1
+"""
+
+_APP_FIXED = """\
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web
+spec:
+  rules: []
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: web
+spec:
+  minAvailable: 1
+"""
+
+
+def _run(cwd: Path, *args: str) -> str:
+    result = subprocess.run(["git", *_GIT_CFG, *args], cwd=cwd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {result.stderr}")
+    return result.stdout
+
+
+@dataclass
+class GitFixture:
+    """A bare repo with a seed commit and a follow-up "fix" commit."""
+
+    bare: str
+    seed_sha: str
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    bare = tmp_path / "origin.git"
+    work = tmp_path / "work"
+    _run(tmp_path, "init", "--bare", str(bare))
+    _run(tmp_path, "clone", str(bare), str(work))
+    _run(work, "checkout", "-B", "main")
+    return work
+
+
+def _build_git_fixture(tmp_path: Path) -> GitFixture:
+    work = _init_repo(tmp_path)
+    (work / "workloads").mkdir()
+    (work / "workloads" / "web.yaml").write_text(_WEB_SEED)
+    (work / "app.yaml").write_text(_APP_SEED)
+    _run(work, "add", "-A")
+    _run(work, "commit", "-m", "seed")
+    seed_sha = _run(work, "rev-parse", "HEAD").strip()
+    _run(work, "push", "-u", "origin", "main")
+
+    (work / "workloads" / "web.yaml").write_text(_WEB_FIXED)
+    (work / "app.yaml").write_text(_APP_FIXED)
+    _run(work, "add", "-A")
+    _run(work, "commit", "-m", "fix")
+    _run(work, "push")
+
+    return GitFixture(bare=str(work.parent / "origin.git"), seed_sha=seed_sha)
+
+
+def test_registered_via_spec(tmp_path: Path) -> None:
+    node = VerificationSpec(
+        {"type": "git_repo_sync", "repo_path": str(tmp_path), "op": "exists"}
+    ).root
+    assert isinstance(node, GitRepoSyncVerifier)
+
+
+def test_repo_path_tilde_expanded() -> None:
+    v = GitRepoSyncVerifier.model_validate(
+        {"type": "git_repo_sync", "repo_path": "~/nonexistent-xyz.git", "op": "exists"}
+    )
+    assert not v.repo_path.startswith("~")
+
+
+def test_image_matches_after_fix(tmp_path: Path) -> None:
+    fixture = _build_git_fixture(tmp_path)
+    v = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": fixture.bare,
+            "file": "workloads/web.yaml",
+            "path": "$[?(@.kind=='Deployment')].spec.template.spec.containers[0].image",
+            "op": "matches",
+            "value": r"nginx:1\.(2[7-9]|[3-9][0-9])",
+        }
+    )
+    result = v.verify(0)
+    assert result.success is True
+    assert result.status == "pass"
+
+
+def test_image_matches_fails_on_seed_ref(tmp_path: Path) -> None:
+    fixture = _build_git_fixture(tmp_path)
+    v = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": fixture.bare,
+            "ref": fixture.seed_sha,
+            "file": "workloads/web.yaml",
+            "path": "$[?(@.kind=='Deployment')].spec.template.spec.containers[0].image",
+            "op": "matches",
+            "value": r"nginx:1\.(2[7-9]|[3-9][0-9])",
+        }
+    )
+    result = v.verify(0)
+    assert result.success is False
+    assert result.status == "fail"
+
+
+# Neither test below combines `require_new_commit` with `file`: both check
+# the repo/ref itself (`op: exists`, no `file`), which is exactly the shape
+# `test_require_new_commit_with_file_is_rejected` requires everyone to use.
+
+
+def test_require_new_commit_true_after_fix(tmp_path: Path) -> None:
+    fixture = _build_git_fixture(tmp_path)
+    v = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": fixture.bare,
+            "require_new_commit": True,
+            "op": "exists",
+        }
+    )
+    result = v.verify(0)
+    assert result.success is True
+    assert result.status == "pass"
+
+
+def test_require_new_commit_false_on_seed_only_repo(tmp_path: Path) -> None:
+    work = _init_repo(tmp_path)
+    (work / "seed.txt").write_text("seed\n")
+    _run(work, "add", "-A")
+    _run(work, "commit", "-m", "seed")
+    _run(work, "push", "-u", "origin", "main")
+
+    v = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": str(work.parent / "origin.git"),
+            "require_new_commit": True,
+            "op": "exists",
+        }
+    )
+    result = v.verify(0)
+    assert result.success is False
+    assert result.status == "fail"
+
+
+def test_require_new_commit_with_file_is_rejected() -> None:
+    # Footgun guard: `_check` resolves the seed commit before it reads any
+    # file, so combining `require_new_commit` with a content assertion in
+    # the same check would let a transient `git rev-list` failure mask the
+    # content assertion's own pass/fail. Reject the combination up front.
+    with pytest.raises(ValidationError, match="does not combine"):
+        GitRepoSyncVerifier.model_validate(
+            {
+                "type": "git_repo_sync",
+                "repo_path": "/tmp/does-not-matter.git",
+                "require_new_commit": True,
+                "file": "workloads/web.yaml",
+                "op": "exists",
+            }
+        )
+
+
+def test_invalid_jsonpath_rejected_at_parse_time() -> None:
+    with pytest.raises(ValidationError, match="invalid JSONPath"):
+        GitRepoSyncVerifier.model_validate(
+            {
+                "type": "git_repo_sync",
+                "repo_path": "/tmp/does-not-matter.git",
+                "file": "workloads/web.yaml",
+                "path": "$[?(",
+                "op": "exists",
+            }
+        )
+
+
+def test_absent_with_across_matches_rejected() -> None:
+    with pytest.raises(ValidationError, match="already asserts emptiness"):
+        GitRepoSyncVerifier.model_validate(
+            {
+                "type": "git_repo_sync",
+                "repo_path": "/tmp/does-not-matter.git",
+                "file": "workloads/web.yaml",
+                "path": "$[*].kind",
+                "op": "absent",
+                "across_matches": "none",
+            }
+        )
+
+
+def test_pathless_exists_with_across_matches_rejected() -> None:
+    with pytest.raises(ValidationError, match="applies to the file/ref itself"):
+        GitRepoSyncVerifier.model_validate(
+            {
+                "type": "git_repo_sync",
+                "repo_path": "/tmp/does-not-matter.git",
+                "op": "exists",
+                "across_matches": "every",
+            }
+        )
+
+
+def test_value_op_without_file_rejected() -> None:
+    with pytest.raises(ValidationError, match="requires 'file'"):
+        GitRepoSyncVerifier.model_validate(
+            {
+                "type": "git_repo_sync",
+                "repo_path": "/tmp/does-not-matter.git",
+                "op": "eq",
+                "value": "banana",
+            }
+        )
+
+
+def test_value_op_without_value_rejected() -> None:
+    with pytest.raises(ValidationError, match="requires 'value'"):
+        GitRepoSyncVerifier.model_validate(
+            {
+                "type": "git_repo_sync",
+                "repo_path": "/tmp/does-not-matter.git",
+                "file": "workloads/web.yaml",
+                "op": "eq",
+            }
+        )
+
+
+def test_multidoc_ingress_apiversion_migrated(tmp_path: Path) -> None:
+    fixture = _build_git_fixture(tmp_path)
+    v = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": fixture.bare,
+            "file": "app.yaml",
+            "path": "$[?(@.kind=='Ingress')].apiVersion",
+            "op": "eq",
+            "value": "networking.k8s.io/v1",
+        }
+    )
+    result = v.verify(0)
+    assert result.success is True
+    assert result.status == "pass"
+
+
+def test_multidoc_v1beta1_absent_on_fixed_present_on_seed(tmp_path: Path) -> None:
+    fixture = _build_git_fixture(tmp_path)
+    spec = {
+        "type": "git_repo_sync",
+        "repo_path": fixture.bare,
+        "file": "app.yaml",
+        "path": "$[?(@.apiVersion=='networking.k8s.io/v1beta1')]",
+        "op": "absent",
+    }
+
+    v_fixed = GitRepoSyncVerifier.model_validate(spec)
+    result_fixed = v_fixed.verify(0)
+    assert result_fixed.success is True
+    assert result_fixed.status == "pass"
+
+    v_seed = GitRepoSyncVerifier.model_validate({**spec, "ref": fixture.seed_sha})
+    result_seed = v_seed.verify(0)
+    assert result_seed.success is False
+    assert result_seed.status == "fail"
+
+
+def test_across_matches_every_and_none(tmp_path: Path) -> None:
+    fixture = _build_git_fixture(tmp_path)
+
+    v_every = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": fixture.bare,
+            "file": "app.yaml",
+            "path": "$[*].kind",
+            "op": "ne",
+            "value": "ServiceAccount",
+            "across_matches": "every",
+        }
+    )
+    result_every = v_every.verify(0)
+    assert result_every.success is True
+    assert result_every.status == "pass"
+
+    v_none_fails = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": fixture.bare,
+            "file": "app.yaml",
+            "path": "$[*].kind",
+            "op": "ne",
+            "value": "ServiceAccount",
+            "across_matches": "none",
+        }
+    )
+    result_none_fails = v_none_fails.verify(0)
+    assert result_none_fails.success is False
+    assert result_none_fails.status == "fail"
+
+    v_none_passes = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": fixture.bare,
+            "file": "app.yaml",
+            "path": "$[*].apiVersion",
+            "op": "eq",
+            "value": "banana",
+            "across_matches": "none",
+        }
+    )
+    result_none_passes = v_none_passes.verify(0)
+    assert result_none_passes.success is True
+    assert result_none_passes.status == "pass"
+
+    v_every_fails = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": fixture.bare,
+            "file": "app.yaml",
+            "path": "$[*].apiVersion",
+            "op": "eq",
+            "value": "banana",
+            "across_matches": "every",
+        }
+    )
+    result_every_fails = v_every_fails.verify(0)
+    assert result_every_fails.success is False
+    assert result_every_fails.status == "fail"
+
+
+def test_repo_path_nonexistent_dir_is_an_error(tmp_path: Path) -> None:
+    v = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": str(tmp_path / "does-not-exist.git"),
+            "op": "exists",
+        }
+    )
+    result = v.verify(0)
+    assert result.success is False
+    assert result.status == "error"
+
+
+def test_file_not_found_at_ref_is_a_fail_not_an_error(tmp_path: Path) -> None:
+    fixture = _build_git_fixture(tmp_path)
+    v = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": fixture.bare,
+            "file": "workloads/does-not-exist.yaml",
+            "op": "exists",
+        }
+    )
+    result = v.verify(0)
+    assert result.success is False
+    assert result.status == "fail"
+
+
+def test_yaml_parse_failure_is_a_fail_not_an_error(tmp_path: Path) -> None:
+    # The file itself was found (the ref resolved and `git show` succeeded);
+    # unparsable content is an observed fact about the repo, not a verifier
+    # error, so this reports "fail" the same way a missing file does.
+    work = _init_repo(tmp_path)
+    (work / "broken.yaml").write_text("key: [unterminated\n")
+    _run(work, "add", "-A")
+    _run(work, "commit", "-m", "seed")
+    _run(work, "push", "-u", "origin", "main")
+
+    v = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": str(work.parent / "origin.git"),
+            "file": "broken.yaml",
+            "path": "$[*].key",
+            "op": "exists",
+        }
+    )
+    result = v.verify(0)
+    assert result.success is False
+    assert result.status == "fail"
+    assert "failed to parse YAML" in result.reason
+
+
+def test_absent_on_missing_file_is_true(tmp_path: Path) -> None:
+    fixture = _build_git_fixture(tmp_path)
+    v = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": fixture.bare,
+            "file": "workloads/does-not-exist.yaml",
+            "op": "absent",
+        }
+    )
+    result = v.verify(0)
+    assert result.success is True
+    assert result.status == "pass"
+
+
+# -- tri-state and across_matches edge cases (Task V3 additions) --------
+
+
+def test_git_command_failure_is_an_error(tmp_path: Path) -> None:
+    v = GitRepoSyncVerifier.model_validate(
+        {"type": "git_repo_sync", "repo_path": str(tmp_path), "op": "exists"}
+    )
+    with patch.object(
+        v,
+        "_git",
+        side_effect=SubprocessError(["git", "rev-parse", "HEAD"], returncode=128, stderr="boom"),
+    ):
+        result = v.verify(0)
+    assert result.success is False
+    assert result.status == "error"
+    assert "boom" in result.reason
+
+
+def test_multiple_matches_without_across_matches_fails_naming_them(tmp_path: Path) -> None:
+    fixture = _build_git_fixture(tmp_path)
+    v = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": fixture.bare,
+            "file": "app.yaml",
+            "path": "$[*].kind",
+            "op": "ne",
+            "value": "ServiceAccount",
+        }
+    )
+    result = v.verify(0)
+    assert result.success is False
+    assert result.status == "fail"
+    assert "across_matches" in result.reason
+    assert "Ingress" in result.reason
+    assert "PodDisruptionBudget" in result.reason
+    # The matched paths render without jsonpath_ng's wrapping parens noise.
+    assert "[0].kind" in result.reason
+    assert "[1].kind" in result.reason
+    assert "([0]" not in result.reason
+    assert "([1]" not in result.reason
+
+
+def test_multiple_matches_deep_path_renders_clean_dotted_reason(tmp_path: Path) -> None:
+    # A deep path (3+ segments through the wildcard) exercises the general
+    # `_render_path` recursion, not just the single-segment `.kind` case
+    # above: jsonpath_ng nests one paren pair per segment in `full_path`'s
+    # own `str()`, so a shallow "strip the outer pair" fix would still leave
+    # nested parens on a path like this one.
+    fixture = _build_git_fixture(tmp_path)
+    v = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": fixture.bare,
+            "file": "app.yaml",
+            "path": "$[*].metadata.name",
+            "op": "eq",
+            "value": "web",
+        }
+    )
+    result = v.verify(0)
+    assert result.success is False
+    assert result.status == "fail"
+    assert "[0].metadata.name" in result.reason
+    assert "[1].metadata.name" in result.reason
+    assert "((" not in result.reason
+
+
+def test_empty_match_set_with_across_matches_none_passes(tmp_path: Path) -> None:
+    fixture = _build_git_fixture(tmp_path)
+    v = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": fixture.bare,
+            "file": "app.yaml",
+            "path": "$[*].apiVersion",
+            "op": "eq",
+            "value": "banana",
+            "across_matches": "none",
+        }
+    )
+    result = v.verify(0)
+    assert result.success is True
+    assert result.status == "pass"
+
+
+# -- element-wise across_matches (PR 47 follow-up) -----------------------
+#
+# JSONPath drops elements that fail to resolve the target field, so a
+# value-wise reduction over the flattened matches silently degrades "every
+# element has X" to "at least one has X". These assert the fix quantifies
+# over the elements the last wildcard-like path segment selects instead:
+# `app.yaml`'s Ingress doc has no `spec.minAvailable` and its
+# PodDisruptionBudget doc has no `spec.rules`, so either field read across
+# both docs must FAIL under `every` by naming the doc that never resolved
+# the suffix.
+
+
+def test_across_matches_every_fails_on_element_missing_field(tmp_path: Path) -> None:
+    fixture = _build_git_fixture(tmp_path)
+    v = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": fixture.bare,
+            "file": "app.yaml",
+            "path": "$[*].spec.rules",
+            "op": "exists",
+            "across_matches": "every",
+        }
+    )
+    result = v.verify(0)
+    assert result.success is False
+    assert result.status == "fail"
+    assert "did not resolve" in result.reason
+    assert "[1]" in result.reason
+
+
+def test_across_matches_every_value_op_fails_on_element_missing_field(tmp_path: Path) -> None:
+    fixture = _build_git_fixture(tmp_path)
+    v = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": fixture.bare,
+            "file": "app.yaml",
+            "path": "$[*].spec.minAvailable",
+            "op": "eq",
+            "value": 1,
+            "across_matches": "every",
+        }
+    )
+    result = v.verify(0)
+    assert result.success is False
+    assert result.status == "fail"
+    assert "did not resolve" in result.reason
+    assert "[0]" in result.reason
+
+
+def test_across_matches_none_element_wise(tmp_path: Path) -> None:
+    fixture = _build_git_fixture(tmp_path)
+
+    v_absent_everywhere = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": fixture.bare,
+            "file": "app.yaml",
+            "path": "$[*].spec.selector",
+            "op": "eq",
+            "value": "anything",
+            "across_matches": "none",
+        }
+    )
+    result_absent = v_absent_everywhere.verify(0)
+    assert result_absent.success is True
+    assert result_absent.status == "pass"
+
+    v_present_and_passing = GitRepoSyncVerifier.model_validate(
+        {
+            "type": "git_repo_sync",
+            "repo_path": fixture.bare,
+            "file": "app.yaml",
+            "path": "$[*].spec.minAvailable",
+            "op": "eq",
+            "value": 1,
+            "across_matches": "none",
+        }
+    )
+    result_present = v_present_and_passing.verify(0)
+    assert result_present.success is False
+    assert result_present.status == "fail"


### PR DESCRIPTION
This adds the `git_repo_sync` verifier, the missing piece behind #56: the opa-remediation task asks the agent to keep the GitOps repository in sync, but nothing deterministic checks it. This PR is verifier-only, matching #54 and #55; a small follow-up PR re-enables the task objective and closes #56 once this merges.

The verifier reads the bare repository directly with `git rev-parse` / `rev-list` / `show` (no clone, read-only), parses a file at a ref as multi-document YAML, resolves a JSONPath, and applies a comparison. It deliberately shares one comparison vocabulary with `resource_property`: the same operators, the same `across_matches` element-wise quantification (every element selected by the path's last wildcard segment must resolve and satisfy the op; a missing field is a named failing observation), and the same fail-closed rules for empty and ambiguous match sets.

Semantics worth calling out:
- Tri-state mapping judges each failure mode by whether repository state was actually observed: a git command failure is `error` (could not evaluate), while a missing file at the ref, unparseable YAML, or a failed comparison are observed facts and report `fail`.
- Every git call carries a fixed 30s cap, so a wedged subprocess cannot stall a run.
- `require_new_commit` (did the agent push anything beyond the seed commit) is a separate check by construction: a validator rejects combining it with a content assertion in the same check, so a transient `rev-list` failure can never mask an observable content failure.

26 unit tests run against real temporary bare repositories rather than mocked subprocess output, including regressions proving the element-wise `every` fails when an element lacks the target field. No new dependencies.

Part of #56.
