### PR TITLE
Remove !needs-ok-to-test from CodeRabbit labels

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -57,6 +57,5 @@ reviews:
     base_branches:
       - ".*"
     labels:
-      - "!needs-ok-to-test"
       - "!do-not-merge/work-in-progress"
       - "!cncf-cla: no"


### PR DESCRIPTION
Enable CodeRabbit for PRs with `needs-ok-to-test` label, given that this repo has a lot of contributors who don't have kubernetes membership yet
