### PR TITLE
feat(verification): implement hold mode for verification entries

### DIFF
--- a/devops_bench/verification/runner.py
+++ b/devops_bench/verification/runner.py
@@ -78,6 +78,15 @@ _SINGLE_SHOT_WAIT_CEILING_SEC = 120.0
 # path and the single-shot wait-ceiling path in :meth:`VerifierAgent._run_parallel`.
 _PARALLEL_INCOMPLETE_REASON = "evaluation did not complete before the deadline"
 
+# Hold-mode defaults used when an entry sets mode: hold but does not override
+# the window / interval. Explicit-only: resolved_mode never derives "hold"
+# from a role, so these apply only to an entry that opts in by name. These
+# join the timing vocabulary (_MIN_LEAF_BUDGET_SECONDS,
+# _SINGLE_SHOT_WAIT_CEILING_SEC) a future shared timing module will
+# consolidate.
+_DEFAULT_HOLD_WINDOW_SEC = 30.0
+_DEFAULT_HOLD_INTERVAL_SEC = 5.0
+
 
 def _node_name(node: Any) -> str | None:
     """Echo the optional ``name`` label from a spec node, if any."""
@@ -195,18 +204,34 @@ class VerifierAgent:
         what an objective wants: the agent is working toward the state and the
         check should wait for it. ``assert`` evaluates once with a zero budget,
         which is what a safeguard wants: a violation that has already happened
-        will not heal, and polling one would only waste the run's time.
+        will not heal, and polling one would only waste the run's time. ``hold``
+        verifies a state STAYS true: where converge gives a condition time to
+        become true, hold denies it time to stop being true, sampling the
+        subtree repeatedly across a window instead of evaluating it once.
 
         Args:
             entry: The parsed entry to evaluate.
-            timeout_sec: Total budget for a converging entry. Ignored under
-                ``assert``.
+            timeout_sec: Total budget for a converging or holding entry.
+                Ignored under ``assert``.
 
         Returns:
             The subtree's result, including per-child results.
         """
-        single_shot = entry.resolved_mode == "assert"
+        mode = entry.resolved_mode
+        single_shot = mode == "assert"
         deadline = time.monotonic() + (0.0 if single_shot else timeout_sec)
+        if mode == "hold":
+            window_sec = (
+                entry.hold_window_sec
+                if entry.hold_window_sec is not None
+                else _DEFAULT_HOLD_WINDOW_SEC
+            )
+            interval_sec = (
+                entry.hold_poll_interval_sec
+                if entry.hold_poll_interval_sec is not None
+                else _DEFAULT_HOLD_INTERVAL_SEC
+            )
+            return self._hold(entry.check, window_sec, interval_sec, deadline)
         return self._run(entry.check, deadline, single_shot=single_shot)
 
     def _run(self, node: Any, deadline: float, *, single_shot: bool = False) -> VerificationResult:
@@ -244,6 +269,124 @@ class VerifierAgent:
         if remaining < _MIN_LEAF_BUDGET_SECONDS:
             return _failed(node, "deadline exhausted before evaluation")
         return node.verify(remaining)
+
+    def _hold(
+        self, node: Any, window_sec: float, interval_sec: float, deadline: float
+    ) -> VerificationResult:
+        """Sample ``node`` repeatedly, verifying a condition STAYS true over a window.
+
+        Every sample runs through :meth:`_run` with ``single_shot=True`` (not a
+        bare ``node.verify(0.0)``), so a compound subtree samples correctly and
+        each leaf's own I/O stays bounded to one snapshot instead of a poll.
+
+        A truncated or partially observed window is never reported as a pass:
+        this repo's no-vacuous-truth doctrine treats "we did not actually watch
+        the whole window" as unknown, not as success. Two guards enforce that.
+        Upfront, if the remaining budget to ``deadline`` cannot cover the full
+        ``window_sec``, the window is rejected before sampling starts (zero
+        samples, status "error"). The window itself is then timed from its own
+        fresh clock read rather than reusing the upfront check's read, so a
+        caller-supplied ``deadline`` that turns out not to cover the full
+        window despite passing that check is still caught: during sampling,
+        if ``deadline`` is reached before the window completes, the samples
+        taken so far are reported as an incomplete observation (status
+        "error"), not a pass.
+
+        A sample that observes the condition false ends the hold immediately
+        with status "fail": a hold's job is to catch the state slipping, and
+        it just did. A sample that could not be evaluated (status "error")
+        does not end the hold early, since the condition may still be holding;
+        sampling continues, but the window can then never report a plain pass
+        once observation was incomplete at any sample, so a window that
+        completes with no fail but at least one error sample reports status
+        "error", naming how many samples were unobserved.
+
+        Args:
+            node: The parsed check subtree to sample.
+            window_sec: Seconds to keep sampling.
+            interval_sec: Seconds to sleep between samples.
+            deadline: Absolute monotonic deadline for the whole entry.
+
+        Returns:
+            "fail" on the first failing sample; "error" when the window could
+            not be fully observed (truncated upfront, cut short mid-window, or
+            tainted by one or more error samples); "pass" only once every
+            sample across the full window passed.
+        """
+        remaining = deadline - time.monotonic()
+        if remaining < window_sec:
+            return VerificationResult(
+                success=False,
+                status="error",
+                elapsed_time=0.0,
+                reason=(
+                    f"hold window of {window_sec:.1f}s cannot be observed within "
+                    f"the remaining entry budget ({remaining:.1f}s)"
+                ),
+                name=_node_name(node),
+            )
+
+        start = time.monotonic()
+        window_end = start + window_sec
+        samples = 0
+        error_samples = 0
+        last: VerificationResult | None = None
+        while True:
+            last = self._run(node, deadline, single_shot=True)
+            samples += 1
+            if last.status == "fail":
+                return VerificationResult(
+                    success=False,
+                    status="fail",
+                    elapsed_time=time.monotonic() - start,
+                    reason=f"hold failed at sample {samples}: {last.reason}",
+                    name=_node_name(node),
+                    children=[last],
+                )
+            if last.status == "error":
+                error_samples += 1
+            now = time.monotonic()
+            if now >= window_end:
+                break
+            if now >= deadline:
+                return VerificationResult(
+                    success=False,
+                    status="error",
+                    elapsed_time=now - start,
+                    reason=(
+                        f"hold window of {window_sec:.1f}s was cut short by the "
+                        f"entry deadline after {now - start:.1f}s "
+                        f"({samples} sample(s) observed)"
+                    ),
+                    name=_node_name(node),
+                    children=[last],
+                )
+            sleep_time = min(interval_sec, window_end - now, deadline - now)
+            if sleep_time > 0:
+                time.sleep(sleep_time)
+
+        elapsed = time.monotonic() - start
+        if error_samples:
+            return VerificationResult(
+                success=False,
+                status="error",
+                elapsed_time=elapsed,
+                reason=(
+                    f"hold window completed with {error_samples} error sample(s) "
+                    f"out of {samples}: the condition may have held, but it was "
+                    "not observed at every sample"
+                ),
+                name=_node_name(node),
+                children=[last],
+            )
+        return VerificationResult(
+            success=True,
+            status="pass",
+            elapsed_time=elapsed,
+            reason=f"hold passed: {samples} sample(s) over {elapsed:.1f}s",
+            name=_node_name(node),
+            children=[last],
+        )
 
     @staticmethod
     def _skip_rest(

--- a/devops_bench/verification/spec.py
+++ b/devops_bench/verification/spec.py
@@ -300,6 +300,17 @@ class VerificationEntry(BaseModel):
     An entry pairs a check subtree with the scoring vocabulary: what the check
     is for (``role``), how badly it matters when it fails (``severity``), how
     much it counts (``weight``), and how it is evaluated (``mode``).
+
+    Attributes:
+        hold_window_sec: Seconds to sample the check for ``mode: hold``. Must
+            be positive when set; ``None`` defers to the runner's default
+            window so most hold entries do not need to spell it out. Setting
+            this on an entry whose mode is not ``hold`` is a validation
+            error, since it would otherwise silently do nothing.
+        hold_poll_interval_sec: Seconds to sleep between hold samples. Must
+            be positive when set; ``None`` defers to the runner's default
+            interval. Same hold-only restriction as ``hold_window_sec``, for
+            the same silent-no-op reason.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -310,6 +321,8 @@ class VerificationEntry(BaseModel):
     mode: Literal["converge", "assert", "hold"] | None = None
     weight: float = Field(default=1.0, gt=0)
     check: Any
+    hold_window_sec: float | None = Field(default=None, gt=0)
+    hold_poll_interval_sec: float | None = Field(default=None, gt=0)
 
     @field_validator("check", mode="before")
     @classmethod
@@ -322,13 +335,22 @@ class VerificationEntry(BaseModel):
 
     @model_validator(mode="after")
     def _check_role_and_mode(self) -> VerificationEntry:
-        """Enforce the role/severity pairing and reject the unbuilt mode."""
+        """Enforce the role/severity pairing and the hold-field/mode coupling.
+
+        A ``hold_*`` field only means something when ``mode`` is explicitly
+        ``"hold"``; setting one on any other entry is rejected by name rather
+        than silently ignored, since a silent no-op is exactly how a
+        misconfigured entry hides.
+        """
         if self.role == "safeguard" and self.severity is None:
             raise ValueError("severity is required when role is 'safeguard'")
         if self.role == "objective" and self.severity is not None:
             raise ValueError("severity is not allowed when role is 'objective'")
-        if self.mode == "hold":
-            raise ValueError("mode 'hold' is not yet supported; use 'converge' or 'assert'")
+        if self.mode != "hold":
+            if self.hold_window_sec is not None:
+                raise ValueError("hold_window_sec is only valid when mode is 'hold'")
+            if self.hold_poll_interval_sec is not None:
+                raise ValueError("hold_poll_interval_sec is only valid when mode is 'hold'")
         return self
 
     @property
@@ -338,7 +360,10 @@ class VerificationEntry(BaseModel):
         Objectives converge because they describe a state the agent is working
         toward. Safeguards assert because they describe a state that must never
         have been entered, and polling one would just wait for a violation to
-        heal.
+        heal. ``hold`` is never derived here, only ever explicit: it is
+        significant enough (a whole sampled window, not a single check) that
+        an entry must opt into it by name rather than inherit it from a role
+        default.
         """
         if self.mode is not None:
             return self.mode

--- a/tests/unit/evalharness/test_verification_wiring.py
+++ b/tests/unit/evalharness/test_verification_wiring.py
@@ -206,6 +206,37 @@ def test_converge_entry_is_recorded_as_budget_exhausted_in_the_sub_second_window
     assert report[1]["reason"] == "verification total budget exhausted before evaluation"
 
 
+def test_hold_entry_is_recorded_as_budget_exhausted_once_the_total_is_gone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hold entry needs budget like a converge entry: it is not assert's carve-out."""
+    hold_spec = {**_SPEC[0], "name": "web-stays-ready", "mode": "hold", "hold_window_sec": 5}
+    entries, errors = parse_entries([_SPEC[0], hold_spec])
+    assert errors == []
+    # Above MIN_LEAF_BUDGET_SECONDS so the first entry clears the guard; the
+    # sleep below then drops the remainder under it for the hold entry.
+    total_budget = MIN_LEAF_BUDGET_SECONDS * 1.2
+    monkeypatch.setattr(
+        "devops_bench.evalharness.default.VERIFICATION_TOTAL_BUDGET_SEC", total_budget
+    )
+
+    def fake_run_entry(entry: object, timeout_sec: float = 120) -> VerificationResult:
+        sleep_sec = MIN_LEAF_BUDGET_SECONDS * 0.3  # outruns the tiny total budget
+        time.sleep(sleep_sec)
+        return VerificationResult(success=True, elapsed_time=sleep_sec, reason="ok")
+
+    with patch(
+        "devops_bench.evalharness.default.VerifierAgent.run_entry", side_effect=fake_run_entry
+    ):
+        report = _harness()._run_verification(entries, timeout_sec=120)
+
+    assert report[0]["success"] is True
+    assert report[1]["mode"] == "hold"
+    assert report[1]["success"] is False
+    assert report[1]["status"] == "error"
+    assert report[1]["reason"] == "verification total budget exhausted before evaluation"
+
+
 def test_assert_entry_still_evaluates_after_the_total_budget_is_exhausted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/verification/test_entries.py
+++ b/tests/unit/verification/test_entries.py
@@ -60,10 +60,42 @@ def test_objective_with_severity_is_an_error() -> None:
     assert "severity is not allowed" in errors[0]["reason"]
 
 
-def test_mode_hold_is_rejected_with_a_specific_message() -> None:
+def test_mode_hold_is_accepted() -> None:
     entries, errors = parse_entries([_entry(mode="hold")])
+    assert errors == []
+    assert entries[0].resolved_mode == "hold"
+
+
+def test_hold_window_sec_is_rejected_on_a_converge_entry() -> None:
+    entries, errors = parse_entries([_entry(hold_window_sec=10)])
     assert entries == []
-    assert "not yet supported" in errors[0]["reason"]
+    assert "hold_window_sec" in errors[0]["reason"]
+
+
+def test_hold_poll_interval_sec_is_rejected_on_an_assert_entry() -> None:
+    entries, errors = parse_entries(
+        [_entry(role="safeguard", severity="recoverable", mode="assert", hold_poll_interval_sec=5)]
+    )
+    assert entries == []
+    assert "hold_poll_interval_sec" in errors[0]["reason"]
+
+
+def test_hold_fields_are_accepted_with_mode_hold() -> None:
+    entries, errors = parse_entries(
+        [_entry(mode="hold", hold_window_sec=10, hold_poll_interval_sec=2)]
+    )
+    assert errors == []
+    assert entries[0].hold_window_sec == 10
+    assert entries[0].hold_poll_interval_sec == 2
+
+
+def test_resolved_mode_never_derives_hold_from_role_defaults() -> None:
+    entries, errors = parse_entries([_entry()])
+    assert errors == []
+    assert entries[0].resolved_mode != "hold"
+    entries, errors = parse_entries([_entry(role="safeguard", severity="recoverable")])
+    assert errors == []
+    assert entries[0].resolved_mode != "hold"
 
 
 def test_duplicate_names_keep_the_first_and_report_the_second() -> None:

--- a/tests/unit/verification/test_hold_mode.py
+++ b/tests/unit/verification/test_hold_mode.py
@@ -1,0 +1,183 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for hold-mode sampling in the entry-level runner.
+
+Windows are kept sub-second (or fully clock-mocked) throughout, so this
+module runs in well under a second: no test here waits on a real multi-second
+window.
+"""
+
+from typing import Any, Literal
+
+import pytest
+
+from devops_bench.verification.base import VERIFIERS, BaseVerifier, VerificationResult
+from devops_bench.verification.runner import VerifierAgent
+from devops_bench.verification.spec import parse_entries
+
+
+@VERIFIERS.register("hold_stub")
+class _Stepping(BaseVerifier):
+    """Test double returning a scripted status per call, in declaration order.
+
+    Attributes:
+        statuses: Per-call outcomes; the last entry repeats once exhausted,
+            so a scripted list shorter than the eventual sample count still
+            behaves sensibly.
+        calls: Total number of times :meth:`verify` has been invoked.
+    """
+
+    type: Literal["hold_stub"] = "hold_stub"
+    statuses: list[str] = []
+    calls: int = 0
+
+    def verify(self, timeout_sec: float) -> VerificationResult:
+        idx = min(self.calls, len(self.statuses) - 1)
+        status = self.statuses[idx]
+        self.calls += 1
+        return VerificationResult(
+            success=status == "pass",
+            status=status,
+            elapsed_time=0.0,
+            reason=f"sample {self.calls}: {status}",
+            name=self.name,
+        )
+
+
+def _entry(statuses: list[str], **extra: Any) -> Any:
+    payload = {
+        "name": "e",
+        "role": "safeguard",
+        "severity": "recoverable",
+        "mode": "hold",
+        "check": {"type": "hold_stub", "statuses": statuses},
+    }
+    payload.update(extra)
+    entries, errors = parse_entries([payload])
+    assert errors == []
+    return entries[0]
+
+
+def test_hold_all_pass_window_samples_at_least_twice_and_names_the_count() -> None:
+    entry = _entry(["pass"] * 8, hold_window_sec=0.05, hold_poll_interval_sec=0.01)
+
+    result = VerifierAgent().run_entry(entry, timeout_sec=5)
+
+    assert result.status == "pass"
+    assert result.success is True
+    assert entry.check.calls >= 2
+    assert f"{entry.check.calls} sample" in result.reason
+
+
+def test_hold_fails_fast_on_the_failing_sample_and_stops_sampling() -> None:
+    entry = _entry(
+        ["pass", "pass", "fail", "pass"], hold_window_sec=0.05, hold_poll_interval_sec=0.01
+    )
+
+    result = VerifierAgent().run_entry(entry, timeout_sec=30)
+
+    assert result.status == "fail"
+    assert result.success is False
+    # No sample past the failing one, so this stops after the third sample
+    # regardless of how large the configured window is.
+    assert entry.check.calls == 3
+    assert "hold failed at sample 3" in result.reason
+    assert len(result.children) == 1
+    assert result.children[0].status == "fail"
+
+
+def test_hold_error_tainted_window_continues_sampling_and_reports_error() -> None:
+    entry = _entry(
+        ["pass", "error", "pass", "error", "pass"],
+        hold_window_sec=0.05,
+        hold_poll_interval_sec=0.01,
+    )
+
+    result = VerifierAgent().run_entry(entry, timeout_sec=5)
+
+    assert result.status == "error"
+    assert result.success is False
+    # Sampling continued well past the first error sample (index 1).
+    assert entry.check.calls >= 4
+    assert "error sample" in result.reason
+
+
+def test_hold_truncation_upfront_is_immediate_error_with_zero_samples() -> None:
+    entry = _entry(["pass"], hold_window_sec=10, hold_poll_interval_sec=1)
+
+    result = VerifierAgent().run_entry(entry, timeout_sec=0.05)
+
+    assert result.status == "error"
+    assert result.success is False
+    assert entry.check.calls == 0
+    assert "cannot be observed" in result.reason
+    assert result.children == []
+
+
+def test_hold_mid_window_deadline_expiry_reports_partial_observation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deadline that lands strictly before the window completes is an error.
+
+    Exercises ``_hold`` directly with a scripted clock: the upfront
+    remaining-budget check and the window's own start are read from separate
+    ``time.monotonic()`` calls, so a caller-supplied deadline that does not
+    actually cover the full window despite passing that upfront check must
+    still be caught mid-loop rather than reported as a completed window.
+    """
+    node = _Stepping(statuses=["pass"] * 5)
+    times = iter([0.0, 15.0, 18.0, 21.0])
+    monkeypatch.setattr("devops_bench.verification.runner.time.monotonic", lambda: next(times))
+    monkeypatch.setattr("devops_bench.verification.runner.time.sleep", lambda _: None)
+
+    result = VerifierAgent()._hold(node, window_sec=10.0, interval_sec=1.0, deadline=20.0)
+
+    assert result.status == "error"
+    assert result.success is False
+    assert node.calls == 2
+    assert "cut short" in result.reason
+    assert "2 sample" in result.reason
+
+
+def test_hold_samples_a_compound_subtree_correctly() -> None:
+    payload = {
+        "name": "e",
+        "role": "safeguard",
+        "severity": "recoverable",
+        "mode": "hold",
+        "hold_window_sec": 0.05,
+        "hold_poll_interval_sec": 0.01,
+        "check": {
+            "type": "all",
+            "checks": [
+                {"type": "hold_stub", "statuses": ["pass"] * 8},
+                {"type": "hold_stub", "statuses": ["pass"] * 8},
+            ],
+        },
+    }
+    entries, errors = parse_entries([payload])
+    assert errors == []
+
+    result = VerifierAgent().run_entry(entries[0], timeout_sec=5)
+
+    assert result.status == "pass"
+    assert result.success is True
+    # The hold's own children carry the last sample: the `all` node's result.
+    assert len(result.children) == 1
+    last_sample = result.children[0]
+    assert len(last_sample.children) == 2
+    assert all(c.status == "pass" for c in last_sample.children)
+    leaves = entries[0].check.checks
+    assert all(leaf.calls >= 2 for leaf in leaves)


### PR DESCRIPTION
This implements `mode: hold`, the third timing mode the entry schema has parsed but rejected since the deterministic verification work landed in #47. A hold entry verifies that a state STAYS true: the check subtree is sampled across a window (default 30s, 5s interval, both overridable per entry) and every sample must pass. Where converge gives a condition time to become true, hold denies it time to stop being true, which is what stability objectives actually mean: a service that stays reachable through a disruption, a restart count that stays flat instead of merely being low at one lucky poll.

Semantics guarantees, all pinned by tests:
- A window that cannot be fully observed never passes vacuously: if the remaining entry budget cannot cover the window, the entry reports `error` before sampling, and a deadline arriving mid-window reports `error` naming the partial observation. The mid-window branch is unreachable through the current `run_entry` path (the upfront guard subsumes it); it stays as a guarded invariant so future callers or refactors cannot silently reintroduce truncation-as-pass.
- An observed failing sample fails the hold immediately, carrying that sample as the child result.
- Evaluation errors do not end sampling but taint the window: no fail plus any errored sample reports `error`, never `pass`, since the condition may have held but was not observed at every sample.
- Samples dispatch through the runner's single-shot path, so compound subtrees compose and leaf I/O stays bounded exactly as assert entries already are.

Hold is explicit-only: objectives still default to converge and safeguards to assert, and declaring the hold window or interval fields on a non-hold entry is a validation error rather than a silent no-op.

11 new unit tests, no real sleeping (scripted clocks). Unblocks the service-uptime and crash-loop stability tasks queued for porting, which declare 60s and 90s holds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit “hold” verification mode for conditions that must remain true throughout a configured time window.
  * Added configurable hold duration and polling interval, with sensible defaults when omitted.
  * Supports repeated checks of compound verification conditions.

* **Bug Fixes**
  * Hold checks now fail immediately when a condition becomes false.
  * Incomplete, errored, or budget-exhausted checks are reported clearly instead of passing.
  * Hold mode no longer activates implicitly based on verification role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->