### PR TITLE
fix(tasks): mint the GitOps repo under an owned scratch root

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,7 +17,11 @@ reviews:
   path_instructions:
     - path: "devops_bench/**/*.py"
       instructions: |
-        Review against Python 3.12+ idioms. All Python code must include type hints. Ensure docstrings are provided for public classes and functions. Enforce `uv` for dependency/environment management and `ruff` for linting and formatting. Ensure Apache 2.0 license headers are present on all new source files.
+        Review against Python 3.12+ idioms. All Python code must include type hints. Ensure docstrings are provided for public classes and functions. Enforce `uv` for dependency/environment management and `ruff` for linting and formatting. Ensure Apache 2.0 license headers are present on all new source files. Flag any `shutil.rmtree` (or other destructive filesystem operation) whose target derives from a variable or config value that was not minted by the code itself; suggest `devops_bench.core.scratch` (`mint_dir` / `remove_minted`) or, for a single-scope lifecycle, `tempfile.TemporaryDirectory`.
+
+    - path: "tf/**/*.sh"
+      instructions: |
+        Flag any `rm -rf` (or other destructive filesystem operation) whose target derives from a Terraform variable or config value that was not constructed by the script under a root it owns; suggest minting the target under an owned scratch root and deleting through a `safe_remove`-style helper that asserts containment before deleting.
 
     - path: "{devops_bench,docs}/**"
       instructions: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - **Linting & Formatting**: Do NOT use `black` or `flake8`. Exclusively use **`ruff`**.
 - **Documentation**: Provide clear, concise docstrings for public functions and classes.
 - **Vendor neutrality**: User-facing text (docstrings, CLI help, error messages, docs) and the generic framework layers must be vendor-neutral. Provider-specific terms and environment variables (GKE, GCP, `gcloud`, `GCP_PROJECT_ID`, ...) belong only in provider-specific modules (`devops_bench/providers/`, deployer implementations, `tf/`) or where they name a real provider artifact.
+- **Destructive operations**: Never delete or overwrite a path the code did not itself mint. Shell scripts construct the target under an owned scratch root and delete through a `safe_remove` that asserts the target lives under that root before touching it. Python code uses `devops_bench.core.scratch` (`mint_dir` / `remove_minted`) for a lifecycle that outlives one function, or a plain `tempfile.TemporaryDirectory` for a lifecycle scoped to a single block. Config knobs that feed a destructive path expose names, never paths.
 
 ## Development Workflow
 All commands should be run from the project root.

--- a/devops_bench/core/__init__.py
+++ b/devops_bench/core/__init__.py
@@ -30,6 +30,7 @@ from devops_bench.core.logging import configure_logging, get_logger
 from devops_bench.core.registry import Registry
 from devops_bench.core.results import Result, Status
 from devops_bench.core.run_env import RunEnv
+from devops_bench.core.scratch import mint_dir, remove_minted, scratch_root
 
 __all__ = [
     "ClusterInfo",
@@ -45,6 +46,9 @@ __all__ = [
     "first_env",
     "get_bool",
     "get_int",
+    "scratch_root",
+    "mint_dir",
+    "remove_minted",
     "DevOpsBenchError",
     "ConfigError",
     "RegistryError",

--- a/devops_bench/core/scratch.py
+++ b/devops_bench/core/scratch.py
@@ -58,14 +58,14 @@ def _validate_root(root: Path) -> Path:
         raise ValueError(f"scratch root must be an absolute path, got {root!r}")
     resolved = root.resolve()
     home = Path.home().resolve()
+    if resolved == home:
+        raise ValueError(f"scratch root must not resolve to the home directory, got {root!r}")
     depth = len(resolved.parts) - 1
     if depth < 2:
         raise ValueError(
             f"scratch root must resolve at least two levels below the filesystem root, "
             f"got {root!r} (resolved: {resolved})"
         )
-    if resolved == home:
-        raise ValueError(f"scratch root must not resolve to the home directory, got {root!r}")
     return resolved
 
 

--- a/devops_bench/core/scratch.py
+++ b/devops_bench/core/scratch.py
@@ -1,0 +1,129 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared scratch-space helpers: mint directories, delete only what was minted.
+
+Mint-don't-guard: rather than trying to make deletion of an arbitrary,
+caller-supplied path safe, callers only ever delete directories this module
+minted under its own root. Destructive helpers here assert that invariant
+rather than acting as a general-purpose permission system.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+__all__ = [
+    "scratch_root",
+    "mint_dir",
+    "remove_minted",
+]
+
+
+def _validate_root(root: Path) -> Path:
+    """Reject a scratch root too broad to safely own, and return it resolved.
+
+    An unvalidated root makes every containment check downstream vacuous:
+    ``DEVOPS_BENCH_SCRATCH_ROOT=/`` would make :func:`remove_minted` willing
+    to ``rmtree`` any absolute path, since everything is "under" ``/``. This
+    is the same class of check ``remove_minted`` does for a minted path,
+    applied to the root itself.
+
+    Args:
+        root: The candidate scratch root, resolved or not.
+
+    Returns:
+        ``root`` resolved to an absolute, symlink-free path.
+
+    Raises:
+        ValueError: If ``root`` is relative, resolves to the filesystem
+            root, resolves to the home directory, or is fewer than two
+            levels below the filesystem root.
+    """
+    if not root.is_absolute():
+        raise ValueError(f"scratch root must be an absolute path, got {root!r}")
+    resolved = root.resolve()
+    home = Path.home().resolve()
+    depth = len(resolved.parts) - 1
+    if depth < 2:
+        raise ValueError(
+            f"scratch root must resolve at least two levels below the filesystem root, "
+            f"got {root!r} (resolved: {resolved})"
+        )
+    if resolved == home:
+        raise ValueError(f"scratch root must not resolve to the home directory, got {root!r}")
+    return resolved
+
+
+def scratch_root() -> Path:
+    """Return the harness scratch root, creating it on first use.
+
+    Defaults to ``<system temp dir>/devops-bench``. Overridable, as a root
+    only, via the ``DEVOPS_BENCH_SCRATCH_ROOT`` environment variable. The
+    bash-side stack (``tf/prebuilt/opa-remediation/scripts/setup.sh``) pins
+    its own default to a fixed ``/tmp/devops-bench`` instead of the system
+    temp dir, because that path is rendered into a static task prompt that
+    must be identical across processes; this module has no such constraint,
+    so it follows the system temp dir here.
+
+    Returns:
+        The scratch root directory, created if it did not already exist.
+
+    Raises:
+        ValueError: If the resolved root fails :func:`_validate_root`'s
+            checks (see its docstring).
+    """
+    override = os.environ.get("DEVOPS_BENCH_SCRATCH_ROOT")
+    root = Path(override) if override else Path(tempfile.gettempdir()) / "devops-bench"
+    root = _validate_root(root)
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def mint_dir(prefix: str) -> Path:
+    """Mint a new unique directory under the scratch root.
+
+    Args:
+        prefix: Prefix for the minted directory's name.
+
+    Returns:
+        The path to the newly created directory.
+    """
+    return Path(tempfile.mkdtemp(prefix=prefix, dir=scratch_root()))
+
+
+def remove_minted(path: Path) -> None:
+    """Remove a directory tree previously minted by :func:`mint_dir`.
+
+    This check is an assertion of the minting contract, not a permission
+    system: it exists to catch a bug that passes in a path this module never
+    minted, not to sanitize arbitrary input.
+
+    Args:
+        path: The minted directory to remove.
+
+    Raises:
+        ValueError: If ``path``, once resolved, is not strictly under the
+            resolved scratch root (including if it is the root itself).
+    """
+    root = scratch_root().resolve()
+    resolved = path.resolve()
+    if resolved == root or root not in resolved.parents:
+        raise ValueError(
+            f"refusing to remove {path}: not a directory minted under the scratch root {root}"
+        )
+    shutil.rmtree(resolved)

--- a/devops_bench/evalharness/default.py
+++ b/devops_bench/evalharness/default.py
@@ -19,8 +19,6 @@ from __future__ import annotations
 import datetime
 import importlib
 import json
-import shutil
-import tempfile
 import threading
 import time
 from dataclasses import replace
@@ -43,6 +41,8 @@ from devops_bench.core import (
     get_bool,
     get_env,
     get_logger,
+    mint_dir,
+    remove_minted,
 )
 from devops_bench.deployers.factory import get_deployer
 from devops_bench.evalharness.artifacts import collect_generated_files, snapshot_dir
@@ -738,7 +738,7 @@ class DefaultEvalHarness(Harness):
             # Own a real per-run workspace so the artifact diff is rooted at
             # the directory the agent actually writes to (its CLI wrapper's
             # working directory), not the harness process's launch cwd.
-            workspace_path = Path(tempfile.mkdtemp(prefix="devops-bench-workspace-"))
+            workspace_path = mint_dir("workspace-")
             context = self.make_context(task, cluster=cluster_info, workspace_path=workspace_path)
 
             target_dep, ns = self._resolve_deployment_and_namespace(task)
@@ -884,7 +884,24 @@ class DefaultEvalHarness(Harness):
             if deployer is not None:
                 self._teardown(deployer, infra_config, task.name)
             if workspace_path is not None:
-                shutil.rmtree(workspace_path, ignore_errors=True)
+                try:
+                    remove_minted(workspace_path)
+                except ValueError:
+                    # A containment bug, not a cleanup hiccup, but teardown must
+                    # never raise (see _teardown above): results are only
+                    # persisted after every task in the batch completes, so
+                    # letting this escape would discard every prior task's
+                    # results, not just this one's cleanup.
+                    _log.exception(
+                        "refusing to remove workspace %s: not a path this run minted",
+                        workspace_path,
+                    )
+                except OSError:
+                    _log.warning(
+                        "failed to remove workspace %s; leaving it in place",
+                        workspace_path,
+                        exc_info=True,
+                    )
 
         return result
 

--- a/tasks/common/opa-remediation/README.md
+++ b/tasks/common/opa-remediation/README.md
@@ -14,9 +14,12 @@ Runs on **kind** (local, on the runner VM): no cloud dependency.
   `scripts/setup.sh`, which installs Kyverno, applies two **audit** `ClusterPolicy`s
   (`disallow-privileged-containers`, `require-resource-limits`), deploys team workloads (across
   `team-alpha`/`team-beta`/`team-gamma`, with `owner`/`env` labels), some violating, one
-  compliant as a control, and seeds a per-run local bare git repo `~/opa-repo-<cluster_name>.git`
-  (run-unique so concurrent runs don't collide; the prompt uses `{{CLUSTER_NAME}}`) with the workload
-  manifests (the GitOps source of truth).
+  compliant as a control, and seeds a per-run local bare git repo
+  `/tmp/devops-bench/opa-repo-<cluster_name>.git` (run-unique so concurrent runs don't collide;
+  the prompt uses `{{CLUSTER_NAME}}`) with the workload manifests (the GitOps source of truth).
+  The repo lives under a scratch root `setup.sh` owns and only ever deletes what it minted there;
+  the root defaults to `/tmp/devops-bench` and is overridable, as a root only, via
+  `DEVOPS_BENCH_SCRATCH_ROOT`.
 - Audit mode means the violating workloads exist **live** and are flagged in PolicyReports,
   rather than being blocked at admission. Nothing in the cluster names the fix. The agent
   discovers the violations by scanning (`kubectl get policyreport,clusterpolicyreport -A`).
@@ -76,7 +79,7 @@ kubectl get pods -n kyverno                              # Kyverno controllers R
 kubectl get cpol                                         # both ClusterPolicies (Audit)
 kubectl get deploy -A | grep -E 'team-'                  # team workloads
 kubectl get policyreport,clusterpolicyreport -A          # FAIL results for the violations
-git clone ~/opa-repo-<cluster_name>.git /tmp/opa && ls /tmp/opa/workloads && rm -rf /tmp/opa
+git clone /tmp/devops-bench/opa-repo-<cluster_name>.git /tmp/opa && ls /tmp/opa/workloads && rm -rf /tmp/opa
 
 tofu destroy -auto-approve -var=infra_provider=kind -var=cluster_name=opa-kind -var=kubeconfig_path=~/.kube/config
 ```

--- a/tasks/common/opa-remediation/task.yaml
+++ b/tasks/common/opa-remediation/task.yaml
@@ -7,7 +7,7 @@ infrastructure:
   teardown: true
 prompt: |
   You are the platform engineer on call for the Kubernetes cluster '{{CLUSTER_NAME}}'. Its
-  workloads are managed via GitOps from the repository at '~/opa-repo-{{CLUSTER_NAME}}.git' (the source of truth).
+  workloads are managed via GitOps from the repository at '/tmp/devops-bench/opa-repo-{{CLUSTER_NAME}}.git' (the source of truth).
 
   Audit the current state of the cluster, remediate any problems you find with the running
   workloads, and keep the git repository in sync with the changes you make. When you're done,
@@ -84,25 +84,25 @@ verification_spec:
   #     type: all
   #     checks:
   #       - type: git_repo_sync
-  #         repo_path: "~/opa-repo-{{CLUSTER_NAME}}.git"
+  #         repo_path: "/tmp/devops-bench/opa-repo-{{CLUSTER_NAME}}.git"
   #         file: workloads/team-alpha.yaml
   #         path: "$[?(@.metadata.name=='cache')].spec.template.spec.containers[*].securityContext.privileged"
   #         op: absent
   #         quantifier: all
   #         require_new_commit: true
   #       - type: git_repo_sync
-  #         repo_path: "~/opa-repo-{{CLUSTER_NAME}}.git"
+  #         repo_path: "/tmp/devops-bench/opa-repo-{{CLUSTER_NAME}}.git"
   #         file: workloads/team-beta.yaml
   #         path: "$[?(@.metadata.name=='payments')].spec.template.spec.containers[*].securityContext.privileged"
   #         op: absent
   #         quantifier: all
   #       - type: git_repo_sync
-  #         repo_path: "~/opa-repo-{{CLUSTER_NAME}}.git"
+  #         repo_path: "/tmp/devops-bench/opa-repo-{{CLUSTER_NAME}}.git"
   #         file: workloads/team-alpha.yaml
   #         path: "$[?(@.metadata.name=='web')].spec.template.spec.containers[*].resources.limits"
   #         op: exists
   #       - type: git_repo_sync
-  #         repo_path: "~/opa-repo-{{CLUSTER_NAME}}.git"
+  #         repo_path: "/tmp/devops-bench/opa-repo-{{CLUSTER_NAME}}.git"
   #         file: workloads/team-gamma.yaml
   #         path: "$[?(@.metadata.name=='worker')].spec.template.spec.containers[*].resources.limits"
   #         op: exists

--- a/tests/unit/core/test_scratch.py
+++ b/tests/unit/core/test_scratch.py
@@ -1,0 +1,144 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.core.scratch."""
+
+from pathlib import Path
+
+import pytest
+
+from devops_bench.core import scratch
+
+
+def test_scratch_root_creates_default_under_system_tempdir(monkeypatch, tmp_path):
+    monkeypatch.delenv("DEVOPS_BENCH_SCRATCH_ROOT", raising=False)
+    monkeypatch.setattr(scratch.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    root = scratch.scratch_root()
+
+    assert root == tmp_path / "devops-bench"
+    assert root.is_dir()
+
+
+def test_scratch_root_env_override(monkeypatch, tmp_path):
+    override = tmp_path / "custom-root"
+    monkeypatch.setenv("DEVOPS_BENCH_SCRATCH_ROOT", str(override))
+
+    root = scratch.scratch_root()
+
+    assert root == override
+    assert root.is_dir()
+
+
+def test_scratch_root_rejects_the_filesystem_root(monkeypatch):
+    monkeypatch.setenv("DEVOPS_BENCH_SCRATCH_ROOT", "/")
+
+    with pytest.raises(ValueError, match="filesystem root"):
+        scratch.scratch_root()
+
+
+def test_scratch_root_rejects_the_home_directory(monkeypatch):
+    monkeypatch.setenv("DEVOPS_BENCH_SCRATCH_ROOT", str(Path.home()))
+
+    with pytest.raises(ValueError, match="home directory"):
+        scratch.scratch_root()
+
+
+def test_scratch_root_rejects_a_relative_path(monkeypatch):
+    monkeypatch.setenv("DEVOPS_BENCH_SCRATCH_ROOT", "relative/scratch-root")
+
+    with pytest.raises(ValueError, match="absolute"):
+        scratch.scratch_root()
+
+
+def test_scratch_root_accepts_a_legitimate_deep_override(monkeypatch, tmp_path):
+    deep = tmp_path / "a" / "b" / "devops-bench"
+    monkeypatch.setenv("DEVOPS_BENCH_SCRATCH_ROOT", str(deep))
+
+    root = scratch.scratch_root()
+
+    assert root == deep
+    assert root.is_dir()
+
+
+def test_mint_dir_creates_a_directory_under_the_root(monkeypatch, tmp_path):
+    monkeypatch.setenv("DEVOPS_BENCH_SCRATCH_ROOT", str(tmp_path))
+
+    minted = scratch.mint_dir("workspace-")
+
+    assert minted.is_dir()
+    assert minted.parent == tmp_path
+    assert minted.name.startswith("workspace-")
+
+
+def test_remove_minted_removes_a_minted_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("DEVOPS_BENCH_SCRATCH_ROOT", str(tmp_path))
+    minted = scratch.mint_dir("workspace-")
+    (minted / "file.txt").write_text("hello")
+
+    scratch.remove_minted(minted)
+
+    assert not minted.exists()
+
+
+def test_remove_minted_refuses_a_path_outside_the_root(monkeypatch, tmp_path):
+    root = tmp_path / "scratch-root"
+    root.mkdir()
+    monkeypatch.setenv("DEVOPS_BENCH_SCRATCH_ROOT", str(root))
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+
+    with pytest.raises(ValueError, match=str(outside)):
+        scratch.remove_minted(outside)
+
+    assert outside.exists()
+
+
+def test_remove_minted_refuses_the_root_itself(monkeypatch, tmp_path):
+    root = tmp_path / "scratch-root"
+    root.mkdir()
+    monkeypatch.setenv("DEVOPS_BENCH_SCRATCH_ROOT", str(root))
+
+    with pytest.raises(ValueError, match=str(root)):
+        scratch.remove_minted(root)
+
+    assert root.exists()
+
+
+def test_remove_minted_refuses_a_sibling_tmp_dir_with_a_shared_prefix(monkeypatch, tmp_path):
+    root = tmp_path / "devops-bench"
+    root.mkdir()
+    monkeypatch.setenv("DEVOPS_BENCH_SCRATCH_ROOT", str(root))
+    # Shares the root's path as a string prefix but is not a child of it, so a
+    # naive string-prefix containment check would wrongly treat it as inside.
+    sibling = tmp_path / "devops-bench-evil"
+    sibling.mkdir()
+
+    with pytest.raises(ValueError, match=str(sibling)):
+        scratch.remove_minted(sibling)
+
+    assert sibling.exists()
+
+
+def test_remove_minted_error_names_the_path(monkeypatch, tmp_path):
+    root = tmp_path / "scratch-root"
+    root.mkdir()
+    monkeypatch.setenv("DEVOPS_BENCH_SCRATCH_ROOT", str(root))
+    outside = tmp_path / "outside-dir"
+    outside.mkdir()
+
+    with pytest.raises(ValueError) as exc_info:
+        scratch.remove_minted(outside)
+
+    assert str(outside) in str(exc_info.value)

--- a/tests/unit/evalharness/test_default_harness.py
+++ b/tests/unit/evalharness/test_default_harness.py
@@ -388,6 +388,46 @@ def test_run_one_collects_files_the_agent_writes_to_its_workspace(
         AGENTS._items.pop("fake-workspace-writer", None)  # noqa: SLF001
 
 
+def test_run_one_survives_a_workspace_containment_bug_during_teardown(
+    isolated_env: None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A remove_minted containment ValueError logs loudly but never aborts the batch.
+
+    Regression test: results are only persisted after every task in a batch
+    completes, so letting a teardown ValueError escape ``_run_one`` would
+    silently discard every prior task's results, not just this task's
+    cleanup. The containment check must still fire (it means a real bug),
+    but it must surface as a loud log, not an exception out of teardown.
+    """
+    AGENTS.register("fake-workspace-writer-teardown-bug")(_WorkspaceWritingAgent)
+
+    def _boom(_path: Path) -> None:
+        raise ValueError("not a path this run minted")
+
+    monkeypatch.setattr(harness_default, "remove_minted", _boom)
+    try:
+        harness = DefaultEvalHarness(
+            project_id="p",
+            cluster_name="c",
+            agent_type="fake-workspace-writer-teardown-bug",
+            no_infra=True,
+        )
+        task = Task.from_dict({"task_id": "t", "name": "demo", "prompt": "p"})
+        run_dir = tmp_path / "run_1"
+        run_dir.mkdir()
+
+        with caplog.at_level(logging.ERROR):
+            record = harness._run_one(task, run_dir)  # noqa: SLF001
+
+        assert record["status"] == "success"
+        assert any("not a path this run minted" in message for message in caplog.messages)
+    finally:
+        AGENTS._items.pop("fake-workspace-writer-teardown-bug", None)  # noqa: SLF001
+
+
 def test_run_one_warns_when_a_verification_entry_fails_to_parse(
     isolated_env: None, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tf/prebuilt/opa-remediation/main.tf
+++ b/tf/prebuilt/opa-remediation/main.tf
@@ -37,11 +37,15 @@ provider "google" {
 provider "kind" {}
 
 locals {
-  # GitOps repo path on the shared bastion host. setup.sh rm -rf's + reseeds it,
-  # so a fixed path would let one run wipe a concurrent run's repo. cluster_name
-  # is run-token-prefixed, making this per-run unique. The task prompt references
-  # the same path via the {{CLUSTER_NAME}} placeholder. An explicit override wins.
-  repo_path = var.repo_path != "" ? var.repo_path : "~/opa-repo-${var.cluster_name}.git"
+  # GitOps repo lives under a scratch root setup.sh owns, not an arbitrary
+  # path: setup.sh mints "<scratch_root>/<repo_name>" itself and only ever
+  # deletes what it minted (mint-don't-guard), so this variable is a leaf
+  # name, never a path. cluster_name is run-token-prefixed, making the
+  # derived name per-run unique so concurrent runs on the shared bastion
+  # don't collide. The task prompt references the same name via the
+  # {{CLUSTER_NAME}} placeholder, against setup.sh's fixed default scratch
+  # root (see setup.sh for why that root does not read $TMPDIR).
+  repo_name = var.repo_name != "" ? var.repo_name : "opa-repo-${var.cluster_name}.git"
 }
 
 # GKE/KinD cluster. Kyverno + the workloads are installed by setup.sh.
@@ -76,7 +80,7 @@ resource "null_resource" "setup" {
       CLUSTER_NAME   = module.cluster.cluster_name
       LOCATION       = var.location
       KUBECONFIG     = pathexpand(var.kubeconfig_path)
-      REPO_PATH      = pathexpand(local.repo_path)
+      REPO_NAME      = local.repo_name
       MANIFESTS_DIR  = "${path.module}/manifests"
     }
   }

--- a/tf/prebuilt/opa-remediation/scripts/setup.sh
+++ b/tf/prebuilt/opa-remediation/scripts/setup.sh
@@ -35,12 +35,97 @@ if [[ "${INFRA_PROVIDER}" == "gcp" ]]; then
   gcloud container clusters get-credentials "${CLUSTER_NAME}" --zone "${LOCATION}" --project "${PROJECT_ID}"
 fi
 
-REPO_PATH="${REPO_PATH:?REPO_PATH is required}"
-REPO_PATH="${REPO_PATH/#\~/$HOME}"
+REPO_NAME="${REPO_NAME:?REPO_NAME is required}"
+# Fixed default, not ${TMPDIR:-/tmp}: TMPDIR is randomized per-user on macOS,
+# but this path is echoed verbatim into the task prompt (see task.yaml),
+# which must resolve to the same string on every process that reads it.
+# Override the root, never the full path, via DEVOPS_BENCH_SCRATCH_ROOT.
+SCRATCH_ROOT="${DEVOPS_BENCH_SCRATCH_ROOT:-/tmp/devops-bench}"
+
+# Validate the root itself, not just containment under it: an unvalidated
+# root makes every safe_remove containment check below vacuous (e.g.
+# DEVOPS_BENCH_SCRATCH_ROOT=/ would make safe_remove willing to touch any
+# absolute path, since everything resolves "under" /). A relative override
+# is rejected outright rather than silently resolved against whatever
+# directory this script happens to be invoked from. Validation runs against
+# a resolved copy, never SCRATCH_ROOT itself: SCRATCH_ROOT stays the literal
+# value so REPO_PATH still matches the literal path baked into the task
+# prompt even when /tmp is itself a symlink (e.g. to /private/tmp on macOS).
+if [[ "${SCRATCH_ROOT}" != /* ]]; then
+  echo "ERROR: DEVOPS_BENCH_SCRATCH_ROOT must be an absolute path, got '${SCRATCH_ROOT}'" >&2
+  exit 1
+fi
+mkdir -p "${SCRATCH_ROOT}"
+_resolved_scratch_root="$(cd "${SCRATCH_ROOT}" && pwd -P)"
+_resolved_home="$(cd "${HOME}" && pwd -P)"
+_scratch_root_stripped="${_resolved_scratch_root#/}"
+if [[ -z "${_scratch_root_stripped}" ]]; then
+  _scratch_root_depth=0
+else
+  IFS='/' read -r -a _scratch_root_parts <<< "${_scratch_root_stripped}"
+  _scratch_root_depth=${#_scratch_root_parts[@]}
+fi
+if [[ "${_scratch_root_depth}" -lt 2 ]]; then
+  echo "ERROR: DEVOPS_BENCH_SCRATCH_ROOT must resolve at least two levels below the filesystem root, got '${SCRATCH_ROOT}' (resolved: '${_resolved_scratch_root}')" >&2
+  exit 1
+fi
+if [[ "${_resolved_scratch_root}" == "${_resolved_home}" ]]; then
+  echo "ERROR: DEVOPS_BENCH_SCRATCH_ROOT must not resolve to the home directory, got '${SCRATCH_ROOT}'" >&2
+  exit 1
+fi
+
+REPO_PATH="${SCRATCH_ROOT}/${REPO_NAME}"
 MANIFESTS_DIR="${MANIFESTS_DIR:?MANIFESTS_DIR is required}"
 MANIFESTS_DIR="$(cd "${MANIFESTS_DIR}" && pwd)"
 KYVERNO_VERSION="${KYVERNO_VERSION:-v1.12.7}"
 
+# Mint-don't-guard: rather than sanitizing an arbitrary caller-supplied path,
+# only ever delete a path this script minted under its own scratch root, and
+# assert that invariant immediately before deleting it.
+safe_remove() {
+  local target="$1"
+  local root="$2"
+  local target_parent target_base resolved_root resolved_parent resolved_target
+
+  # Reject a top-level symlink explicitly rather than relying on rm's own
+  # non-follow default for its argument: that default is an implementation
+  # detail of rm, not an assertion this script makes, and the resolution
+  # below only canonicalizes target's parent, never target itself.
+  if [[ -L "${target}" ]]; then
+    echo "ERROR: safe_remove: ${target} is a symlink; refusing to remove it" >&2
+    exit 1
+  fi
+
+  resolved_root="$(cd "${root}" && pwd -P)"
+  target_parent="$(dirname -- "${target}")"
+  target_base="$(basename -- "${target}")"
+  if ! resolved_parent="$(cd "${target_parent}" 2>/dev/null && pwd -P)"; then
+    echo "ERROR: safe_remove: parent directory of ${target} does not exist" >&2
+    exit 1
+  fi
+  resolved_target="${resolved_parent}/${target_base}"
+
+  if [[ "${resolved_target}/" != "${resolved_root}/"* ]]; then
+    echo "ERROR: safe_remove: ${target} is not under the scratch root ${root}" >&2
+    exit 1
+  fi
+  # Safety-load-bearing, not cosmetic: resolved_target above is built by
+  # string-concatenating the resolved parent with the literal basename
+  # (target may not exist yet, so it cannot be cd'd into directly), so a
+  # basename of ".." would satisfy the prefix check above as a string while
+  # actually resolving outside the root. Requiring a *.git suffix is what
+  # rules that out, since ".." can never end in ".git".
+  if [[ "${target_base}" != *.git ]]; then
+    echo "ERROR: safe_remove: ${target} does not look like a minted GitOps repo (*.git)" >&2
+    exit 1
+  fi
+  if [[ "${resolved_target}" == "${resolved_root}" || "${resolved_target}" == "${HOME}" || "${resolved_target}" == "/" ]]; then
+    echo "ERROR: safe_remove: refusing to remove ${target}, it resolves to a root, not a minted leaf" >&2
+    exit 1
+  fi
+
+  rm -rf -- "${resolved_target}"
+}
 
 echo "==> Installing Kyverno ${KYVERNO_VERSION}..."
 # Server-side apply: the Kyverno CRDs are large and exceed the client-side
@@ -128,7 +213,7 @@ if [ "${reports_ready}" != true ]; then
 fi
 
 echo "==> Seeding GitOps repo at ${REPO_PATH}..."
-rm -rf "${REPO_PATH}"
+safe_remove "${REPO_PATH}" "${SCRATCH_ROOT}"
 git init --bare "${REPO_PATH}"
 WORK="$(mktemp -d)"
 (

--- a/tf/prebuilt/opa-remediation/variables.tf
+++ b/tf/prebuilt/opa-remediation/variables.tf
@@ -56,8 +56,13 @@ variable "kubeconfig_path" {
   default     = "~/.kube/config"
 }
 
-variable "repo_path" {
+variable "repo_name" {
   type        = string
-  description = "Local bare git repo (GitOps source of truth). Empty (default) derives a per-run-unique path from cluster_name so concurrent runs on the shared bastion don't collide (see locals)."
+  description = "Leaf name (never a path) for the local bare git repo (GitOps source of truth). Empty (default) derives a per-run-unique name from cluster_name so concurrent runs on the shared bastion don't collide (see locals). setup.sh always constructs the full path as <scratch_root>/<repo_name>; scratch_root defaults to /tmp/devops-bench and is overridable only as a root via the DEVOPS_BENCH_SCRATCH_ROOT environment variable."
   default     = ""
+
+  validation {
+    condition     = var.repo_name == "" || can(regex("^[A-Za-z0-9._-]+$", var.repo_name))
+    error_message = "repo_name must be a bare leaf name (letters, digits, '.', '_', '-'), never a path."
+  }
 }


### PR DESCRIPTION
Follow-up to the safety concern raised on #47 (https://github.com/kubernetes-sigs/devops-bench/pull/47#discussion_r3686958545): setup.sh ran `rm -rf` on an env-derived, tilde-expanded, user-overridable path, so a misconfigured `repo_path` such as `~` would have deleted the operator's home directory.

Rather than guarding the delete with validation, this makes the disaster class unexpressible: mint, do not guard. The GitOps repo now always lives under an owned scratch root (`/tmp/devops-bench` by default on the script side, pinned rather than TMPDIR-derived because the path appears in agent-facing prompt text and must be deterministic; overridable only as a root via `DEVOPS_BENCH_SCRATCH_ROOT`). The old free-form `repo_path` variable is replaced by a validated name-only `repo_name` knob, so callers can influence the leaf name but can never supply a path. The reseed goes through a `safe_remove` helper that asserts the minting contract as a backstop: target strictly under the validated root, `*.git` basename, never the root, `$HOME`, `/`, or a symlink. The root itself is validated too, since an unvalidated root would make every downstream containment check vacuous.

The same pattern ships as a paved path for harness code: `devops_bench.core.scratch` provides `scratch_root` / `mint_dir` / `remove_minted` (containment-asserting), adopted by the agent workspace lifecycle in the harness. AGENTS.md gains a short destructive-operations section and the reviewer configuration now flags destructive operations on derived, unminted paths, so future tasks get steered onto the pattern at authoring and review time.
