### PR TITLE
Share the verification budget across converging entries

### DIFF
--- a/devops_bench/evalharness/default.py
+++ b/devops_bench/evalharness/default.py
@@ -448,28 +448,41 @@ class DefaultEvalHarness(Harness):
         evaluator.
 
         Two budgets apply. ``timeout_sec`` is the per-entry cap for a single
-        converging entry's checks. :data:`VERIFICATION_TOTAL_BUDGET_SEC` is
-        the wall-clock cap for this whole pass across every entry; without it
-        a task with many failing converge objectives burns entries x
-        ``timeout_sec`` (12 entries x 120s is 22+ minutes). A single monotonic
-        deadline is computed from the total budget once at the top, and the
-        converging entries **share** what remains of it: each gets
-        ``min(timeout_sec, remaining / converging_entries_left)``. Sharing is
-        what keeps the total cap from being consumed first-come-first-served,
+        converging entry's checks. :data:`VERIFICATION_TOTAL_BUDGET_SEC`
+        bounds the converging entries as a group; without it a task with many
+        failing converge objectives burns entries x ``timeout_sec`` (12
+        entries x 120s is 22+ minutes). It is not a cap on the pass as a
+        whole: each assert entry runs outside the budget and pushes the
+        deadline out by its own duration, so the worst case is the total
+        budget plus the sum of those durations, and an assert leaf floors its
+        own kubectl call rather than inheriting a zero budget (see
+        :func:`~devops_bench.verification.base.single_call_timeout`).
+
+        A single monotonic deadline is computed from the total budget once at
+        the top, and the converging entries **share** what remains of it: each
+        gets ``min(timeout_sec, remaining / converging_entries_left)``. Sharing
+        is what keeps the total cap from being consumed first-come-first-served,
         where a handful of early entries polling to their own cap leave the
-        rest unevaluated and silently drop out of the score's denominator.
-        The share is recomputed from the live remaining time, so an entry that
-        finishes early hands its unused budget back to the ones after it, and
-        the deadline is pushed out by however long each assert entry took so a
-        slow single evaluation does not shorten the converging entries after
-        it. Assert entries
-        ignore the total budget and always run: they are single evaluations,
-        and a safeguard that goes unchecked defeats the point of having it.
-        A converging entry with less than :data:`MIN_LEAF_BUDGET_SECONDS`
-        remaining is recorded here as budget-exhausted rather than handed to
-        ``run_entry``: the runner's own leaf guard uses that same threshold
-        to short-circuit an under-budget leaf as a definite "deadline
-        exhausted" outcome, and this entry was never observed either way.
+        rest unevaluated and silently drop out of the score's denominator. The
+        share is recomputed from the live remaining time, so an entry that
+        finishes early hands its unused budget back to the ones after it.
+        Assert entries ignore the total budget and always run: they are single
+        evaluations, and a safeguard that goes unchecked defeats the point of
+        having it.
+
+        A converging entry whose share came in under ``timeout_sec`` and did
+        not converge is recorded ``"error"``, not ``"fail"``. Such an entry
+        fails only by reaching a deadline, and a truncated deadline is one this
+        pass imposed rather than one the task agreed to: the condition was not
+        observed false, it was not observed. Scoring it as a miss would trade
+        the old symptom (correctness computed from a fraction of the
+        objectives, with coverage visibly low) for a subtler one: full-looking
+        coverage over failures the harness never saw. A converging entry with
+        less than :data:`MIN_LEAF_BUDGET_SECONDS` remaining is likewise
+        recorded as budget-exhausted rather than handed to ``run_entry``: the
+        runner's own leaf guard uses that same threshold to short-circuit an
+        under-budget leaf as a definite "deadline exhausted" outcome, and this
+        entry was never observed either way.
 
         Args:
             entries: The task's parsed verification entries.
@@ -483,14 +496,22 @@ class DefaultEvalHarness(Harness):
         agent = VerifierAgent()
         report: list[dict[str, Any]] = []
         total_deadline = time.monotonic() + VERIFICATION_TOTAL_BUDGET_SEC
-        # Converging entries share what is left of the total budget evenly, so an
+        # How many converging entries remain from each position onward, so an
         # early entry that polls to its own cap cannot starve the ones after it.
-        # Only converging entries count toward the divisor: assert entries
-        # evaluate once and consume no budget, so including them would shrink
-        # everyone's share for nothing.
-        converging_left = sum(1 for e in entries if e.resolved_mode != "assert")
+        # Counted per position rather than decremented as the loop goes: a
+        # running counter goes stale the moment an entry is skipped before
+        # reaching the decrement, and obliges every mode added later to maintain
+        # it. Assert entries are excluded because they consume no budget, so
+        # counting them would shrink everyone's share for nothing.
+        converging_left: list[int] = []
+        still_to_come = 0
+        for entry in reversed(entries):
+            if entry.resolved_mode != "assert":
+                still_to_come += 1
+            converging_left.append(still_to_come)
+        converging_left.reverse()
 
-        for entry in entries:
+        for index, entry in enumerate(entries):
             remaining = total_deadline - time.monotonic()
             if entry.resolved_mode != "assert" and remaining < MIN_LEAF_BUDGET_SECONDS:
                 # Never evaluated, not a condition observed false.
@@ -510,22 +531,43 @@ class DefaultEvalHarness(Harness):
                 )
                 continue
 
-            if entry.resolved_mode == "assert":
-                entry_budget = remaining
-            else:
-                # Recomputed from the live remaining time, so an entry that
-                # finishes early hands its unused share back to the rest.
-                entry_budget = max(remaining / converging_left, MIN_LEAF_BUDGET_SECONDS)
-                converging_left -= 1
+            # Recomputed from the live remaining time, so an entry that finishes
+            # early hands its unused share back to the rest.
+            share = remaining / max(converging_left[index], 1)
+            # The floor is not a guard: the check above already establishes
+            # remaining >= MIN_LEAF_BUDGET_SECONDS. It deliberately lets an entry
+            # overspend its share once that share drops below a second, because a
+            # leaf handed a fraction of a second buys a guaranteed non-answer
+            # rather than a cheap one. The cost is tail starvation in miniature:
+            # past roughly VERIFICATION_TOTAL_BUDGET_SEC / MIN_LEAF_BUDGET_SECONDS
+            # converging entries the early ones take their full second and the
+            # rest fall into the budget-exhausted path above.
+            entry_budget = max(share, MIN_LEAF_BUDGET_SECONDS)
+            # Handed to an assert entry for symmetry only: run_entry discards
+            # timeout_sec outright for a single evaluation.
+            granted = min(timeout_sec, entry_budget)
+            truncated = entry.resolved_mode != "assert" and granted < timeout_sec
 
             started = time.monotonic()
             try:
-                result = agent.run_entry(entry, timeout_sec=min(timeout_sec, entry_budget))
+                result = agent.run_entry(entry, timeout_sec=granted)
                 success = result.success
                 status = result.status
                 reason = result.reason
                 elapsed = result.elapsed_time
                 children = [child.model_dump() for child in result.children]
+                if truncated and status == "fail":
+                    # Not observed false, just not observed: a converging entry
+                    # fails only by reaching a deadline, and this one's deadline
+                    # was the shared budget rather than the cap the task agreed
+                    # to. "error" keeps it out of the correctness denominator so
+                    # coverage can report how much of the spec was measured.
+                    success = False
+                    status = "error"
+                    reason = (
+                        f"not observed: given {granted:.1f}s of the "
+                        f"{timeout_sec:.0f}s converge budget; {reason}"
+                    )
             except Exception as exc:  # noqa: BLE001 - one entry must not abort the rest
                 _log.exception("verification entry %r failed to evaluate", entry.name)
                 success, status, reason, elapsed, children = (

--- a/devops_bench/evalharness/default.py
+++ b/devops_bench/evalharness/default.py
@@ -452,8 +452,15 @@ class DefaultEvalHarness(Harness):
         the wall-clock cap for this whole pass across every entry; without it
         a task with many failing converge objectives burns entries x
         ``timeout_sec`` (12 entries x 120s is 22+ minutes). A single monotonic
-        deadline is computed from the total budget once at the top, and each
-        converging entry gets ``min(timeout_sec, remaining)``. Assert entries
+        deadline is computed from the total budget once at the top, and the
+        converging entries **share** what remains of it: each gets
+        ``min(timeout_sec, remaining / converging_entries_left)``. Sharing is
+        what keeps the total cap from being consumed first-come-first-served,
+        where a handful of early entries polling to their own cap leave the
+        rest unevaluated and silently drop out of the score's denominator.
+        The share is recomputed from the live remaining time, so an entry that
+        finishes early hands its unused budget back to the ones after it.
+        Assert entries
         ignore the total budget and always run: they are single evaluations,
         and a safeguard that goes unchecked defeats the point of having it.
         A converging entry with less than :data:`MIN_LEAF_BUDGET_SECONDS`
@@ -474,6 +481,12 @@ class DefaultEvalHarness(Harness):
         agent = VerifierAgent()
         report: list[dict[str, Any]] = []
         total_deadline = time.monotonic() + VERIFICATION_TOTAL_BUDGET_SEC
+        # Converging entries share what is left of the total budget evenly, so an
+        # early entry that polls to its own cap cannot starve the ones after it.
+        # Only converging entries count toward the divisor: assert entries
+        # evaluate once and consume no budget, so including them would shrink
+        # everyone's share for nothing.
+        converging_left = sum(1 for e in entries if e.resolved_mode != "assert")
 
         for entry in entries:
             remaining = total_deadline - time.monotonic()
@@ -495,8 +508,16 @@ class DefaultEvalHarness(Harness):
                 )
                 continue
 
+            if entry.resolved_mode == "assert":
+                entry_budget = remaining
+            else:
+                # Recomputed from the live remaining time, so an entry that
+                # finishes early hands its unused share back to the rest.
+                entry_budget = max(remaining / converging_left, MIN_LEAF_BUDGET_SECONDS)
+                converging_left -= 1
+
             try:
-                result = agent.run_entry(entry, timeout_sec=min(timeout_sec, remaining))
+                result = agent.run_entry(entry, timeout_sec=min(timeout_sec, entry_budget))
                 success = result.success
                 status = result.status
                 reason = result.reason

--- a/devops_bench/evalharness/default.py
+++ b/devops_bench/evalharness/default.py
@@ -459,8 +459,10 @@ class DefaultEvalHarness(Harness):
         where a handful of early entries polling to their own cap leave the
         rest unevaluated and silently drop out of the score's denominator.
         The share is recomputed from the live remaining time, so an entry that
-        finishes early hands its unused budget back to the ones after it.
-        Assert entries
+        finishes early hands its unused budget back to the ones after it, and
+        the deadline is pushed out by however long each assert entry took so a
+        slow single evaluation does not shorten the converging entries after
+        it. Assert entries
         ignore the total budget and always run: they are single evaluations,
         and a safeguard that goes unchecked defeats the point of having it.
         A converging entry with less than :data:`MIN_LEAF_BUDGET_SECONDS`
@@ -516,6 +518,7 @@ class DefaultEvalHarness(Harness):
                 entry_budget = max(remaining / converging_left, MIN_LEAF_BUDGET_SECONDS)
                 converging_left -= 1
 
+            started = time.monotonic()
             try:
                 result = agent.run_entry(entry, timeout_sec=min(timeout_sec, entry_budget))
                 success = result.success
@@ -532,6 +535,13 @@ class DefaultEvalHarness(Harness):
                     0.0,
                     [],
                 )
+            finally:
+                if entry.resolved_mode == "assert":
+                    # An assert entry is outside the total budget, so it must not
+                    # spend it either: push the deadline out by however long it
+                    # took. Otherwise a slow single evaluation silently shortens
+                    # every converging entry that follows.
+                    total_deadline += time.monotonic() - started
 
             report.append(
                 {

--- a/tests/unit/evalharness/test_verification_wiring.py
+++ b/tests/unit/evalharness/test_verification_wiring.py
@@ -402,4 +402,46 @@ def test_an_early_finisher_hands_its_unused_budget_to_later_entries(
     # Each returns instantly, so the later shares should not shrink below the
     # first one's — the unspent remainder is redistributed, not lost.
     assert len(seen) == 4
-    assert seen[-1] >= seen[0] - 1.0
+    # Strictly greater: a static per-entry share would leave these equal, so
+    # this is what actually shows the unused time being handed back.
+    assert seen[-1] > seen[0]
+
+
+def test_a_slow_assert_entry_does_not_eat_the_converging_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An assert entry is outside the total budget, so it must not spend it.
+
+    Assert entries are excluded from the share divisor, but that alone does not
+    protect the converging entries: a slow single evaluation still advances the
+    wall clock the total deadline is measured against. The deadline is pushed
+    out by the assert's own duration so the entries after it are unaffected.
+    """
+    spec = [
+        {**_SPEC[0], "name": "safeguard", "role": "safeguard", "severity": "recoverable"},
+        {**_SPEC[0], "name": "objective-1"},
+        {**_SPEC[0], "name": "objective-2"},
+    ]
+    entries, errors = parse_entries(spec)
+    assert errors == []
+    assert entries[0].resolved_mode == "assert"
+    monkeypatch.setattr("devops_bench.evalharness.default.VERIFICATION_TOTAL_BUDGET_SEC", 10.0)
+
+    slow_assert_sec = 1.0
+    seen: list[tuple[str, float]] = []
+
+    def fake_run_entry(entry: object, timeout_sec: float = 120) -> VerificationResult:
+        name = entry.name  # type: ignore[attr-defined]
+        seen.append((name, timeout_sec))
+        if name == "safeguard":
+            time.sleep(slow_assert_sec)
+        return VerificationResult(success=True, elapsed_time=0.0, reason="ok")
+
+    with patch(
+        "devops_bench.evalharness.default.VerifierAgent.run_entry", side_effect=fake_run_entry
+    ):
+        _harness()._run_verification(entries, timeout_sec=120)
+
+    budgets = {name: t for name, t in seen}
+    # Both objectives still split the full 10s, not 10s minus the assert's 1s.
+    assert budgets["objective-1"] >= 10.0 / 2 - 0.1

--- a/tests/unit/evalharness/test_verification_wiring.py
+++ b/tests/unit/evalharness/test_verification_wiring.py
@@ -443,5 +443,11 @@ def test_a_slow_assert_entry_does_not_eat_the_converging_budget(
         _harness()._run_verification(entries, timeout_sec=120)
 
     budgets = {name: t for name, t in seen}
+    # Both objectives must actually run: asserting only the first would pass
+    # even if the second were skipped or handed an exhausted budget.
+    assert set(budgets) == {"safeguard", "objective-1", "objective-2"}
     # Both objectives still split the full 10s, not 10s minus the assert's 1s.
     assert budgets["objective-1"] >= 10.0 / 2 - 0.1
+    # objective-1 returns instantly, so its unspent share is handed back and
+    # objective-2 sees close to the whole budget rather than half of it.
+    assert budgets["objective-2"] >= 10.0 - 0.5

--- a/tests/unit/evalharness/test_verification_wiring.py
+++ b/tests/unit/evalharness/test_verification_wiring.py
@@ -57,6 +57,24 @@ def _harness() -> DefaultEvalHarness:
     return harness
 
 
+class _FakeClock:
+    """Monotonic clock a test advances explicitly, in place of real sleeps.
+
+    ``_run_verification`` reads the clock only through ``time.monotonic``, so
+    substituting this for the module's ``time`` binding makes the budget
+    arithmetic exact and keeps the suite off the wall clock.
+    """
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
 def test_report_carries_the_scoring_vocabulary_for_every_entry() -> None:
     entries, errors = parse_entries(_SPEC)
     assert errors == []
@@ -357,6 +375,7 @@ def test_converging_entries_share_the_total_budget_rather_than_racing_for_it(
     entries, errors = parse_entries(spec)
     assert errors == []
     monkeypatch.setattr("devops_bench.evalharness.default.VERIFICATION_TOTAL_BUDGET_SEC", 100.0)
+    monkeypatch.setattr("devops_bench.evalharness.default.time", _FakeClock())
 
     seen: list[float] = []
 
@@ -374,9 +393,14 @@ def test_converging_entries_share_the_total_budget_rather_than_racing_for_it(
     assert not any(
         r["reason"] == "verification total budget exhausted before evaluation" for r in report
     )
-    # The first entry got roughly its fair share (100/10), not the full 120s cap.
-    assert seen[0] <= 100.0 / 10 + 1.0
-    assert report[0]["status"] == "fail"
+    # The first entry got exactly its fair share (100/10), not the full 120s cap.
+    assert seen[0] == 100.0 / 10
+    # ...and because that share is a fraction of the 120s the task agreed to, a
+    # non-convergence is not an observation that the condition is false. Scoring
+    # it "fail" would report full coverage over a failure never actually seen.
+    assert report[0]["status"] == "error"
+    assert report[0]["success"] is False
+    assert "not observed" in report[0]["reason"]
 
 
 def test_an_early_finisher_hands_its_unused_budget_to_later_entries(
@@ -387,6 +411,7 @@ def test_an_early_finisher_hands_its_unused_budget_to_later_entries(
     entries, errors = parse_entries(spec)
     assert errors == []
     monkeypatch.setattr("devops_bench.evalharness.default.VERIFICATION_TOTAL_BUDGET_SEC", 40.0)
+    monkeypatch.setattr("devops_bench.evalharness.default.time", _FakeClock())
 
     seen: list[float] = []
 
@@ -399,9 +424,9 @@ def test_an_early_finisher_hands_its_unused_budget_to_later_entries(
     ):
         _harness()._run_verification(entries, timeout_sec=120)
 
-    # Each returns instantly, so the later shares should not shrink below the
-    # first one's — the unspent remainder is redistributed, not lost.
-    assert len(seen) == 4
+    # Each returns instantly, so nothing is spent and every entry sees the whole
+    # 40s divided by however many converging entries are still to come.
+    assert seen == [40.0 / 4, 40.0 / 3, 40.0 / 2, 40.0 / 1]
     # Strictly greater: a static per-entry share would leave these equal, so
     # this is what actually shows the unused time being handed back.
     assert seen[-1] > seen[0]
@@ -426,6 +451,8 @@ def test_a_slow_assert_entry_does_not_eat_the_converging_budget(
     assert errors == []
     assert entries[0].resolved_mode == "assert"
     monkeypatch.setattr("devops_bench.evalharness.default.VERIFICATION_TOTAL_BUDGET_SEC", 10.0)
+    clock = _FakeClock()
+    monkeypatch.setattr("devops_bench.evalharness.default.time", clock)
 
     slow_assert_sec = 1.0
     seen: list[tuple[str, float]] = []
@@ -434,7 +461,7 @@ def test_a_slow_assert_entry_does_not_eat_the_converging_budget(
         name = entry.name  # type: ignore[attr-defined]
         seen.append((name, timeout_sec))
         if name == "safeguard":
-            time.sleep(slow_assert_sec)
+            clock.advance(slow_assert_sec)
         return VerificationResult(success=True, elapsed_time=0.0, reason="ok")
 
     with patch(
@@ -447,7 +474,7 @@ def test_a_slow_assert_entry_does_not_eat_the_converging_budget(
     # even if the second were skipped or handed an exhausted budget.
     assert set(budgets) == {"safeguard", "objective-1", "objective-2"}
     # Both objectives still split the full 10s, not 10s minus the assert's 1s.
-    assert budgets["objective-1"] >= 10.0 / 2 - 0.1
+    assert budgets["objective-1"] == 10.0 / 2
     # objective-1 returns instantly, so its unspent share is handed back and
-    # objective-2 sees close to the whole budget rather than half of it.
-    assert budgets["objective-2"] >= 10.0 - 0.5
+    # objective-2 sees the whole budget rather than half of it.
+    assert budgets["objective-2"] == 10.0

--- a/tests/unit/evalharness/test_verification_wiring.py
+++ b/tests/unit/evalharness/test_verification_wiring.py
@@ -339,3 +339,67 @@ def test_resolve_spec_placeholders_recurses_through_nested_entries() -> None:
     checks = resolved[0]["check"]["checks"]
     assert checks[0]["namespace"] == "shop"
     assert checks[1]["selector"] == "app=web"
+
+
+def test_converging_entries_share_the_total_budget_rather_than_racing_for_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No converging entry may take the whole budget and starve the rest.
+
+    Regression: the total budget used to be consumed first-come-first-served,
+    so on a failing task the first few entries each polled to their own
+    per-entry cap and every later entry was recorded budget-exhausted. Those
+    entries then dropped out of the score's denominator, producing a
+    plausible-looking correctness value computed from a fraction of the
+    declared objectives.
+    """
+    spec = [{**_SPEC[0], "name": f"web-ready-{i}"} for i in range(10)]
+    entries, errors = parse_entries(spec)
+    assert errors == []
+    monkeypatch.setattr("devops_bench.evalharness.default.VERIFICATION_TOTAL_BUDGET_SEC", 100.0)
+
+    seen: list[float] = []
+
+    def fake_run_entry(entry: object, timeout_sec: float = 120) -> VerificationResult:
+        seen.append(timeout_sec)
+        return VerificationResult(success=False, elapsed_time=0.0, reason="not ready")
+
+    with patch(
+        "devops_bench.evalharness.default.VerifierAgent.run_entry", side_effect=fake_run_entry
+    ):
+        report = _harness()._run_verification(entries, timeout_sec=120)
+
+    # Every entry was actually evaluated: none fell off the end of the budget.
+    assert len(seen) == 10
+    assert not any(
+        r["reason"] == "verification total budget exhausted before evaluation" for r in report
+    )
+    # The first entry got roughly its fair share (100/10), not the full 120s cap.
+    assert seen[0] <= 100.0 / 10 + 1.0
+    assert report[0]["status"] == "fail"
+
+
+def test_an_early_finisher_hands_its_unused_budget_to_later_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The share is recomputed live, so unused time is not forfeited."""
+    spec = [{**_SPEC[0], "name": f"web-ready-{i}"} for i in range(4)]
+    entries, errors = parse_entries(spec)
+    assert errors == []
+    monkeypatch.setattr("devops_bench.evalharness.default.VERIFICATION_TOTAL_BUDGET_SEC", 40.0)
+
+    seen: list[float] = []
+
+    def fake_run_entry(entry: object, timeout_sec: float = 120) -> VerificationResult:
+        seen.append(timeout_sec)
+        return VerificationResult(success=True, elapsed_time=0.0, reason="ok")
+
+    with patch(
+        "devops_bench.evalharness.default.VerifierAgent.run_entry", side_effect=fake_run_entry
+    ):
+        _harness()._run_verification(entries, timeout_sec=120)
+
+    # Each returns instantly, so the later shares should not shrink below the
+    # first one's — the unspent remainder is redistributed, not lost.
+    assert len(seen) == 4
+    assert seen[-1] >= seen[0] - 1.0

--- a/tests/unit/evalharness/test_verification_wiring.py
+++ b/tests/unit/evalharness/test_verification_wiring.py
@@ -375,13 +375,20 @@ def test_converging_entries_share_the_total_budget_rather_than_racing_for_it(
     entries, errors = parse_entries(spec)
     assert errors == []
     monkeypatch.setattr("devops_bench.evalharness.default.VERIFICATION_TOTAL_BUDGET_SEC", 100.0)
-    monkeypatch.setattr("devops_bench.evalharness.default.time", _FakeClock())
+    clock = _FakeClock()
+    monkeypatch.setattr("devops_bench.evalharness.default.time", clock)
 
     seen: list[float] = []
 
     def fake_run_entry(entry: object, timeout_sec: float = 120) -> VerificationResult:
+        # Model the worst case the regression was about: an entry that never
+        # converges polls to the end of whatever it was granted. Burning the
+        # share is what makes the budget actually deplete, so a starving
+        # allocation would show up in `seen` instead of being masked by a
+        # clock that never moves.
         seen.append(timeout_sec)
-        return VerificationResult(success=False, elapsed_time=0.0, reason="not ready")
+        clock.advance(timeout_sec)
+        return VerificationResult(success=False, elapsed_time=timeout_sec, reason="not ready")
 
     with patch(
         "devops_bench.evalharness.default.VerifierAgent.run_entry", side_effect=fake_run_entry
@@ -393,14 +400,16 @@ def test_converging_entries_share_the_total_budget_rather_than_racing_for_it(
     assert not any(
         r["reason"] == "verification total budget exhausted before evaluation" for r in report
     )
-    # The first entry got exactly its fair share (100/10), not the full 120s cap.
-    assert seen[0] == 100.0 / 10
+    # Every entry got exactly its fair share (100/10), not the full 120s cap, and
+    # the ten shares add up to the whole budget with nothing left stranded.
+    assert seen == [100.0 / 10] * 10
+    assert clock.now == 100.0
     # ...and because that share is a fraction of the 120s the task agreed to, a
     # non-convergence is not an observation that the condition is false. Scoring
     # it "fail" would report full coverage over a failure never actually seen.
-    assert report[0]["status"] == "error"
-    assert report[0]["success"] is False
-    assert "not observed" in report[0]["reason"]
+    assert all(r["status"] == "error" for r in report)
+    assert all(r["success"] is False for r in report)
+    assert all("not observed" in r["reason"] for r in report)
 
 
 def test_an_early_finisher_hands_its_unused_budget_to_later_entries(


### PR DESCRIPTION
`_run_verification` consumed `VERIFICATION_TOTAL_BUDGET_SEC` first come first served: each
converging entry took `min(timeout_sec, remaining)`. On a task whose objectives fail, the
early entries each poll to the full per-entry cap, and every later entry is recorded
`verification total budget exhausted before evaluation` without ever running.

With the shipped values this is deterministic rather than flaky. 600s total and a 120s
per-entry cap evaluate five entries and abandon everything after them.

## Why it matters beyond lost coverage

An abandoned entry counts toward neither the numerator nor the denominator in `rollup`, so
the run still emits a correctness score. It is just computed from whichever entries
happened to run first, and it looks like a normal result.

Found this on a live run of `deploy-hello-app`, which declares 13 objectives:

```
status counts: {'fail': 4, 'error': 9, 'pass': 2}
  8 of the 9 errors: "verification total budget exhausted before evaluation"

VerificationCorrectness  0.0     <- computed from 4 of 13 objectives
VerificationCoverage     0.4
OutcomeScore             0.0
```

`VerificationCoverage` correctly flagged that only 40% of checks were evaluated, but the
correctness score alongside it carries no such warning.

## The change

The converging entries now share what remains of the total, each getting
`min(timeout_sec, remaining / converging_entries_left)`. The share is recomputed per entry
from the live remaining time, so an entry that finishes early hands its unused budget back
to the ones after it rather than forfeiting it. Assert entries stay out of the divisor,
since they evaluate once and consume no budget.

The total cap is unchanged, so the worst case wall clock for the pass does not grow. For
the 13-entry task above, every entry now gets a real budget (46s for the first, rising as
earlier entries return) instead of five entries taking everything.

Raising the cap was the other option, but it does not scale: guaranteeing 13 entries at
120s each needs 26 minutes per task, and the next task with 20 objectives breaks again. The
comment above the constant already explains why the cap exists.

## Tests

Two regression tests. The first drives 10 converging entries against a 100s total and
asserts none is abandoned and the first does not take the full per-entry cap; I confirmed
it fails against the old behavior. The second asserts an early finisher's unused share is
redistributed rather than lost.

/kind bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification scheduling so checks share available time fairly.
  * Redistributed unused time from early-finishing checks to later checks.
  * Preserved converging-check time when independent assertions run slowly.
  * Applied minimum verification time and clearer error reporting when convergence is insufficiently observed.

* **Tests**
  * Added coverage for time allocation, redistribution, assertion timing protection, and failure classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->