### PR TITLE
Add the prebuilt/minimum TF stack

### DIFF
--- a/tf/prebuilt/minimum/main.tf
+++ b/tf/prebuilt/minimum/main.tf
@@ -1,0 +1,93 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0.0"
+    }
+    kind = {
+      source  = "tehcyx/kind"
+      version = ">= 0.5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id != "" ? var.project_id : null
+  region  = var.location != "" && var.location != "local" ? var.location : null
+}
+
+# Sweep the Artifact Registry repo the deploy-hello-app agent creates
+# (hello-app-<cluster>, project-global and NOT in this stack's tofu state) so it
+# doesn't leak across runs — the cluster teardown alone never removes it. No-op
+# for the other tasks on this stack (the repo won't exist).
+#
+# The repo's region is NOT pinned (the agent picks it, and a multi-region default
+# like `us` is common), so deleting at one derived location would miss a repo
+# that landed elsewhere. Instead, discover wherever the run-unique repo lives by
+# listing the project's repos and delete it at its own location. The name match
+# is an exact suffix on the run-unique cluster, so a sibling run's repo is never
+# touched.
+resource "null_resource" "ar_cleanup" {
+  triggers = {
+    project = var.project_id
+    repo    = "hello-app-${var.cluster_name}"
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = <<-EOT
+      gcloud artifacts repositories list --project='${self.triggers.project}' \
+        --format='value(name)' 2>/dev/null \
+      | while IFS= read -r full; do
+          case "$full" in
+            */repositories/'${self.triggers.repo}')
+              loc=$(printf '%s\n' "$full" | sed -E 's#.*/locations/([^/]+)/repositories/.*#\1#')
+              gcloud artifacts repositories delete '${self.triggers.repo}' \
+                --location="$loc" --project='${self.triggers.project}' \
+                --quiet 2>/dev/null || true
+              ;;
+          esac
+        done
+    EOT
+  }
+}
+
+provider "kind" {}
+
+module "cluster" {
+  source          = "../../modules/cluster"
+  infra_provider  = var.infra_provider
+  cluster_name    = var.cluster_name
+  location        = var.location
+  node_count      = var.node_count
+  machine_type    = var.machine_type
+  project_id      = var.project_id
+  kubeconfig_path = var.kubeconfig_path
+}
+
+output "cluster_name" {
+  value = module.cluster.cluster_name
+}
+
+output "cluster_location" {
+  value = module.cluster.location
+}

--- a/tf/prebuilt/minimum/variables.tf
+++ b/tf/prebuilt/minimum/variables.tf
@@ -1,0 +1,62 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "infra_provider" {
+  type        = string
+  description = "The target cloud provider (gcp, kind)"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Name of the cluster to provision"
+}
+
+variable "location" {
+  type        = string
+  description = "Region/zone (GCP) or 'local' (KinD)"
+  default     = ""
+}
+
+variable "node_count" {
+  type        = number
+  description = "Number of worker nodes"
+  default     = 3
+}
+
+variable "machine_type" {
+  type        = string
+  description = "VM instance type"
+  default     = ""
+}
+
+# Provider-specific optional variables
+variable "project_id" {
+  type        = string
+  description = "GCP Project ID"
+  default     = ""
+}
+
+variable "kubeconfig_path" {
+  type        = string
+  description = "Target path to write kubeconfig (KinD-only)"
+  default     = "~/.kube/config"
+}
+
+# Unused by this bare stack, but declared so tasks that pin NAMESPACE (for
+# prompt/fixture consistency) don't trip an "undeclared variable" warning when
+# the provider resolver forwards namespace= to every GCP stack.
+variable "namespace" {
+  type    = string
+  default = "default"
+}


### PR DESCRIPTION
`tasks/gcp/deploy-hello-app/task.yaml` declares `stack: "prebuilt/minimum"`, but `tf/prebuilt/minimum/` is not in this repo — `git log upstream/main -- tf/prebuilt/minimum` is empty, so it never landed.

The effect is that the only GCP task here cannot run at all. `TFDeployer.__init__` raises `ConfigError: TF stack not found under <tf_root>: prebuilt/minimum` before any cluster is created.

In `migrated.bara.sky` the task and the stack are a single flip-group:

```
# "tasks/gcp/deploy-hello-app/**",  # flip-group: minimum
# "tf/prebuilt/minimum/**",  # flip-group: minimum
```

The task came over with #47 and the stack did not follow.

## The port

Unmodified apart from the Apache headers. The stack consumes `tf/modules/cluster` via `infra_provider` / `cluster_name` / `location` / `node_count` / `machine_type` / `project_id` / `kubeconfig_path`, and this repo's module already exposes exactly that variable set (identical to gke-labs', including the provider-neutral abstraction), so nothing needed adapting.

It also carries a destroy-time `null_resource` that sweeps the `hello-app-<cluster>` Artifact Registry repo, which the agent creates project-globally and outside this stack's state — without it, teardown leaks a repo per run.

## Verification

- `TFDeployer(tf_dir="prebuilt/minimum")` now resolves instead of raising.
- `tofu fmt -check` clean; `hack/boilerplate.py --dry-run` clean.
- Not applied against a live project from this checkout. This exact stack has been running the task on our bastion, which is how the gap surfaced: it had been hand-placed there, masking the fact that it was never migrated.

## Interaction with #63

#63 adds `docs/appendix/known_issues.md` with a router row describing this break, and drops the Artifact Registry hacks-table row on the grounds that the stack was absent. Once this merges, that pairing should flip — the router row goes away and the AR-sweep row comes back. I will send that follow-up rather than fold it in here, since the two PRs touch different areas and either could land first.