### PR TITLE
fix(verification): preserve a parallel child's observed result at the deadline

### DIFF
--- a/devops_bench/verification/runner.py
+++ b/devops_bench/verification/runner.py
@@ -78,18 +78,13 @@ _SINGLE_SHOT_WAIT_CEILING_SEC = 120.0
 # path and the single-shot wait-ceiling path in :meth:`VerifierAgent._run_parallel`.
 _PARALLEL_INCOMPLETE_REASON = "evaluation did not complete before the deadline"
 
-# Converge-mode children are handed a deadline this much earlier than the
-# parent's own wait, so the parent outlives its children instead of racing
-# them for the same instant. Without this margin, a child that genuinely
-# converges right at the deadline is frequently not yet in ``done`` when the
-# parent's ``futures_wait`` returns, and its real observed result is
-# discarded in favor of the generic incomplete-evaluation placeholder.
-_CHILD_DEADLINE_MARGIN_SEC = 0.25
-
 # After the parent's initial wait, converge-mode children still pending are
-# given one short additional pass to land, so a result that completes in the
-# margin gap is used instead of the placeholder. Kept brief since it is a
-# straggler catch, not a second budget.
+# given one short additional pass to land, so a child that finishes just
+# after the parent's ``futures_wait`` returns is still picked up instead of
+# falling back to the placeholder. This is a straggler catch for the
+# collection race at the deadline instant, not a second polling budget: the
+# child is handed the parent's own deadline and keeps polling right up to
+# it, same as any other node.
 _STRAGGLER_GRACE_SEC = 0.5
 
 
@@ -521,20 +516,22 @@ class VerifierAgent:
         clamped to whichever of the ceiling and the remaining deadline is
         smaller.
 
-        Under converge, children are also submitted against a deadline
-        slightly earlier than the parent's own wait (see
-        :data:`_CHILD_DEADLINE_MARGIN_SEC`) and, if any are still pending
-        once the parent's wait returns, given one short additional grace
-        pass (see :data:`_STRAGGLER_GRACE_SEC`) before falling back to the
-        placeholder. Both exist for the same reason: a child converging
-        right at the shared deadline otherwise races the parent for the same
-        instant, and its real observed result is lost to the generic
-        incomplete-evaluation placeholder more often than not. ``single_shot``
-        keeps racing the same ceiling-bound instant on purpose: the ceiling
-        is already the hard backstop against a hung safeguard leaf stalling
-        the run, and stretching it with a grace period would blur that bound
-        for the sake of a mode where a late "error" verdict is already the
-        correct, safe answer.
+        Under converge, children are submitted against the same shared
+        ``deadline`` the parent itself waits on, so a child keeps polling
+        right up to it instead of losing part of its budget to an earlier
+        cutoff. If any are still pending once the parent's wait returns,
+        one short additional grace pass (see :data:`_STRAGGLER_GRACE_SEC`)
+        is given before falling back to the placeholder: a child converging
+        right at the shared deadline can still race the parent for the same
+        instant and not yet be in ``done`` when the parent's ``futures_wait``
+        returns, even though it already has a real observed result. The
+        grace pass exists to collect that result, not to extend how long a
+        child gets to converge. ``single_shot`` keeps racing the same
+        ceiling-bound instant on purpose: the ceiling is already the hard
+        backstop against a hung safeguard leaf stalling the run, and
+        stretching it with a grace period would blur that bound for the sake
+        of a mode where a late "error" verdict is already the correct, safe
+        answer.
         """
         start = time.monotonic()
         results: list[VerificationResult] = [
@@ -547,18 +544,8 @@ class VerifierAgent:
         # ``verify(remaining)`` call, so they cannot linger long.
         ex = ThreadPoolExecutor(max_workers=workers)
         try:
-            remaining = deadline - time.monotonic()
-            # Only shrink the child's deadline when there is enough budget that
-            # doing so still clears _MIN_LEAF_BUDGET_SECONDS by a real margin;
-            # a child's own floor check runs later still (thread-pool dispatch
-            # takes a little time), so landing the child deadline exactly at
-            # the floor would make that check flaky rather than reliable.
-            if single_shot or remaining <= _MIN_LEAF_BUDGET_SECONDS + _CHILD_DEADLINE_MARGIN_SEC:
-                child_deadline = deadline
-            else:
-                child_deadline = deadline - _CHILD_DEADLINE_MARGIN_SEC
             futs = {
-                ex.submit(self._run, child, child_deadline, single_shot=single_shot): i
+                ex.submit(self._run, child, deadline, single_shot=single_shot): i
                 for i, child in enumerate(node.checks)
             }
             if single_shot:

--- a/devops_bench/verification/runner.py
+++ b/devops_bench/verification/runner.py
@@ -78,6 +78,20 @@ _SINGLE_SHOT_WAIT_CEILING_SEC = 120.0
 # path and the single-shot wait-ceiling path in :meth:`VerifierAgent._run_parallel`.
 _PARALLEL_INCOMPLETE_REASON = "evaluation did not complete before the deadline"
 
+# Converge-mode children are handed a deadline this much earlier than the
+# parent's own wait, so the parent outlives its children instead of racing
+# them for the same instant. Without this margin, a child that genuinely
+# converges right at the deadline is frequently not yet in ``done`` when the
+# parent's ``futures_wait`` returns, and its real observed result is
+# discarded in favor of the generic incomplete-evaluation placeholder.
+_CHILD_DEADLINE_MARGIN_SEC = 0.25
+
+# After the parent's initial wait, converge-mode children still pending are
+# given one short additional pass to land, so a result that completes in the
+# margin gap is used instead of the placeholder. Kept brief since it is a
+# straggler catch, not a second budget.
+_STRAGGLER_GRACE_SEC = 0.5
+
 
 def _node_name(node: Any) -> str | None:
     """Echo the optional ``name`` label from a spec node, if any."""
@@ -506,6 +520,21 @@ class VerifierAgent:
         by up to the ceiling, defeating the total-budget bound; the wait is
         clamped to whichever of the ceiling and the remaining deadline is
         smaller.
+
+        Under converge, children are also submitted against a deadline
+        slightly earlier than the parent's own wait (see
+        :data:`_CHILD_DEADLINE_MARGIN_SEC`) and, if any are still pending
+        once the parent's wait returns, given one short additional grace
+        pass (see :data:`_STRAGGLER_GRACE_SEC`) before falling back to the
+        placeholder. Both exist for the same reason: a child converging
+        right at the shared deadline otherwise races the parent for the same
+        instant, and its real observed result is lost to the generic
+        incomplete-evaluation placeholder more often than not. ``single_shot``
+        keeps racing the same ceiling-bound instant on purpose: the ceiling
+        is already the hard backstop against a hung safeguard leaf stalling
+        the run, and stretching it with a grace period would blur that bound
+        for the sake of a mode where a late "error" verdict is already the
+        correct, safe answer.
         """
         start = time.monotonic()
         results: list[VerificationResult] = [
@@ -518,8 +547,18 @@ class VerifierAgent:
         # ``verify(remaining)`` call, so they cannot linger long.
         ex = ThreadPoolExecutor(max_workers=workers)
         try:
+            remaining = deadline - time.monotonic()
+            # Only shrink the child's deadline when there is enough budget that
+            # doing so still clears _MIN_LEAF_BUDGET_SECONDS by a real margin;
+            # a child's own floor check runs later still (thread-pool dispatch
+            # takes a little time), so landing the child deadline exactly at
+            # the floor would make that check flaky rather than reliable.
+            if single_shot or remaining <= _MIN_LEAF_BUDGET_SECONDS + _CHILD_DEADLINE_MARGIN_SEC:
+                child_deadline = deadline
+            else:
+                child_deadline = deadline - _CHILD_DEADLINE_MARGIN_SEC
             futs = {
-                ex.submit(self._run, child, deadline, single_shot=single_shot): i
+                ex.submit(self._run, child, child_deadline, single_shot=single_shot): i
                 for i, child in enumerate(node.checks)
             }
             if single_shot:
@@ -531,7 +570,9 @@ class VerifierAgent:
                 )
             else:
                 wait_timeout = max(0.0, deadline - time.monotonic())
-            done, _ = futures_wait(futs, timeout=wait_timeout)
+            done, pending = futures_wait(futs, timeout=wait_timeout)
+            if pending and not single_shot:
+                done, _ = futures_wait(futs, timeout=_STRAGGLER_GRACE_SEC)
             for f, i in futs.items():
                 if f not in done:
                     continue

--- a/tests/unit/verification/test_runner.py
+++ b/tests/unit/verification/test_runner.py
@@ -344,9 +344,11 @@ def test_parallel_converge_hung_child_alongside_an_observed_fail_stays_fail(
     agent: VerifierAgent,
 ) -> None:
     """An observed fail still wins the group verdict over an unfinished sibling."""
-    # The deadline must clear _MIN_LEAF_BUDGET_SECONDS so the hung leaf's
-    # verify() is actually invoked (and outlasts the wait) rather than being
-    # short-circuited by the per-leaf min-budget guard before it ever runs.
+    # The deadline must clear _MIN_LEAF_BUDGET_SECONDS by a real margin so both
+    # leaves' verify() calls are actually invoked (and the hung one outlasts
+    # the wait) rather than being short-circuited by the per-leaf min-budget
+    # guard before they ever run; 1.5s leaves ~0.25s of that margin after the
+    # child-deadline clamp, same as the neighboring converge tests.
     spec = {
         "type": "parallel",
         "checks": [
@@ -355,7 +357,7 @@ def test_parallel_converge_hung_child_alongside_an_observed_fail_stays_fail(
         ],
     }
 
-    res = agent.wait_for_condition(spec, timeout_sec=1.2)
+    res = agent.wait_for_condition(spec, timeout_sec=1.5)
 
     assert res.status == "fail"
     assert res.success is False
@@ -395,6 +397,63 @@ def test_parallel_single_shot_bounds_the_wait_at_the_ceiling(agent: VerifierAgen
         agent.run_entry(entries[0], timeout_sec=30)
 
     assert recorded["timeout"] == _SINGLE_SHOT_WAIT_CEILING_SEC
+
+
+def test_parallel_converge_close_race_uses_straggler_grace_pass(
+    agent: VerifierAgent, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A child converging just past the parent's first wait is caught by the grace pass.
+
+    Without the straggler grace pass, this real observed failure would be
+    replaced by the generic incomplete-evaluation placeholder purely because
+    the child's future was not yet in ``done`` when the parent's first wait
+    returned, even though the child had already computed a real result.
+    """
+    # The grace pass returns as soon as the child future completes, so
+    # widening its ceiling does not slow the test down; it only removes the
+    # upper-bound race against a fixed collection-window close time, leaving
+    # only the (deterministic, since time.sleep is a lower bound) guarantee
+    # that the child is still running when the parent's first wait expires.
+    # ``raising=False``: this constant does not exist on the pre-fix runner,
+    # and this test must still fail (on the pre-fix placeholder substitution,
+    # not on the patch itself) rather than erroring out on a missing attr.
+    monkeypatch.setattr(
+        "devops_bench.verification.runner._STRAGGLER_GRACE_SEC", 30.0, raising=False
+    )
+    spec = {
+        "type": "parallel",
+        "checks": [_leaf(succeed=False, tag="closerace", sleep_for=1.8)],
+    }
+
+    res = agent.wait_for_condition(spec, timeout_sec=1.5)
+
+    assert res.status == "fail"
+    assert res.children[0].status == "fail"
+    assert res.children[0].reason == "leaf:closerace"
+    assert res.children[0].raw is not None
+
+
+def test_parallel_converge_still_hung_after_grace_yields_placeholder(
+    agent: VerifierAgent, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A child still pending after the straggler grace pass keeps the placeholder.
+
+    The grace pass is a brief straggler catch, not a second budget; a child
+    that genuinely never converges must still fall back to the same
+    unobserved "error" placeholder as before.
+    """
+    monkeypatch.setattr("devops_bench.verification.runner._STRAGGLER_GRACE_SEC", 0.05)
+    spec = {
+        "type": "parallel",
+        "checks": [_leaf(succeed=True, tag="hung", sleep_for=5.0)],
+    }
+
+    res = agent.wait_for_condition(spec, timeout_sec=1.5)
+
+    assert res.status == "error"
+    assert res.children[0].status == "error"
+    assert res.children[0].reason == "evaluation did not complete before the deadline"
+    assert res.children[0].raw is None
 
 
 # --- nesting --------------------------------------------------------------

--- a/tests/unit/verification/test_runner.py
+++ b/tests/unit/verification/test_runner.py
@@ -48,6 +48,12 @@ class _FakeLeaf(BaseVerifier):
             a check that could not be evaluated.
         boom: When true, :meth:`verify` raises instead of returning a result.
         sleep_for: Seconds to block inside :meth:`verify` before returning.
+        converge_after: When set, models a resource that only converges once
+            it has been polled for this many seconds. Succeeds only if the
+            ``timeout_sec`` it is actually handed is at least this long
+            (sleeping for it before returning success); otherwise it sleeps
+            out its shorter budget and reports a fail, as an unconverged
+            resource would. Takes precedence over ``succeed``/``sleep_for``.
         tag: Label folded into the result ``reason`` for assertions.
     """
 
@@ -56,12 +62,28 @@ class _FakeLeaf(BaseVerifier):
     status: Literal["pass", "fail", "error"] | None = None
     boom: bool = False
     sleep_for: float = 0.0
+    converge_after: float | None = None
     tag: str = ""
 
     def verify(self, timeout_sec: float) -> VerificationResult:
         """Return (or raise) a canned result, echoing the budget it was given."""
         if self.boom:
             raise RuntimeError(f"boom:{self.tag}")
+        if self.converge_after is not None:
+            if timeout_sec >= self.converge_after:
+                time.sleep(self.converge_after)
+                success = True
+            else:
+                time.sleep(timeout_sec)
+                success = False
+            return VerificationResult(
+                success=success,
+                status=None,
+                elapsed_time=0.0,
+                reason=f"leaf:{self.tag}",
+                name=self.name,
+                raw={"timeout_sec": timeout_sec},
+            )
         if self.sleep_for:
             time.sleep(self.sleep_for)
         return VerificationResult(
@@ -347,8 +369,7 @@ def test_parallel_converge_hung_child_alongside_an_observed_fail_stays_fail(
     # The deadline must clear _MIN_LEAF_BUDGET_SECONDS by a real margin so both
     # leaves' verify() calls are actually invoked (and the hung one outlasts
     # the wait) rather than being short-circuited by the per-leaf min-budget
-    # guard before they ever run; 1.5s leaves ~0.25s of that margin after the
-    # child-deadline clamp, same as the neighboring converge tests.
+    # guard before they ever run.
     spec = {
         "type": "parallel",
         "checks": [
@@ -431,6 +452,36 @@ def test_parallel_converge_close_race_uses_straggler_grace_pass(
     assert res.children[0].status == "fail"
     assert res.children[0].reason == "leaf:closerace"
     assert res.children[0].raw is not None
+
+
+def test_parallel_converge_child_polls_through_the_full_parent_deadline(
+    agent: VerifierAgent,
+) -> None:
+    """A converge child is not cut short by a deadline earlier than the parent's.
+
+    The child here only converges (succeeds) once it has actually been
+    polled for 1.4s. The parent's own deadline is 1.5s away, so the child
+    has enough real budget to converge, and must be handed all of it: if it
+    were instead started against a deadline shortened by any real margin
+    (as the pre-fix code did), it would run out of budget at ~1.25s, sleep
+    out that shorter window, and report an unconverged fail before ever
+    reaching its actual convergence point. That failure would then not be
+    rescued by the straggler grace pass, since the grace pass only waits
+    longer for an in-flight future to finish; it cannot hand the child back
+    time it was never given to converge in the first place.
+    """
+    spec = {
+        "type": "parallel",
+        "checks": [_leaf(converge_after=1.4, tag="lateconverge")],
+    }
+
+    res = agent.wait_for_condition(spec, timeout_sec=1.5)
+
+    assert res.status == "pass"
+    assert res.children[0].status == "pass"
+    assert res.children[0].reason == "leaf:lateconverge"
+    assert res.children[0].raw is not None
+    assert res.children[0].raw["timeout_sec"] >= 1.4
 
 
 def test_parallel_converge_still_hung_after_grace_yields_placeholder(


### PR DESCRIPTION
Fixes #67

### Problem

Under `mode: converge`, a `parallel` or `all` group reports children as `status: "error"` with reason `"evaluation did not complete before the deadline"` and `raw: null`, even when the child completed and produced a real observation.

`_run_parallel` submits every child against the same absolute `deadline` it then uses for its own `futures_wait` (`runner.py:522` and `runner.py:533`). A child whose budget expires at that instant races the parent, and when it loses, `if f not in done: continue` (`runner.py:536`) leaves the placeholder pre-filled at `runner.py:511-513`. Since `ex.shutdown(wait=False, cancel_futures=True)` does not interrupt a running thread, the child finishes anyway and its result is never read.

That discarded result is a real one: `_poll_to_result` (`base.py:212-231`) records status, reason, and raw on every poll and builds its result from the last observation. So an observed `fail` is downgraded to an unobserved `error`, which rolls up differently, and the diagnostic explaining the failure is lost.

`_run_sequence` is unaffected; it awaits each child synchronously.

### Fix

Converge children get a deadline `_CHILD_DEADLINE_MARGIN_SEC` (0.25s) ahead of the parent's wait, so the parent outlives its children instead of racing them. The margin is applied only when enough budget remains that the child still clears `_MIN_LEAF_BUDGET_SECONDS`, so short budgets are untouched. If any child is still pending when the parent's wait returns, one bounded `_STRAGGLER_GRACE_SEC` (0.5s) pass collects it. Children that genuinely never return keep the placeholder.

Single-shot is deliberately excluded. `_SINGLE_SHOT_WAIT_CEILING_SEC` is the hard backstop against a hung safeguard leaf stalling the run, and extending it with a grace period would stop it being a true ceiling. Under assert mode a late unobserved verdict is already the correct answer.

### Testing

- New regression test for the close-race case, confirmed to fail on unpatched code with `assert 'error' == 'fail'`.
- New test that a child which never returns still yields the placeholder, so the fallback is not weakened.
- Existing single-shot timing assertions unchanged.
- Verification suite run 10 times consecutively with no flakes; full suite 1183 passed.

Related to #61, which fixes a separate budget-division defect in `_run_verification`. No overlap in files or mechanism.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parallel verification near deadlines by allowing a brief grace period for straggling evaluations.
  * Reports results from evaluations that finish shortly after the initial wait instead of marking them incomplete.
  * Evaluations still pending after the grace period continue to receive an incomplete status.
  * Preserved existing timing behavior for single-shot evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->