### PR TITLE
Set an explicit provider on the deploy-hello-app task

### DIFF
--- a/tasks/gcp/deploy-hello-app/task.yaml
+++ b/tasks/gcp/deploy-hello-app/task.yaml
@@ -2,6 +2,7 @@ task_id: 6
 name: "deploy-hello-app"
 infrastructure:
   deployer: "tofu"
+  provider: "gcp"
   stack: "prebuilt/minimum"
   teardown: true
   variables:


### PR DESCRIPTION
Found while running the task end to end. It fails before provisioning even starts:

```
stack 'prebuilt/minimum' requires an explicit provider; set 'provider' in task
config or the INFRA_PROVIDER env var (e.g. 'gcp' or 'kind')
```

Provider deduction only fires for an in-repo stack whose final path segment is in `_DEDUCIBLE_PROVIDERS` (`kind`, `vcluster`), and it deliberately never falls back to `gcp` (documented in `docs/components/infra.md`). `prebuilt/minimum` is in neither set, so a GCP stack with no explicit provider raises `ConfigError`.

gke-labs fixed this across all GCP tasks in `2c43cff` ("tasks(gcp): set an explicit provider on all GCP task configs", 8 files). `deploy-hello-app` migrated here from an earlier state and lost the line.

One-line change. With it, `provider` parses as `gcp` and the task proceeds to provisioning.

Was stacked on #64, which merged on 2026-08-21, so `tf/prebuilt/minimum/` is on `main` and this is now the only remaining blocker before `deploy-hello-app` runs here.
