### PR TITLE
fix(core): never let a subprocess inherit the operator's stdin

### DIFF
--- a/devops_bench/core/subprocess.py
+++ b/devops_bench/core/subprocess.py
@@ -85,6 +85,19 @@ def run(
             text=text,
             timeout=timeout,
             input=input,
+            # DEVNULL, not the default of None. `None` makes the child INHERIT this
+            # process's stdin, which in an interactive run is the operator's terminal.
+            # `capture_output` only redirects stdout and stderr, so it does not help.
+            #
+            # A CLI subprocess that finds an open, non-TTY stdin can block reading it
+            # indefinitely. Observed with an agent CLI that printed a terminal-
+            # capability warning and then hung until the run's timeout killed it,
+            # producing no output and looking exactly like a slow network call. No
+            # subprocess this harness launches has any reason to read the operator's
+            # keyboard, so close the channel here rather than rely on every child to.
+            #
+            # `input=` manages stdin itself, so only override when there is none.
+            stdin=subprocess.DEVNULL if input is None else None,
             check=False,
         )
     except subprocess.TimeoutExpired as exc:

--- a/tests/unit/core/test_subprocess.py
+++ b/tests/unit/core/test_subprocess.py
@@ -115,3 +115,18 @@ def test_as_text_handles_bytes_and_none():
     assert bench_subprocess._as_text(None) is None
     assert bench_subprocess._as_text("text") == "text"
     assert isinstance(bench_subprocess._as_text(b"\xff\xfe"), str)
+
+
+def test_child_does_not_inherit_parent_stdin() -> None:
+    """A child reading stdin must see EOF immediately, not block on the terminal.
+
+    Regression guard. With subprocess.run's default of ``stdin=None`` the child
+    inherits the parent's stdin, and a CLI that inspects it can hang until the
+    caller's timeout. ``cat`` blocks until EOF, so this only returns promptly when
+    stdin has been closed for the child.
+    """
+    completed = bench_subprocess.run(
+        ["sh", "-c", "cat > /dev/null; echo reached-eof"], check=False, timeout=10
+    )
+    assert completed.returncode == 0
+    assert "reached-eof" in completed.stdout

--- a/tests/unit/core/test_subprocess.py
+++ b/tests/unit/core/test_subprocess.py
@@ -19,6 +19,7 @@ These exercise the wrapper against real, portable shell-free commands
 the standard library.
 """
 
+import os
 import sys
 from pathlib import Path
 
@@ -124,9 +125,24 @@ def test_child_does_not_inherit_parent_stdin() -> None:
     inherits the parent's stdin, and a CLI that inspects it can hang until the
     caller's timeout. ``cat`` blocks until EOF, so this only returns promptly when
     stdin has been closed for the child.
+
+    The test process's own fd 0 is swapped for a pipe that is kept open (and
+    never fed EOF) for the duration of the call, so the assertion actually
+    depends on ``run`` closing the child's stdin rather than on whatever state
+    the test runner happened to leave fd 0 in. If the child inherited the open
+    pipe, ``cat`` would block and the call would time out instead of returning.
     """
-    completed = bench_subprocess.run(
-        ["sh", "-c", "cat > /dev/null; echo reached-eof"], check=False, timeout=10
-    )
+    read_fd, write_fd = os.pipe()
+    saved_stdin_fd = os.dup(0)
+    try:
+        os.dup2(read_fd, 0)
+        os.close(read_fd)
+        completed = bench_subprocess.run(
+            ["sh", "-c", "cat > /dev/null; echo reached-eof"], check=False, timeout=10
+        )
+    finally:
+        os.dup2(saved_stdin_fd, 0)
+        os.close(saved_stdin_fd)
+        os.close(write_fd)
     assert completed.returncode == 0
     assert "reached-eof" in completed.stdout


### PR DESCRIPTION
`core.subprocess.run` passed `stdin=None` through to `subprocess.run`, which means the
child INHERITS the parent's stdin rather than receiving nothing. In an interactive run
that is the operator's terminal.

A CLI agent that finds an open, non-TTY stdin can sit reading it forever. We hit this
with the gemini CLI: it prints "256-color support not detected" and then blocks, which
from the outside is indistinguishable from a model call that never returns. Every run
that hit it burned the full agent timeout and produced no output to debug from.

This passes `stdin=subprocess.DEVNULL` whenever the caller did not supply `input=`.
When `input=` is given, `subprocess.run` manages stdin itself and the argument is left
alone, so existing callers that write to stdin are unaffected.

The change is unconditional rather than opt-in: no subprocess this harness launches has
any business reading the operator's keyboard.

Includes a regression test asserting a child that reads stdin sees EOF rather than
blocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented subprocesses from hanging while waiting for input when no input is provided.
  * Explicitly supplied input continues to work as expected.

* **Tests**
  * Added coverage to verify subprocesses complete promptly without inheriting interactive input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->