### PR TITLE
feat(agents): optionally run CLI agents in a container with a scoped cluster identity

### DIFF
--- a/devops_bench/agents/cli/gemini_cli/agent.py
+++ b/devops_bench/agents/cli/gemini_cli/agent.py
@@ -50,7 +50,7 @@ from devops_bench.agents.shared.cli_capabilities import (
 )
 from devops_bench.core import SubprocessError, get_logger
 from devops_bench.core.model_providers import resolve_provider
-from devops_bench.core.subprocess import run
+from devops_bench.core.subprocess import CompletedProcess, run
 
 if TYPE_CHECKING:  # pragma: no cover - typing-only import
     from devops_bench.agents.capabilities import McpBinding
@@ -255,9 +255,7 @@ class GeminiCliAgent(AgentHarness):
             sandboxed = False
             if sandbox.sandbox_enabled():
                 cluster = sandbox.current_cluster_name()
-                kubeconfig = (
-                    sandbox.build_agent_kubeconfig(cluster, workdir) if cluster else None
-                )
+                kubeconfig = sandbox.build_agent_kubeconfig(cluster, workdir) if cluster else None
                 if kubeconfig is None:
                     # Refuse rather than silently running unsandboxed on the host: a
                     # containment control that quietly degrades is worse than none.
@@ -270,6 +268,8 @@ class GeminiCliAgent(AgentHarness):
                 )
                 sandboxed = True
 
+            completed: CompletedProcess | None = None
+            timeout_exc: SubprocessError | None = None
             try:
                 completed = run(
                     run_argv,
@@ -279,21 +279,31 @@ class GeminiCliAgent(AgentHarness):
                     timeout=self.config.timeout_sec,
                 )
             except SubprocessError as exc:
-                return AgentResult.errored(f"gemini subprocess error: {exc}")
+                # check=False means this can only be a timeout. The stream-json
+                # events already flushed to stdout before the process was
+                # killed still describe real tool calls the agent made: fall
+                # through to recover them below instead of discarding the
+                # captured output and returning an empty trajectory.
+                timeout_exc = exc
             except OSError as exc:
                 # Missing / non-executable binary; core.subprocess.run does not wrap.
                 return AgentResult.errored(f"gemini binary unavailable: {exc}")
 
-        output, trajectory, tokens, parse_errors = parse_stream_json(completed.stdout or "")
+        stdout = (timeout_exc.stdout if timeout_exc is not None else completed.stdout) or ""
+        output, trajectory, tokens, parse_errors = parse_stream_json(stdout)
         errors: list[str] = list(parse_errors)
-        if completed.returncode != 0:
+        metadata: dict = {"trajectory_captured": bool(trajectory)}
+        if timeout_exc is not None:
+            metadata["timed_out"] = True
+            errors.append(f"gemini subprocess error: {timeout_exc}")
+            if not output:
+                output = f"Error: gemini subprocess error: {timeout_exc}"
+        elif completed.returncode != 0:
             stderr = (completed.stderr or "").strip()
             errors.append(f"gemini exited {completed.returncode}: {stderr or '<no stderr>'}")
+            metadata["returncode"] = completed.returncode
             if not output:
                 output = f"Error: gemini exited {completed.returncode}"
-        metadata: dict = {}
-        if completed.returncode != 0:
-            metadata["returncode"] = completed.returncode
         return AgentResult(
             output=output,
             trajectory=trajectory,

--- a/devops_bench/agents/cli/gemini_cli/agent.py
+++ b/devops_bench/agents/cli/gemini_cli/agent.py
@@ -33,6 +33,7 @@ mechanisms, written into the per-run working directory before invocation:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 from pathlib import Path
@@ -253,6 +254,7 @@ class GeminiCliAgent(AgentHarness):
             # by value as explicit -e flags rather than as inherited process env.
             run_argv = argv
             sandboxed = False
+            container_name: str | None = None
             if sandbox.sandbox_enabled():
                 cluster = sandbox.current_cluster_name()
                 kubeconfig = sandbox.build_agent_kubeconfig(cluster, workdir) if cluster else None
@@ -263,31 +265,46 @@ class GeminiCliAgent(AgentHarness):
                         "BENCH_AGENT_SANDBOX is set but no sandbox kubeconfig could be "
                         "built; refusing to fall back to an unsandboxed run"
                     )
+                container_name = sandbox.container_name_for_workspace(workdir)
                 run_argv = sandbox.wrap_argv(
-                    argv, workspace=workdir, kubeconfig=kubeconfig, extra_env=env_overlay
+                    argv,
+                    workspace=workdir,
+                    kubeconfig=kubeconfig,
+                    extra_env=env_overlay,
+                    container_name=container_name,
                 )
                 sandboxed = True
 
             completed: CompletedProcess | None = None
             timeout_exc: SubprocessError | None = None
-            try:
-                completed = run(
-                    run_argv,
-                    extra_env=None if sandboxed else env_overlay,
-                    cwd=workdir,
-                    check=False,
-                    timeout=self.config.timeout_sec,
-                )
-            except SubprocessError as exc:
-                # check=False means this can only be a timeout. The stream-json
-                # events already flushed to stdout before the process was
-                # killed still describe real tool calls the agent made: fall
-                # through to recover them below instead of discarding the
-                # captured output and returning an empty trajectory.
-                timeout_exc = exc
-            except OSError as exc:
-                # Missing / non-executable binary; core.subprocess.run does not wrap.
-                return AgentResult.errored(f"gemini binary unavailable: {exc}")
+            # container_guard reaps the sandbox container by name on every exit
+            # from this block, normal or not: `--rm` alone only cleans up when
+            # the container's own process exits, not when the timeout below
+            # kills the local `docker run` client out from under it.
+            guard = (
+                sandbox.container_guard(container_name)
+                if container_name is not None
+                else contextlib.nullcontext()
+            )
+            with guard:
+                try:
+                    completed = run(
+                        run_argv,
+                        extra_env=None if sandboxed else env_overlay,
+                        cwd=workdir,
+                        check=False,
+                        timeout=self.config.timeout_sec,
+                    )
+                except SubprocessError as exc:
+                    # check=False means this can only be a timeout. The stream-json
+                    # events already flushed to stdout before the process was
+                    # killed still describe real tool calls the agent made: fall
+                    # through to recover them below instead of discarding the
+                    # captured output and returning an empty trajectory.
+                    timeout_exc = exc
+                except OSError as exc:
+                    # Missing / non-executable binary; core.subprocess.run does not wrap.
+                    return AgentResult.errored(f"gemini binary unavailable: {exc}")
 
         stdout = (timeout_exc.stdout if timeout_exc is not None else completed.stdout) or ""
         output, trajectory, tokens, parse_errors = parse_stream_json(stdout)

--- a/devops_bench/agents/cli/gemini_cli/agent.py
+++ b/devops_bench/agents/cli/gemini_cli/agent.py
@@ -38,6 +38,7 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from devops_bench.agents import sandbox
 from devops_bench.agents.base import AGENTS, AgentHarness
 from devops_bench.agents.cli.gemini_cli.parsing import parse_stream_json
 from devops_bench.agents.config import AgentConfig
@@ -240,10 +241,39 @@ class GeminiCliAgent(AgentHarness):
                 (gemini_dir / _GEMINI_SETTINGS_FILE).write_text(
                     json.dumps(settings, indent=2), encoding="utf-8"
                 )
+            # Containerised execution, opt-in via BENCH_AGENT_SANDBOX=docker.
+            #
+            # Everything above still runs on the host: GEMINI.md, settings.json and the
+            # skills tree are written into `workdir`, which is then mounted into the
+            # container as /workspace. Only the agent process itself moves.
+            #
+            # env_overlay is handed to wrap_argv rather than to run(). It is the
+            # RESOLVED configuration (provider-routed api key, GEMINI_MODEL, the OTLP
+            # disables), so it is exactly what should cross the boundary, and it crosses
+            # by value as explicit -e flags rather than as inherited process env.
+            run_argv = argv
+            sandboxed = False
+            if sandbox.sandbox_enabled():
+                cluster = sandbox.current_cluster_name()
+                kubeconfig = (
+                    sandbox.build_agent_kubeconfig(cluster, workdir) if cluster else None
+                )
+                if kubeconfig is None:
+                    # Refuse rather than silently running unsandboxed on the host: a
+                    # containment control that quietly degrades is worse than none.
+                    return AgentResult.errored(
+                        "BENCH_AGENT_SANDBOX is set but no sandbox kubeconfig could be "
+                        "built; refusing to fall back to an unsandboxed run"
+                    )
+                run_argv = sandbox.wrap_argv(
+                    argv, workspace=workdir, kubeconfig=kubeconfig, extra_env=env_overlay
+                )
+                sandboxed = True
+
             try:
                 completed = run(
-                    argv,
-                    extra_env=env_overlay,
+                    run_argv,
+                    extra_env=None if sandboxed else env_overlay,
                     cwd=workdir,
                     check=False,
                     timeout=self.config.timeout_sec,

--- a/devops_bench/agents/sandbox.py
+++ b/devops_bench/agents/sandbox.py
@@ -1,0 +1,268 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Run a CLI agent inside a container with a scoped cluster identity.
+
+WHY THIS EXISTS. The CLI agent harnesses invoke the agent binary as a plain
+subprocess inheriting the parent environment, so ``run_shell_command`` under
+``--approval-mode yolo`` has the operator's entire filesystem. Observed in real
+runs: an agent read another task's ``seed.sh`` and ``verify.sh``, searched the
+home directory for its own fixtures by namespace name, and copied an unrelated
+archive out of ``~/Downloads`` before running ``rm -rf``. The agent's own
+workspace sandbox does not help, because it only guards the native file tools
+and not the shell.
+
+Two boundaries, and they solve different problems:
+
+* The CONTAINER removes the host filesystem and the operator's environment. That
+  closes the on-disk answer-key channel and the safety hazard.
+* The SCOPED TOKEN decides what the agent may do to the cluster. That is task
+  design, not containment: it makes the agent's identity part of the topology.
+
+Neither closes the third channel. An agent that can read a cluster can read
+anything a task put IN that cluster, and a task that needs the agent to inspect a
+workload cannot use RBAC to hide that workload's own definition. Answer material
+must not be seeded into the cluster in the first place; see the factory's
+``answer-leakage.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+from devops_bench.core import get_logger
+from devops_bench.core.subprocess import run
+
+__all__ = ["sandbox_enabled", "build_agent_kubeconfig", "wrap_argv"]
+
+_log = get_logger("agents.sandbox")
+
+# The ServiceAccount a task may seed to declare what its agent is allowed to do.
+# Absent, the agent falls back to the operator's own context, which is what the
+# harness did unconditionally before this module existed.
+AGENT_SA_NAME = os.environ.get("BENCH_AGENT_SA", "bench-agent")
+AGENT_SA_NAMESPACE = os.environ.get("BENCH_AGENT_SA_NAMESPACE", "bench-system")
+TOKEN_DURATION = os.environ.get("BENCH_AGENT_TOKEN_DURATION", "2h")
+
+
+def sandbox_enabled() -> bool:
+    """True when the agent should run containerised.
+
+    Opt-in rather than default so it can be A/B'd against the current behaviour
+    while tasks are still being debugged.
+    """
+    return os.environ.get("BENCH_AGENT_SANDBOX", "").strip().lower() in {"docker", "1", "true"}
+
+
+def current_cluster_name() -> str | None:
+    """Derive the kind cluster name from the active kubectl context.
+
+    The agent harness is handed a workspace and a prompt, never the cluster name,
+    so rather than widen that interface we recover it from the context kind wrote:
+    ``kind-<cluster>``. That is also exactly the prefix of the control-plane
+    container name the container needs to reach, so the two stay consistent by
+    construction. Returns None for a non-kind context, which is the signal that
+    this sandbox's networking assumptions do not apply.
+    """
+    ctx = run(["kubectl", "config", "current-context"], check=False).stdout or ""
+    ctx = ctx.strip()
+    if not ctx.startswith("kind-"):
+        _log.error("context %r is not a kind context; the docker-network sandbox assumes kind", ctx)
+        return None
+    return ctx[len("kind-") :]
+
+
+def _kubectl_json(*args: str) -> dict:
+    completed = run(["kubectl", *args, "-o", "json"], check=False)
+    if completed.returncode != 0:
+        return {}
+    try:
+        return json.loads(completed.stdout or "{}")
+    except json.JSONDecodeError:
+        return {}
+
+
+def build_agent_kubeconfig(cluster_name: str, dest_dir: Path) -> Path | None:
+    """Write a kubeconfig the container can use, and return its path.
+
+    Two things have to change from the operator's own kubeconfig:
+
+    1. The SERVER. ``kind`` writes ``https://127.0.0.1:<port>``, which means
+       nothing inside a container. ``kind`` also creates a Docker network named
+       ``kind``, so a container joined to it reaches the API server at
+       ``https://<cluster>-control-plane:6443``. The API server certificate
+       covers the control-plane node name, so TLS still verifies and no
+       ``--insecure-skip-tls-verify`` is needed.
+    2. The CREDENTIAL. The operator's context authenticates with an admin client
+       certificate. If the task seeded an agent ServiceAccount we mint a short
+       lived token for it instead, so the agent holds exactly the permissions the
+       task chose to give it. If it did not, we fall back to the admin
+       credential and say so loudly, because that is a strictly larger grant than
+       most tasks intend.
+
+    Returns None when no kubeconfig could be built, in which case the caller
+    should refuse to run rather than silently fall back to the host.
+    """
+    ca = run(
+        [
+            "kubectl",
+            "config",
+            "view",
+            "--raw",
+            "--minify",
+            "-o",
+            "jsonpath={.clusters[0].cluster.certificate-authority-data}",
+        ],
+        check=False,
+    ).stdout
+    if not ca:
+        _log.error("could not read cluster CA from the current context; refusing to sandbox")
+        return None
+
+    server = f"https://{cluster_name}-control-plane:6443"
+
+    sa_exists = (
+        run(
+            ["kubectl", "-n", AGENT_SA_NAMESPACE, "get", "sa", AGENT_SA_NAME],
+            check=False,
+        ).returncode
+        == 0
+    )
+
+    if sa_exists:
+        token = run(
+            [
+                "kubectl",
+                "-n",
+                AGENT_SA_NAMESPACE,
+                "create",
+                "token",
+                AGENT_SA_NAME,
+                f"--duration={TOKEN_DURATION}",
+            ],
+            check=False,
+        ).stdout
+        if not token:
+            _log.error("ServiceAccount %s/%s exists but token minting failed", AGENT_SA_NAMESPACE, AGENT_SA_NAME)
+            return None
+        user_block = f"user: {{token: {token.strip()}}}"
+        _log.info(
+            "agent identity: ServiceAccount %s/%s (scoped by the task)",
+            AGENT_SA_NAMESPACE,
+            AGENT_SA_NAME,
+        )
+    else:
+        # No task-declared identity. Reuse the operator's client cert. This is
+        # cluster-admin on kind, so the container boundary is doing all the work
+        # and the RBAC boundary is doing none.
+        cert = run(
+            ["kubectl", "config", "view", "--raw", "--minify", "-o",
+             "jsonpath={.users[0].user.client-certificate-data}"],
+            check=False,
+        ).stdout
+        key = run(
+            ["kubectl", "config", "view", "--raw", "--minify", "-o",
+             "jsonpath={.users[0].user.client-key-data}"],
+            check=False,
+        ).stdout
+        if not (cert and key):
+            _log.error("no agent ServiceAccount and no client cert in the current context")
+            return None
+        user_block = f"user: {{client-certificate-data: {cert}, client-key-data: {key}}}"
+        _log.warning(
+            "no ServiceAccount %s/%s: agent runs with the operator's admin credential. "
+            "Seed one in the task's stack to scope it.",
+            AGENT_SA_NAMESPACE,
+            AGENT_SA_NAME,
+        )
+
+    path = dest_dir / "kubeconfig"
+    path.write_text(
+        "apiVersion: v1\n"
+        "kind: Config\n"
+        f"clusters: [{{name: c, cluster: {{server: {server}, certificate-authority-data: {ca}}}}}]\n"
+        f"users: [{{name: u, {user_block}}}]\n"
+        "contexts: [{name: ctx, context: {cluster: c, user: u}}]\n"
+        "current-context: ctx\n"
+    )
+    path.chmod(0o600)
+    return path
+
+
+def wrap_argv(
+    argv: list[str],
+    *,
+    workspace: Path,
+    kubeconfig: Path,
+    image: str | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> list[str]:
+    """Wrap an agent command line in ``docker run``.
+
+    The mount set is deliberately short, and what is ABSENT matters more than
+    what is present:
+
+    * the repository is not mounted, so task definitions, seed scripts and
+      scoring rubrics are unreachable
+    * ``$HOME`` is not mounted, and HOME is repointed inside the container so a
+      bare ``~`` cannot resolve to the operator's profile
+    * the Docker socket is not mounted; with it the container boundary would be
+      decorative, and it is tempting precisely because the cluster is Docker-hosted
+    * Application Default Credentials are not mounted. Model access should use a
+      credential scoped to model access; ADC is the operator's whole cloud identity
+      and is a larger grant than the filesystem access this wrapper removes.
+    """
+    image = image or os.environ.get("BENCH_AGENT_IMAGE", "")
+    if not image:
+        raise ValueError("BENCH_AGENT_IMAGE must name an image containing the agent CLI")
+
+    # Only the caller's resolved overlay crosses the boundary. Deliberately NOT
+    # scraping os.environ for well-known credential names: that would reinstate
+    # "inherit whatever the operator happened to export", which is the behaviour
+    # this wrapper exists to remove. If a credential is not in the resolved
+    # config, the agent does not get it.
+    env_flags: list[str] = []
+    for key, value in (extra_env or {}).items():
+        env_flags += ["-e", f"{key}={value}"]
+
+    return [
+        # No -i. Keeping stdin open gives the agent an open, non-TTY stdin to block
+        # on, and a headless `-p <prompt>` run never reads it. Combined with
+        # stdin=DEVNULL in core.subprocess this closes the channel at both ends.
+        "docker", "run", "--rm",
+        "--network", "kind",
+        "--user", f"{os.getuid()}:{os.getgid()}",
+        "-v", f"{workspace}:/workspace",
+        "-v", f"{kubeconfig}:/kubeconfig:ro",
+        "-e", "KUBECONFIG=/kubeconfig",
+        "-e", "HOME=/workspace",
+        "-w", "/workspace",
+        *env_flags,
+        image,
+        *argv,
+    ]
+
+
+def make_workspace() -> Path:
+    """A world-writable scratch dir the container's non-root user can write to."""
+    path = Path(tempfile.mkdtemp(prefix="devops-bench-sandbox-"))
+    path.chmod(0o777)
+    return path
+
+
+def cleanup(path: Path) -> None:
+    shutil.rmtree(path, ignore_errors=True)

--- a/devops_bench/agents/sandbox.py
+++ b/devops_bench/agents/sandbox.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Google LLC
+# Copyright 2026 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Run a CLI agent inside a container with a scoped cluster identity.
 
 WHY THIS EXISTS. The CLI agent harnesses invoke the agent binary as a plain

--- a/devops_bench/agents/sandbox.py
+++ b/devops_bench/agents/sandbox.py
@@ -38,16 +38,26 @@ must not be seeded into the cluster in the first place; see the factory's
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import shutil
 import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 
 from devops_bench.core import get_logger
 from devops_bench.core.subprocess import run
 
-__all__ = ["sandbox_enabled", "build_agent_kubeconfig", "wrap_argv"]
+__all__ = [
+    "sandbox_enabled",
+    "build_agent_kubeconfig",
+    "wrap_argv",
+    "container_name_for_workspace",
+    "kill_container",
+    "container_guard",
+    "sweep_stray_containers",
+]
 
 _log = get_logger("agents.sandbox")
 
@@ -57,6 +67,15 @@ _log = get_logger("agents.sandbox")
 AGENT_SA_NAME = os.environ.get("BENCH_AGENT_SA", "bench-agent")
 AGENT_SA_NAMESPACE = os.environ.get("BENCH_AGENT_SA_NAMESPACE", "bench-system")
 TOKEN_DURATION = os.environ.get("BENCH_AGENT_TOKEN_DURATION", "2h")
+
+# Every sandboxed container this harness starts carries this name prefix,
+# followed by its run workspace's own directory name (see
+# ``container_name_for_workspace``). The prefix is what lets
+# ``sweep_stray_containers`` find and reap containers this harness itself
+# created, and only those: a name match is the entire authorization to kill
+# something, so it must never be able to match a container this harness did
+# not start.
+_CONTAINER_NAME_PREFIX = "devops-bench-agent-"
 
 
 def sandbox_enabled() -> bool:
@@ -157,7 +176,11 @@ def build_agent_kubeconfig(cluster_name: str, dest_dir: Path) -> Path | None:
             check=False,
         ).stdout
         if not token:
-            _log.error("ServiceAccount %s/%s exists but token minting failed", AGENT_SA_NAMESPACE, AGENT_SA_NAME)
+            _log.error(
+                "ServiceAccount %s/%s exists but token minting failed",
+                AGENT_SA_NAMESPACE,
+                AGENT_SA_NAME,
+            )
             return None
         user_block = f"user: {{token: {token.strip()}}}"
         _log.info(
@@ -170,13 +193,27 @@ def build_agent_kubeconfig(cluster_name: str, dest_dir: Path) -> Path | None:
         # cluster-admin on kind, so the container boundary is doing all the work
         # and the RBAC boundary is doing none.
         cert = run(
-            ["kubectl", "config", "view", "--raw", "--minify", "-o",
-             "jsonpath={.users[0].user.client-certificate-data}"],
+            [
+                "kubectl",
+                "config",
+                "view",
+                "--raw",
+                "--minify",
+                "-o",
+                "jsonpath={.users[0].user.client-certificate-data}",
+            ],
             check=False,
         ).stdout
         key = run(
-            ["kubectl", "config", "view", "--raw", "--minify", "-o",
-             "jsonpath={.users[0].user.client-key-data}"],
+            [
+                "kubectl",
+                "config",
+                "view",
+                "--raw",
+                "--minify",
+                "-o",
+                "jsonpath={.users[0].user.client-key-data}",
+            ],
             check=False,
         ).stdout
         if not (cert and key):
@@ -210,6 +247,7 @@ def wrap_argv(
     kubeconfig: Path,
     image: str | None = None,
     extra_env: dict[str, str] | None = None,
+    container_name: str | None = None,
 ) -> list[str]:
     """Wrap an agent command line in ``docker run``.
 
@@ -225,6 +263,13 @@ def wrap_argv(
     * Application Default Credentials are not mounted. Model access should use a
       credential scoped to model access; ADC is the operator's whole cloud identity
       and is a larger grant than the filesystem access this wrapper removes.
+
+    Args:
+        container_name: When given, passed as ``--name``, giving the running
+            container a deterministic identity a caller can reap by name (see
+            :func:`container_guard` / :func:`sweep_stray_containers`) even
+            after the local ``docker run`` client process is gone. Normally
+            :func:`container_name_for_workspace` derived from ``workspace``.
     """
     image = image or os.environ.get("BENCH_AGENT_IMAGE", "")
     if not image:
@@ -239,22 +284,103 @@ def wrap_argv(
     for key, value in (extra_env or {}).items():
         env_flags += ["-e", f"{key}={value}"]
 
+    name_flags = ["--name", container_name] if container_name else []
+
     return [
         # No -i. Keeping stdin open gives the agent an open, non-TTY stdin to block
         # on, and a headless `-p <prompt>` run never reads it. Combined with
         # stdin=DEVNULL in core.subprocess this closes the channel at both ends.
-        "docker", "run", "--rm",
-        "--network", "kind",
-        "--user", f"{os.getuid()}:{os.getgid()}",
-        "-v", f"{workspace}:/workspace",
-        "-v", f"{kubeconfig}:/kubeconfig:ro",
-        "-e", "KUBECONFIG=/kubeconfig",
-        "-e", "HOME=/workspace",
-        "-w", "/workspace",
+        "docker",
+        "run",
+        "--rm",
+        *name_flags,
+        "--network",
+        "kind",
+        "--user",
+        f"{os.getuid()}:{os.getgid()}",
+        "-v",
+        f"{workspace}:/workspace",
+        "-v",
+        f"{kubeconfig}:/kubeconfig:ro",
+        "-e",
+        "KUBECONFIG=/kubeconfig",
+        "-e",
+        "HOME=/workspace",
+        "-w",
+        "/workspace",
         *env_flags,
         image,
         *argv,
     ]
+
+
+def container_name_for_workspace(workspace: Path) -> str:
+    """Deterministic ``docker run --name`` for one run's sandboxed agent.
+
+    Ties the container 1:1 to the run's own workspace directory name (already
+    unique per run: it comes from ``mint_dir(...)`` / ``TemporaryDirectory``),
+    so a reaper can find and kill a stray container purely from its name,
+    without threading a separate run id through the agent harness.
+    """
+    return f"{_CONTAINER_NAME_PREFIX}{workspace.name}"
+
+
+def kill_container(name: str) -> None:
+    """Best-effort ``docker kill`` by name. Never raises.
+
+    ``--rm`` only removes a container once *the container's own process*
+    exits; a ``docker run`` client killed out from under it (which is exactly
+    what happens when ``core.subprocess.run`` hits its timeout and SIGKILLs
+    the local wrapper process) leaves the container itself running in the
+    daemon, unaffected, silently burning whatever quota the agent inside it
+    is still spending. This is what actually stops it, independent of what
+    happened to the local ``docker run`` process. A container that is already
+    gone (the common case, when the agent exited cleanly and ``--rm`` already
+    reaped it) fails harmlessly.
+    """
+    result = run(["docker", "kill", name], check=False)
+    if result.returncode == 0:
+        _log.info("reaped sandbox container %s", name)
+
+
+@contextlib.contextmanager
+def container_guard(name: str) -> Iterator[None]:
+    """Guarantee :func:`kill_container` runs on every exit path.
+
+    Wrap the ``docker run`` invocation in this so a normal return, an
+    exception, and a timeout (which ``core.subprocess.run`` turns into a
+    ``SubprocessError``) all still reap the container by name. ``--rm``
+    already handles the graceful-exit case on its own; this closes every
+    other one.
+    """
+    try:
+        yield
+    finally:
+        kill_container(name)
+
+
+def sweep_stray_containers() -> None:
+    """Best-effort reap of containers this harness left running from a prior run.
+
+    Intended to run once at harness start (before any run's own container
+    exists) so a container orphaned by a prior crash or a killed harness
+    process gets cleaned up before it burns any more quota. Matches
+    exclusively on :data:`_CONTAINER_NAME_PREFIX`, this harness's own naming
+    convention, so it can never reap a container it did not itself create.
+    """
+    listed = run(
+        ["docker", "ps", "-q", "--filter", f"name=^{_CONTAINER_NAME_PREFIX}"],
+        check=False,
+    )
+    if listed.returncode != 0:
+        return
+    stray_ids = [line.strip() for line in (listed.stdout or "").splitlines() if line.strip()]
+    for container_id in stray_ids:
+        result = run(["docker", "kill", container_id], check=False)
+        if result.returncode == 0:
+            _log.warning(
+                "reaped stray sandbox container %s left running from a prior run", container_id
+            )
 
 
 def make_workspace() -> Path:

--- a/devops_bench/evalharness/default.py
+++ b/devops_bench/evalharness/default.py
@@ -84,6 +84,17 @@ _AGENT_TYPE_ALIASES: dict[str, str] = {
 # Default agent type when neither --agent-type nor BENCH_AGENT_TYPE is set.
 _DEFAULT_AGENT_TYPE = "gemini-cli"
 
+# Record-level ``status`` values for a run whose agent process itself never
+# completed cleanly (crashed, exited non-zero, or timed out). Distinct from
+# "success" so a degraded run cannot be mistaken for a genuine one, and
+# distinct from "failed" (reserved for a harness-side exception aborting the
+# task before/around the agent step, e.g. infra provisioning). Both are
+# excluded from scoring in :meth:`DefaultEvalHarness._score`, the same way
+# "failed" already is: a run with no reliable agent output must not receive a
+# composite OutcomeScore that reads as if the agent had a fair turn.
+_STATUS_AGENT_ERROR = "agent_error"
+_STATUS_AGENT_TIMEOUT = "agent_timeout"
+
 # Default target deployment + namespace used both for placeholder
 # substitution in the agent prompt and as the chaos port-forward target, so the
 # operator agent and the chaos injector address the same workload when env is
@@ -916,6 +927,20 @@ class DefaultEvalHarness(Harness):
         """
         dumped = agent_res.to_dict()
         agent_errors = list(dumped.get("errors") or [])
+        agent_metadata = dumped.get("metadata") or {}
+        # A populated ``errors`` list means the agent process itself never
+        # completed cleanly (``AgentResult.errored()`` covers 429 / SDK fault /
+        # missing binary / an unexpected exception in ``_execute``, and a CLI
+        # agent that recovered a partial trajectory after a timeout or a
+        # non-zero exit still appends its own error). ``metadata["timed_out"]``
+        # (set by a CLI agent's own timeout handling) distinguishes the two
+        # degraded statuses; anything else with an error is the general case.
+        if not agent_errors:
+            status = "success"
+        elif agent_metadata.get("timed_out"):
+            status = _STATUS_AGENT_TIMEOUT
+        else:
+            status = _STATUS_AGENT_ERROR
         record = self._empty_record(task)
         record.update(
             {
@@ -930,14 +955,12 @@ class DefaultEvalHarness(Harness):
                     entry.get("name") for entry in dumped.get("trajectory", []) if entry.get("name")
                 ],
                 "trajectory": dumped.get("trajectory", []),
-                "status": "success",
+                "status": status,
                 # Run-level validity gate: a vetted task only promotes to the
                 # leaderboard when this run actually produced a usable result.
-                # ``AgentResult.errored()`` (429 / SDK fault / agent timeout)
-                # yields populated ``errors`` + an empty trajectory while the
-                # record still reads ``status:"success"``, so gating on the task
-                # flag alone would let an empty/errored run pass as a genuine low
-                # score. Require no agent error *and* a non-empty trajectory.
+                # Require no agent error *and* a non-empty trajectory (stricter
+                # than ``status`` alone: a clean-exit run with a stray parse
+                # warning is still "success" but not "validated").
                 "validated": (
                     task.validated and not agent_errors and bool(dumped.get("trajectory"))
                 ),
@@ -1147,10 +1170,14 @@ class DefaultEvalHarness(Harness):
 
         Args:
             detailed_results: Execution results to score; ``scores`` is written
-                into each in place. Records marked ``status: "failed"`` are
-                skipped, since there is no agent output to judge.
+                into each in place. Records marked ``status: "failed"``,
+                ``"agent_error"``, or ``"agent_timeout"`` are skipped: none of
+                the three has a reliable agent output to judge, and scoring
+                one anyway would compute a normal-looking composite
+                OutcomeScore for a run whose agent process never completed.
         """
-        scorable = [r for r in detailed_results if r.get("status") != "failed"]
+        _unscored_statuses = ("failed", _STATUS_AGENT_ERROR, _STATUS_AGENT_TIMEOUT)
+        scorable = [r for r in detailed_results if r.get("status") not in _unscored_statuses]
         if not scorable:
             return
         # Lazy import keeps ``deepeval`` / provider SDKs out of harness import.

--- a/devops_bench/evalharness/default.py
+++ b/devops_bench/evalharness/default.py
@@ -633,6 +633,7 @@ class DefaultEvalHarness(Harness):
             The detailed per-task result dicts, scored in place, in the
             ``results.json`` schema.
         """
+        self._sweep_stray_sandbox_containers()
         run_dir = self.reporter.new_run_dir()
         detailed_results: list[dict[str, Any]] = [self._run_one(task, run_dir) for task in tasks]
 
@@ -661,6 +662,26 @@ class DefaultEvalHarness(Harness):
         except Exception:  # noqa: BLE001 - rows/manifest are derived, never load-bearing
             _log.exception("failed to write rows.json/manifest.json for %s", run_dir)
         return detailed_results
+
+    def _sweep_stray_sandbox_containers(self) -> None:
+        """Reap any sandboxed agent container left running from a prior run.
+
+        Best-effort and a no-op unless ``BENCH_AGENT_SANDBOX`` is set: a
+        container the harness starts is normally cleaned up by
+        ``sandbox.container_guard`` around its own run, but a harness process
+        killed outright (Ctrl-C, OOM, a host reboot) never gets the chance to
+        run that guard's ``finally``. Sweeping once here, before this batch's
+        own containers exist, catches exactly that leak without risking a
+        live container from the run in progress.
+        """
+        from devops_bench.agents import sandbox
+
+        if not sandbox.sandbox_enabled():
+            return
+        try:
+            sandbox.sweep_stray_containers()
+        except Exception:  # noqa: BLE001 - a sweep failure must not block the run
+            _log.exception("stray sandbox container sweep failed; continuing")
 
     def _write_run_artifacts(self, run_dir: Path, detailed_results: list[dict[str, Any]]) -> None:
         """Flatten ``detailed_results`` into ``rows.json`` + ``manifest.json``.

--- a/hack/agent-credential.sh
+++ b/hack/agent-credential.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Mint a MINIMAL model credential for the sandboxed agent.
+#
+# Why not just pass ADC through. The containerised agent needs some credential to
+# reach a model, but Application Default Credentials are the operator's entire
+# cloud identity. Handing that to an agent we are containerising precisely because
+# it wanders is a strictly larger grant than the filesystem access the container
+# removes. This mints a credential that can call one API and nothing else.
+#
+#   ./hack/agent-credential.sh                 # restricted API key (default)
+#   ./hack/agent-credential.sh --vertex-sa     # scoped SA + short-lived token
+#   ./hack/agent-credential.sh --revoke        # delete keys this script created
+#
+# Default path produces a GCP API key restricted to the Generative Language API.
+# Blast radius if it leaks: model calls billed to this project. Nothing else.
+set -euo pipefail
+
+PROJECT="${PROJECT:-$(gcloud config get-value project 2>/dev/null)}"
+KEY_DISPLAY_NAME="devops-bench-agent-sandbox"
+SA_NAME="devops-bench-agent"
+MODE="apikey"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --vertex-sa) MODE="vertex-sa"; shift ;;
+    --revoke)    MODE="revoke"; shift ;;
+    --project)   PROJECT="$2"; shift 2 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "${PROJECT}" ]] || { echo "no project set; pass --project or run 'gcloud config set project'" >&2; exit 2; }
+echo "project: ${PROJECT}"
+
+# --------------------------------------------------------------------------
+case "${MODE}" in
+
+apikey)
+  echo "==> Enabling generativelanguage.googleapis.com (idempotent)..."
+  gcloud services enable generativelanguage.googleapis.com --project="${PROJECT}" >/dev/null
+
+  echo "==> Creating an API key restricted to that one API..."
+  # --api-target is the restriction that makes this minimal. Without it the key
+  # can call every enabled API in the project, which defeats the point.
+  gcloud services api-keys create \
+    --project="${PROJECT}" \
+    --display-name="${KEY_DISPLAY_NAME}" \
+    --api-target=service=generativelanguage.googleapis.com \
+    --format=none
+
+  KEY_NAME="$(gcloud services api-keys list --project="${PROJECT}" \
+      --filter="displayName=${KEY_DISPLAY_NAME}" --format='value(name)' --limit=1)"
+  KEY_STRING="$(gcloud services api-keys get-key-string "${KEY_NAME}" \
+      --project="${PROJECT}" --format='value(keyString)')"
+
+  cat <<EOF
+
+Credential ready. It can call generativelanguage.googleapis.com and nothing else.
+
+  export AGENT_PROVIDER=google
+  export AGENT_MODEL=gemini-2.5-flash
+  export AGENT_API_KEY='${KEY_STRING}'
+
+AGENT_PROVIDER must be 'google', not 'google-vertex': the vertex provider is
+keyless and authenticates via ADC, which is the thing we are avoiding. The
+'google' provider routes AGENT_API_KEY to GEMINI_API_KEY/GOOGLE_API_KEY, which
+the sandbox wrapper passes into the container by value.
+
+Revoke with: $0 --revoke --project ${PROJECT}
+EOF
+  ;;
+
+# --------------------------------------------------------------------------
+vertex-sa)
+  # Alternative for staying on Vertex. Produces a SHORT-LIVED token by
+  # impersonation rather than a downloadable JSON key, so there is no long-lived
+  # secret sitting on disk waiting to be mounted somewhere by accident.
+  SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+
+  echo "==> Creating service account ${SA_EMAIL} (idempotent)..."
+  gcloud iam service-accounts describe "${SA_EMAIL}" --project="${PROJECT}" >/dev/null 2>&1 || \
+    gcloud iam service-accounts create "${SA_NAME}" \
+      --project="${PROJECT}" --display-name="devops-bench sandboxed agent" >/dev/null
+
+  echo "==> Granting roles/aiplatform.user (model access only)..."
+  gcloud projects add-iam-policy-binding "${PROJECT}" \
+    --member="serviceAccount:${SA_EMAIL}" --role="roles/aiplatform.user" \
+    --condition=None --format=none >/dev/null
+
+  echo "==> Allowing you to impersonate it..."
+  gcloud iam service-accounts add-iam-policy-binding "${SA_EMAIL}" \
+    --project="${PROJECT}" \
+    --member="user:$(gcloud config get-value account)" \
+    --role="roles/iam.serviceAccountTokenCreator" --format=none >/dev/null
+
+  TOKEN="$(gcloud auth print-access-token --impersonate-service-account="${SA_EMAIL}")"
+  cat <<EOF
+
+Short-lived token minted (expires in ~1h, no key file on disk).
+
+  export AGENT_PROVIDER=google-vertex
+  export GOOGLE_CLOUD_PROJECT='${PROJECT}'
+  export AGENT_API_KEY='${TOKEN}'
+
+Re-run this to refresh. A run that outlives the token fails mid-flight, which is
+the trade for not having a long-lived key.
+EOF
+  ;;
+
+# --------------------------------------------------------------------------
+revoke)
+  echo "==> Deleting API keys named ${KEY_DISPLAY_NAME}..."
+  for name in $(gcloud services api-keys list --project="${PROJECT}" \
+      --filter="displayName=${KEY_DISPLAY_NAME}" --format='value(name)'); do
+    gcloud services api-keys delete "${name}" --project="${PROJECT}" --quiet
+    echo "    deleted ${name}"
+  done
+  echo "==> Done. (The --vertex-sa service account is left alone; delete it by hand if unwanted.)"
+  ;;
+esac

--- a/hack/agent-credential.sh
+++ b/hack/agent-credential.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # Mint a MINIMAL model credential for the sandboxed agent.
 #

--- a/hack/agent-sandbox.Dockerfile
+++ b/hack/agent-sandbox.Dockerfile
@@ -1,0 +1,47 @@
+# Image for running a CLI agent under test, isolated from the host.
+#
+# Contains the agent CLI and the cluster tooling a DevOps task needs, and
+# deliberately nothing else. The host repo, the operator's home directory, the
+# Docker socket and ADC are all absent by construction rather than by policy:
+# they are simply not in this image and not mounted by the sandbox wrapper.
+#
+#   docker build -f hack/agent-sandbox.Dockerfile -t devops-bench/agent-sandbox:dev .
+#
+# Pin GEMINI_CLI_VERSION for reproducible runs. Leaving it at "latest" means the
+# agent under test changes underneath you between runs, which quietly makes
+# results incomparable.
+FROM node:22-slim
+
+ARG KUBECTL_VERSION=v1.31.4
+ARG GEMINI_CLI_VERSION=latest
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates curl jq git less \
+ && rm -rf /var/lib/apt/lists/*
+
+# kubectl, matched to the architecture the image is built for so this works on
+# both arm64 laptops and amd64 CI.
+RUN arch="$(dpkg --print-architecture)" \
+ && curl -fsSLo /usr/local/bin/kubectl \
+      "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+ && chmod 0755 /usr/local/bin/kubectl \
+ && kubectl version --client=true >/dev/null
+
+RUN npm install -g "@google/gemini-cli@${GEMINI_CLI_VERSION}" \
+ && npm cache clean --force
+
+# The wrapper runs this container as the host user's uid:gid so files written to
+# the mounted workspace are owned correctly. That uid does not exist in
+# /etc/passwd, and some tooling resolves $HOME by looking the uid up rather than
+# reading the env var, so give it a world-writable fallback. The wrapper also
+# sets HOME=/workspace explicitly.
+RUN mkdir -p /workspace /home/agent \
+ && chmod 0777 /workspace /home/agent
+ENV HOME=/workspace
+WORKDIR /workspace
+
+# No ENTRYPOINT on purpose: the sandbox wrapper appends the agent's own argv,
+# which already begins with the binary name. An entrypoint here would silently
+# prepend a second command.
+CMD ["gemini", "--version"]

--- a/tests/unit/agents/test_agents_cli_gemini.py
+++ b/tests/unit/agents/test_agents_cli_gemini.py
@@ -750,3 +750,101 @@ def test_execute_uses_distinct_cwd_per_run(monkeypatch: pytest.MonkeyPatch) -> N
     assert len(cwds) == 3
     assert all(c is not None for c in cwds)
     assert len(set(cwds)) == 3, f"cwds must be unique per run, got {cwds}"
+
+
+# ---------------------------------------------------------------------------
+# Sandbox container reaping: BENCH_AGENT_SANDBOX=docker must never orphan a
+# container, whether the run completes, times out, or crashes.
+# ---------------------------------------------------------------------------
+
+
+def _enable_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stand in for a working kind cluster so ``_execute`` reaches the docker
+    invocation without shelling out to a real ``kubectl``."""
+    monkeypatch.setenv("BENCH_AGENT_SANDBOX", "docker")
+    monkeypatch.setenv("BENCH_AGENT_IMAGE", "agent-image")
+    monkeypatch.setattr(gemini_mod.sandbox, "current_cluster_name", lambda: "kind")
+    monkeypatch.setattr(
+        gemini_mod.sandbox,
+        "build_agent_kubeconfig",
+        lambda cluster, dest_dir: dest_dir / "kubeconfig",
+    )
+
+
+def test_execute_sandboxed_run_names_the_container_from_its_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_sandbox(monkeypatch)
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        captured["cwd"] = kwargs.get("cwd")
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    GeminiCliAgent(AgentConfig(target="gemini")).run("p")
+
+    workdir_name = os.path.basename(captured["cwd"])
+    assert "--name" in captured["argv"]
+    assert (
+        captured["argv"][captured["argv"].index("--name") + 1]
+        == f"devops-bench-agent-{workdir_name}"
+    )
+
+
+def test_execute_sandboxed_run_reaps_container_on_normal_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_sandbox(monkeypatch)
+    killed: list[str] = []
+    monkeypatch.setattr(gemini_mod.sandbox, "kill_container", killed.append)
+
+    def fake_run(argv, **kwargs):
+        return SimpleNamespace(stdout=SAMPLE_STREAM, stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    GeminiCliAgent(AgentConfig(target="gemini")).run("p")
+
+    assert len(killed) == 1
+    assert killed[0].startswith("devops-bench-agent-")
+
+
+def test_execute_sandboxed_run_reaps_container_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A timeout SIGKILLs the local ``docker run`` client but never touches
+    the daemon; the container must still be reaped by name."""
+    _enable_sandbox(monkeypatch)
+    killed: list[str] = []
+    monkeypatch.setattr(gemini_mod.sandbox, "kill_container", killed.append)
+
+    def fake_run(argv, **kwargs):
+        raise SubprocessError(argv, returncode=-1, stdout="", stderr="")
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    result = GeminiCliAgent(AgentConfig(target="gemini")).run("p")
+
+    assert result.metadata.get("timed_out") is True
+    assert len(killed) == 1
+    assert killed[0].startswith("devops-bench-agent-")
+
+
+def test_execute_sandboxed_run_reaps_container_when_binary_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unexpected exception (here: ``run`` itself raising ``OSError``)
+    inside the guarded block must still reap the container."""
+    _enable_sandbox(monkeypatch)
+    killed: list[str] = []
+    monkeypatch.setattr(gemini_mod.sandbox, "kill_container", killed.append)
+
+    def fake_run(argv, **kwargs):
+        raise OSError("docker not found")
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    result = GeminiCliAgent(AgentConfig(target="gemini")).run("p")
+
+    assert result.has_errors()
+    assert len(killed) == 1
+    assert killed[0].startswith("devops-bench-agent-")

--- a/tests/unit/agents/test_agents_cli_gemini.py
+++ b/tests/unit/agents/test_agents_cli_gemini.py
@@ -234,6 +234,45 @@ def test_execute_handles_subprocess_error(monkeypatch: pytest.MonkeyPatch) -> No
     assert result.has_errors()
     assert "subprocess error" in result.errors[0]
     assert result.trajectory == []
+    assert result.metadata.get("timed_out") is True
+    assert result.metadata.get("trajectory_captured") is False
+
+
+def test_execute_timeout_recovers_partial_trajectory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A timeout must not discard the stream-json events flushed before the
+    kill: whatever partial stdout the subprocess captured is still parsed
+    into the canonical trajectory rather than dropped on the floor."""
+    partial_stream = _stream(
+        {"type": "init", "session_id": "abc-123", "model": "gemini-2.5-pro"},
+        {
+            "type": "tool_use",
+            "id": "call-1",
+            "name": "mcp_gke_list_clusters",
+            "input": {"project": "p1"},
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "call-1",
+            "content": "cluster-a, cluster-b",
+        },
+    )
+
+    def fake_run(argv, **kwargs):
+        raise SubprocessError(argv, returncode=-1, stdout=partial_stream, stderr="")
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    result = GeminiCliAgent(AgentConfig(target="gemini", timeout_sec=600.0)).run("p")
+    assert result.has_errors()
+    assert result.metadata.get("timed_out") is True
+    assert result.metadata.get("trajectory_captured") is True
+    assert result.trajectory == [
+        {
+            "name": "mcp_gke_list_clusters",
+            "args": {"project": "p1"},
+            "result": "cluster-a, cluster-b",
+            "status": "completed",
+        },
+    ]
 
 
 def test_execute_handles_missing_binary(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/agents/test_sandbox.py
+++ b/tests/unit/agents/test_sandbox.py
@@ -1,0 +1,176 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.agents.sandbox: container naming and reaping."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from devops_bench.agents import sandbox
+from devops_bench.core.errors import SubprocessError
+
+
+def test_container_name_for_workspace_is_deterministic_and_prefixed() -> None:
+    name = sandbox.container_name_for_workspace(Path("/tmp/workspace-abc123"))
+    assert name == "devops-bench-agent-workspace-abc123"
+
+
+def test_container_name_for_workspace_differs_per_workspace() -> None:
+    a = sandbox.container_name_for_workspace(Path("/tmp/workspace-a"))
+    b = sandbox.container_name_for_workspace(Path("/tmp/workspace-b"))
+    assert a != b
+
+
+def test_wrap_argv_includes_name_flag_when_container_name_given() -> None:
+    argv = sandbox.wrap_argv(
+        ["gemini", "-p", "hi"],
+        workspace=Path("/tmp/ws"),
+        kubeconfig=Path("/tmp/ws/kubeconfig"),
+        image="agent-image",
+        container_name="devops-bench-agent-ws",
+    )
+    assert "--name" in argv
+    assert argv[argv.index("--name") + 1] == "devops-bench-agent-ws"
+
+
+def test_wrap_argv_omits_name_flag_when_none_given() -> None:
+    argv = sandbox.wrap_argv(
+        ["gemini", "-p", "hi"],
+        workspace=Path("/tmp/ws"),
+        kubeconfig=Path("/tmp/ws/kubeconfig"),
+        image="agent-image",
+    )
+    assert "--name" not in argv
+
+
+def test_kill_container_invokes_docker_kill_by_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return SimpleNamespace(returncode=0, stdout="devops-bench-agent-ws\n", stderr="")
+
+    monkeypatch.setattr(sandbox, "run", fake_run)
+    sandbox.kill_container("devops-bench-agent-ws")
+    assert captured["argv"] == ["docker", "kill", "devops-bench-agent-ws"]
+
+
+def test_kill_container_never_raises_when_docker_kill_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Killing an already-gone container (the common case, ``--rm`` beat us to
+    it) must be a harmless no-op, not a crash."""
+
+    def fake_run(argv, **kwargs):
+        return SimpleNamespace(returncode=1, stdout="", stderr="No such container")
+
+    monkeypatch.setattr(sandbox, "run", fake_run)
+    sandbox.kill_container("devops-bench-agent-gone")  # must not raise
+
+
+def test_container_guard_kills_container_on_normal_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    killed: list[str] = []
+    monkeypatch.setattr(sandbox, "kill_container", killed.append)
+
+    with sandbox.container_guard("devops-bench-agent-ws"):
+        pass
+
+    assert killed == ["devops-bench-agent-ws"]
+
+
+def test_container_guard_kills_container_on_exception_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A crash inside the guarded block must still reap the container."""
+    killed: list[str] = []
+    monkeypatch.setattr(sandbox, "kill_container", killed.append)
+
+    with (
+        pytest.raises(RuntimeError, match="boom"),
+        sandbox.container_guard("devops-bench-agent-ws"),
+    ):
+        raise RuntimeError("boom")
+
+    assert killed == ["devops-bench-agent-ws"]
+
+
+def test_container_guard_kills_container_on_timeout_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A SubprocessError raised by a timed-out ``core.subprocess.run`` call
+    inside the guarded block must still reap the container, exactly as the
+    gemini_cli agent's own timeout handling relies on."""
+    killed: list[str] = []
+    monkeypatch.setattr(sandbox, "kill_container", killed.append)
+
+    timeout_exc: SubprocessError | None = None
+    with sandbox.container_guard("devops-bench-agent-ws"):
+        try:
+            raise SubprocessError(["docker", "run"], returncode=-1, stdout="partial", stderr="")
+        except SubprocessError as exc:
+            # Mirrors how the agent harness swallows the timeout inside the
+            # guarded block rather than letting it propagate.
+            timeout_exc = exc
+
+    assert timeout_exc is not None
+    assert killed == ["devops-bench-agent-ws"]
+
+
+def test_sweep_stray_containers_kills_only_matching_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        if argv[:2] == ["docker", "ps"]:
+            return SimpleNamespace(returncode=0, stdout="abc123\ndef456\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(sandbox, "run", fake_run)
+    sandbox.sweep_stray_containers()
+
+    list_call = calls[0]
+    assert list_call[0:2] == ["docker", "ps"]
+    assert any("devops-bench-agent-" in arg for arg in list_call)
+    kill_calls = [c for c in calls if c[:2] == ["docker", "kill"]]
+    assert kill_calls == [["docker", "kill", "abc123"], ["docker", "kill", "def456"]]
+
+
+def test_sweep_stray_containers_handles_docker_ps_failure_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(argv, **kwargs):
+        return SimpleNamespace(returncode=1, stdout="", stderr="docker daemon not running")
+
+    monkeypatch.setattr(sandbox, "run", fake_run)
+    sandbox.sweep_stray_containers()  # must not raise
+
+
+def test_sweep_stray_containers_is_a_noop_when_none_are_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(sandbox, "run", fake_run)
+    sandbox.sweep_stray_containers()
+
+    kill_calls = [c for c in calls if c[:2] == ["docker", "kill"]]
+    assert kill_calls == []

--- a/tests/unit/agents/test_sandbox.py
+++ b/tests/unit/agents/test_sandbox.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Google LLC
+# Copyright 2026 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/evalharness/test_default_harness.py
+++ b/tests/unit/evalharness/test_default_harness.py
@@ -891,3 +891,58 @@ def test_score_excludes_agent_error_and_timeout_records_from_scoring(
     assert len(scored_batches) == 1
     assert {r["name"] for r in scored_batches[0]} == {"ok"}
     by_name = {r["name"]: r for r in records}
+    assert by_name["ok"]["scores"] == {"probe": {"score": 1.0}}
+    assert by_name["crashed"]["scores"] == {}
+    assert by_name["timed-out"]["scores"] == {}
+    assert by_name["infra-died"]["scores"] == {}
+
+
+# --- sandbox container reaping at harness start ---
+
+
+def test_sweep_stray_sandbox_containers_noop_when_sandbox_disabled(
+    isolated_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No ``BENCH_AGENT_SANDBOX`` means no docker calls at all."""
+    from devops_bench.agents import sandbox
+
+    monkeypatch.delenv("BENCH_AGENT_SANDBOX", raising=False)
+    calls: list[None] = []
+    monkeypatch.setattr(sandbox, "sweep_stray_containers", lambda: calls.append(None))
+
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+    harness._sweep_stray_sandbox_containers()  # noqa: SLF001
+
+    assert calls == []
+
+
+def test_sweep_stray_sandbox_containers_sweeps_when_sandbox_enabled(
+    isolated_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from devops_bench.agents import sandbox
+
+    monkeypatch.setenv("BENCH_AGENT_SANDBOX", "docker")
+    calls: list[None] = []
+    monkeypatch.setattr(sandbox, "sweep_stray_containers", lambda: calls.append(None))
+
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+    harness._sweep_stray_sandbox_containers()  # noqa: SLF001
+
+    assert calls == [None]
+
+
+def test_sweep_stray_sandbox_containers_survives_a_sweep_failure(
+    isolated_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A sweep failure (e.g. docker unreachable) must never block the run."""
+    from devops_bench.agents import sandbox
+
+    monkeypatch.setenv("BENCH_AGENT_SANDBOX", "docker")
+
+    def _boom() -> None:
+        raise RuntimeError("docker daemon unreachable")
+
+    monkeypatch.setattr(sandbox, "sweep_stray_containers", _boom)
+
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+    harness._sweep_stray_sandbox_containers()  # noqa: SLF001 - must not raise

--- a/tests/unit/evalharness/test_default_harness.py
+++ b/tests/unit/evalharness/test_default_harness.py
@@ -789,3 +789,105 @@ def test_success_and_failed_records_have_identical_top_level_keys(isolated_env: 
     )
     failed = harness._build_failed_record(task, RuntimeError("boom"))  # noqa: SLF001
     assert set(success.keys()) == set(failed.keys()) == _RESULTS_JSON_REQUIRED_KEYS
+
+
+# --- degraded agent-process outcome (a crashed/timed-out agent is not "success") ---
+
+
+def test_success_record_status_is_agent_timeout_when_metadata_flags_timeout(
+    isolated_env: None,
+) -> None:
+    """A CLI agent that recovered a partial trajectory after a timeout still
+    reports a distinct ``agent_timeout`` status, never ``success``."""
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+    agent_res = AgentResult(
+        output="Error: gemini subprocess error: timed out",
+        trajectory=[
+            ToolCall(name="kubectl_top", args={}, result="ok", status="completed").to_dict()
+        ],
+        errors=["gemini subprocess error: command failed with exit code -1"],
+        metadata={"timed_out": True, "trajectory_captured": True},
+    )
+    record = harness._build_success_record(  # noqa: SLF001
+        task=_stub_task(),
+        prompt="p",
+        expected_output="e",
+        agent_res=agent_res,
+        chaos_report={},
+        perf_report={},
+    )
+    assert record["status"] == "agent_timeout"
+    assert record["validated"] is False
+    # The recovered trajectory is still on the record for forensics.
+    assert record["trajectory"] != []
+
+
+def test_success_record_status_is_agent_error_for_a_non_timeout_agent_failure(
+    isolated_env: None,
+) -> None:
+    """A non-zero agent exit (or any other ``AgentResult.errored()`` path,
+    e.g. a missing binary or an SDK fault) reads as ``agent_error``, not
+    ``success`` and not ``agent_timeout``."""
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+    agent_res = AgentResult(
+        output="Error: gemini exited 2",
+        trajectory=[],
+        errors=["gemini exited 2: boom"],
+        metadata={"returncode": 2, "trajectory_captured": False},
+    )
+    record = harness._build_success_record(  # noqa: SLF001
+        task=_stub_task(),
+        prompt="p",
+        expected_output="e",
+        agent_res=agent_res,
+        chaos_report={},
+        perf_report={},
+    )
+    assert record["status"] == "agent_error"
+    assert record["validated"] is False
+
+
+def test_success_record_status_stays_success_with_no_agent_errors(isolated_env: None) -> None:
+    """Sanity: an agent result with no errors is unaffected by the new statuses."""
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+    record = harness._build_success_record(  # noqa: SLF001
+        task=_stub_task(),
+        prompt="p",
+        expected_output="e",
+        agent_res=_stub_agent_result(),
+        chaos_report={},
+        perf_report={},
+    )
+    assert record["status"] == "success"
+
+
+def test_score_excludes_agent_error_and_timeout_records_from_scoring(
+    isolated_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A degraded record (``agent_error`` / ``agent_timeout``) never reaches
+    the metrics pipeline, mirroring how a ``"failed"`` record already skips
+    scoring: no ``scores`` means no misleading composite OutcomeScore for a
+    run whose agent process never completed."""
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c", judge_model=object())
+    scored_batches: list[list[dict[str, Any]]] = []
+
+    def fake_evaluate_metrics_batch(results, judge_model, *, use_mcp=None):
+        scored_batches.append(list(results))
+        for r in results:
+            r["scores"] = {"probe": {"score": 1.0}}
+
+    import devops_bench.metrics as metrics_mod
+
+    monkeypatch.setattr(metrics_mod, "evaluate_metrics_batch", fake_evaluate_metrics_batch)
+
+    records: list[dict[str, Any]] = [
+        {"status": "success", "name": "ok", "scores": {}},
+        {"status": "agent_error", "name": "crashed", "scores": {}},
+        {"status": "agent_timeout", "name": "timed-out", "scores": {}},
+        {"status": "failed", "name": "infra-died", "scores": {}},
+    ]
+    harness._score(records)  # noqa: SLF001
+
+    assert len(scored_batches) == 1
+    assert {r["name"] for r in scored_batches[0]} == {"ok"}
+    by_name = {r["name"]: r for r in records}


### PR DESCRIPTION
Agent transcripts showed CLI agents ranging well outside the task: reading files from
the operator's home directory, copying archives out of ~/Downloads, running `rm -rf`,
and in one case running `find ~ | grep -i <task-name>` to hunt for the benchmark's own
fixtures. On a workstation checkout that is the harness author's whole filesystem, and
any answer material sitting on disk is reachable.

This adds an opt-in container sandbox for CLI agents. When `BENCH_AGENT_SANDBOX` is set
to `docker`, `1`, or `true`, the agent argv is wrapped in `docker run` with:

* only a per-run scratch workspace and a generated kubeconfig mounted, so the host
  filesystem and the operator's environment are not visible
* `HOME` pointed at the workspace, so agent config and history stay inside the run
* the container joined to the `kind` network with the kubeconfig server rewritten to the
  control-plane node, so TLS still verifies against the existing cert
* credentials passed explicitly rather than by scraping os.environ for well-known names

`BENCH_AGENT_IMAGE` names the image. `hack/agent-sandbox.Dockerfile` builds a suitable
one (node + kubectl + the gemini CLI). `hack/agent-credential.sh` mints a credential for
the agent: by default an API key restricted to generativelanguage.googleapis.com, or a
short-lived impersonated token with `--vertex-sa`, plus `--revoke` to clean up.

Off by default so it can be A/B'd against current behaviour while tasks are still being
debugged.

Worth being explicit about scope: this is filesystem and environment isolation only. It
does not scope what the agent can do to the cluster, which is a separate concern best
handled with per-task RBAC, and it does not help if answer material is seeded inside the
cluster itself.