### PR TITLE
chore: ignore local OpenTofu state and working directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,12 @@ env/
 # OS generated files
 .DS_Store
 Thumbs.db
+
+# OpenTofu / Terraform local state and working directories
+**/.terraform/
+**/.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+*.tfstate.backup
+crash.log
+crash.*.log


### PR DESCRIPTION
Running a stack under `tf/` leaves `.terraform/`, a provider lock file, and
`terraform.tfstate` in the stack directory. None of it is source and all of it is
machine and run specific.

It is also actively harmful to commit: a `terraform.tfstate` that still references a
torn-down kind cluster makes the next `tofu` run in that directory fail on refresh with
"could not locate any control plane nodes", before it gets anywhere near applying.