### PR TITLE
Treat a NotFound resource as observed absence, not an unobserved check

### DIFF
--- a/devops_bench/k8s/__init__.py
+++ b/devops_bench/k8s/__init__.py
@@ -18,6 +18,7 @@ from devops_bench.k8s.conditions import poll_until
 from devops_bench.k8s.kubectl import (
     apply,
     get_resource,
+    is_not_found,
     port_forward,
     rollout_status,
     wait,
@@ -26,6 +27,7 @@ from devops_bench.k8s.kubectl import (
 __all__ = [
     "apply",
     "get_resource",
+    "is_not_found",
     "poll_until",
     "port_forward",
     "rollout_status",

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import re
 import subprocess
 import time
 from collections.abc import Iterator
@@ -37,11 +38,22 @@ __all__ = [
 
 _log = get_logger("k8s.kubectl")
 
-# The apiserver's reason code, as kubectl renders it:
+# kubectl renders a server error with exactly two templates, one per branch of
+# whether the returned Status carries a reason:
 #   Error from server (NotFound): namespaces "hello-app" not found
-# Matched in full, parentheses included, so an unrelated message that merely
-# contains the words "not found" (a missing binary, say) cannot pass for it.
-_NOT_FOUND_MARKER = "(NotFound)"
+#   Error from server: namespaces "hello-app" not found
+# The second is rare but real: a hand-rolled ``metav1.Status`` from an
+# aggregated apiserver or an admission webhook can 404 with an empty reason,
+# and kubectl then drops the parenthesised code entirely.
+#
+# So the anchor is the "Error from server" prefix, not the parentheses. The
+# prefix is what does the real work of keeping an unrelated message that merely
+# contains "not found" (a missing binary, say) from passing for the reason
+# code, and matching on it covers both renderings.
+_NOT_FOUND_RE = re.compile(
+    r"^Error from server \(NotFound\):|^Error from server: .*\bnot found\s*$",
+    re.MULTILINE,
+)
 
 
 def is_not_found(exc: BaseException) -> bool:
@@ -58,7 +70,7 @@ def is_not_found(exc: BaseException) -> bool:
     Returns:
         ``True`` when the apiserver reported ``NotFound``.
     """
-    return _NOT_FOUND_MARKER in (getattr(exc, "stderr", None) or "")
+    return bool(_NOT_FOUND_RE.search(getattr(exc, "stderr", None) or ""))
 
 
 # Seconds to let ``kubectl port-forward`` establish the tunnel before yielding.

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -50,7 +50,7 @@ _log = get_logger("k8s.kubectl")
 # prefix is what does the real work of keeping an unrelated message that merely
 # contains "not found" (a missing binary, say) from passing for the reason
 # code, and matching on it covers both renderings.
-_NOT_FOUND_RE = re.compile(
+_NOT_FOUND_RE: re.Pattern[str] = re.compile(
     r"^Error from server \(NotFound\):|^Error from server: .*\bnot found\s*$",
     re.MULTILINE,
 )

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -29,12 +29,36 @@ from devops_bench.core.subprocess import CompletedProcess, _build_env, run
 __all__ = [
     "apply",
     "get_resource",
+    "is_not_found",
     "port_forward",
     "rollout_status",
     "wait",
 ]
 
 _log = get_logger("k8s.kubectl")
+
+# The apiserver's reason code, as kubectl renders it:
+#   Error from server (NotFound): namespaces "hello-app" not found
+# Matched in full, parentheses included, so an unrelated message that merely
+# contains the words "not found" (a missing binary, say) cannot pass for it.
+_NOT_FOUND_MARKER = "(NotFound)"
+
+
+def is_not_found(exc: BaseException) -> bool:
+    """Report whether ``exc`` is kubectl saying the resource does not exist.
+
+    Absence reaches a caller two different ways. A selector query returns an
+    empty item list and exits zero, whereas a query naming a resource exits
+    non-zero with ``NotFound`` on stderr. Both mean the same thing, so callers
+    use this to stop the second from looking like a failure to observe.
+
+    Args:
+        exc: The exception raised by a kubectl helper.
+
+    Returns:
+        ``True`` when the apiserver reported ``NotFound``.
+    """
+    return _NOT_FOUND_MARKER in (getattr(exc, "stderr", None) or "")
 
 # Seconds to let ``kubectl port-forward`` establish the tunnel before yielding.
 _PORT_FORWARD_SETTLE_SEC = 3

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -60,6 +60,7 @@ def is_not_found(exc: BaseException) -> bool:
     """
     return _NOT_FOUND_MARKER in (getattr(exc, "stderr", None) or "")
 
+
 # Seconds to let ``kubectl port-forward`` establish the tunnel before yielding.
 _PORT_FORWARD_SETTLE_SEC = 3
 

--- a/devops_bench/verification/verifiers/resource_property.py
+++ b/devops_bench/verification/verifiers/resource_property.py
@@ -48,7 +48,7 @@ from jsonpath_ng.jsonpath import Slice as _JsonPathSlice
 from jsonpath_ng.jsonpath import This as _JsonPathThis
 from pydantic import model_validator
 
-from devops_bench.k8s import get_resource
+from devops_bench.k8s import get_resource, is_not_found
 from devops_bench.verification.base import (
     VERIFIERS,
     BaseVerifier,
@@ -378,7 +378,14 @@ class ResourcePropertyVerifier(BaseVerifier):
                 timeout=single_call_timeout(timeout_sec),
             )
         except Exception as exc:  # noqa: BLE001 - a kubectl failure is a check error
-            return "error", f"kubectl get {self.kind} failed: {exc}", None
+            if not is_not_found(exc):
+                return "error", f"kubectl get {self.kind} failed: {exc}", None
+            # NotFound is the apiserver answering, not a failure to reach it, so
+            # absence here was observed. Naming a resource surfaces that as a
+            # non-zero exit while a selector returns an empty list; substituting
+            # an empty payload puts both on the same path below, so "absent"
+            # still passes and every other operator fails.
+            payload = {"items": []}
 
         items = payload.get("items")
         objects = items if isinstance(items, list) else [payload]

--- a/devops_bench/verification/verifiers/scaling_complete.py
+++ b/devops_bench/verification/verifiers/scaling_complete.py
@@ -21,7 +21,7 @@ from typing import Any, Literal
 from pydantic import model_validator
 
 from devops_bench.core import SubprocessError, get_logger
-from devops_bench.k8s import get_resource
+from devops_bench.k8s import get_resource, is_not_found
 from devops_bench.verification.base import (
     VERIFIERS,
     BaseVerifier,
@@ -114,6 +114,9 @@ class ScalingCompleteVerifier(BaseVerifier):
             )
         except SubprocessError as exc:
             stderr = (exc.stderr or "").strip()
+            if is_not_found(exc):
+                # A deployment that does not exist has observably not scaled.
+                return "fail", f"Deployment {self.deployment} not found", None
             _log.warning("Failed to get deployment %s: %s", self.deployment, stderr)
             return "error", f"Failed to get deployment: {stderr}", None
         except ValueError:

--- a/tests/unit/k8s/test_k8s_kubectl.py
+++ b/tests/unit/k8s/test_k8s_kubectl.py
@@ -322,3 +322,39 @@ def test_port_forward_abandons_process_that_survives_sigkill(mocker: MockerFixtu
     proc.terminate.assert_called_once()
     proc.kill.assert_called_once()
     assert proc.wait.call_count == 2
+
+
+# kubectl renders a server error with one of two templates depending on whether
+# the returned Status carries a reason, so both have to read as NotFound while
+# every other stderr keeps erroring.
+@pytest.mark.parametrize(
+    ("stderr", "expected"),
+    [
+        # Reason set: the common rendering.
+        ('Error from server (NotFound): namespaces "hello-app" not found', True),
+        ('Error from server (NotFound): deployments.apps "web" not found', True),
+        ("Error from server (NotFound): the server could not find the requested resource", True),
+        # Reason empty: kubectl drops the parenthesised code entirely.
+        ('Error from server: namespaces "hello-app" not found', True),
+        ('W0902 client warning\nError from server: deployments.apps "web" not found\n', True),
+        # A different reason is not an absence, even when the message quotes the
+        # code verbatim.
+        ('Error from server (Forbidden): configmaps "(NotFound)" is forbidden', False),
+        ("Error from server (Timeout): the request timed out", False),
+        # Not the apiserver answering at all: an unreachable cluster, a missing
+        # binary, an unknown resource type. These stay unobserved.
+        ("Unable to connect to the server: dial tcp: connection refused", False),
+        ("bash: kubectl: command not found", False),
+        ('error: the server doesn\'t have a resource type "widget"', False),
+        ("not found", False),
+        ("", False),
+    ],
+)
+def test_is_not_found_matches_both_renderings_only(stderr: str, expected: bool) -> None:
+    exc = SubprocessError(["kubectl", "get"], returncode=1, stderr=stderr)
+
+    assert kubectl.is_not_found(exc) is expected
+
+
+def test_is_not_found_tolerates_an_exception_without_stderr() -> None:
+    assert kubectl.is_not_found(RuntimeError("boom")) is False

--- a/tests/unit/verification/test_resource_property.py
+++ b/tests/unit/verification/test_resource_property.py
@@ -922,6 +922,20 @@ def test_absent_passes_when_the_named_resource_does_not_exist() -> None:
     assert result.success is True
 
 
+def test_a_notfound_without_the_reason_code_is_still_a_fail() -> None:
+    # A 404 whose Status carries no reason (a hand-rolled one from an aggregated
+    # apiserver or an admission webhook) renders without the parenthesised code.
+    # It is the same observation, so it must not fall back to "error".
+    exc = SubprocessError(
+        cmd=["kubectl", "get", "namespace", "hello-app", "-o", "json"],
+        returncode=1,
+        stderr='Error from server: namespaces "hello-app" not found',
+    )
+    with patch(_GET, side_effect=exc):
+        result = _verifier(op="exists", resource_name="hello-app").verify(0.0)
+    assert result.status == "fail"
+
+
 def test_a_kubectl_failure_that_is_not_notfound_still_errors() -> None:
     exc = SubprocessError(
         cmd=["kubectl", "get", "namespace", "hello-app"],
@@ -934,9 +948,8 @@ def test_a_kubectl_failure_that_is_not_notfound_still_errors() -> None:
 
 
 def test_a_message_merely_containing_not_found_is_not_treated_as_notfound() -> None:
-    # A missing kubectl binary says "not found" too. Only the apiserver's
-    # "(NotFound)" reason code counts, or an environment problem would score as
-    # an observed absence.
+    # A missing kubectl binary says "not found" too. Only an "Error from server"
+    # line counts, or an environment problem would score as an observed absence.
     exc = SubprocessError(
         cmd=["kubectl", "get", "namespace", "hello-app"],
         returncode=127,

--- a/tests/unit/verification/test_resource_property.py
+++ b/tests/unit/verification/test_resource_property.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 import pytest
 from pydantic import ValidationError
 
+from devops_bench.core import SubprocessError
 from devops_bench.verification.spec import parse_node
 from devops_bench.verification.verifiers.resource_property import (
     ResourcePropertyVerifier,
@@ -889,3 +890,58 @@ def test_converge_mode_polls_until_the_property_holds(monkeypatch: pytest.Monkey
             op="gte", value=2, path="status.readyReplicas", resource_name="web"
         ).verify(5.0)
     assert result.success is True
+
+
+_NOT_FOUND_STDERR = 'Error from server (NotFound): namespaces "hello-app" not found'
+
+
+def _not_found() -> SubprocessError:
+    """The exception kubectl raises when a *named* resource does not exist."""
+    return SubprocessError(
+        cmd=["kubectl", "get", "namespace", "hello-app", "-o", "json"],
+        returncode=1,
+        stderr=_NOT_FOUND_STDERR,
+    )
+
+
+def test_a_named_resource_that_does_not_exist_is_a_fail_not_an_error() -> None:
+    # Absence reaches the verifier as a non-zero exit when the resource is named
+    # (a selector would return an empty list and exit zero). Both are the same
+    # observation, so neither may drop the entry out of the correctness
+    # denominator the way an "error" does.
+    with patch(_GET, side_effect=_not_found()):
+        result = _verifier(op="exists", resource_name="hello-app").verify(0.0)
+    assert result.status == "fail"
+    assert result.success is False
+
+
+def test_absent_passes_when_the_named_resource_does_not_exist() -> None:
+    with patch(_GET, side_effect=_not_found()):
+        result = _verifier(op="absent", resource_name="hello-app").verify(0.0)
+    assert result.status == "pass"
+    assert result.success is True
+
+
+def test_a_kubectl_failure_that_is_not_notfound_still_errors() -> None:
+    exc = SubprocessError(
+        cmd=["kubectl", "get", "namespace", "hello-app"],
+        returncode=1,
+        stderr="Unable to connect to the server: dial tcp: connection refused",
+    )
+    with patch(_GET, side_effect=exc):
+        result = _verifier(op="exists", resource_name="hello-app").verify(0.0)
+    assert result.status == "error"
+
+
+def test_a_message_merely_containing_not_found_is_not_treated_as_notfound() -> None:
+    # A missing kubectl binary says "not found" too. Only the apiserver's
+    # "(NotFound)" reason code counts, or an environment problem would score as
+    # an observed absence.
+    exc = SubprocessError(
+        cmd=["kubectl", "get", "namespace", "hello-app"],
+        returncode=127,
+        stderr="bash: kubectl: command not found",
+    )
+    with patch(_GET, side_effect=exc):
+        result = _verifier(op="exists", resource_name="hello-app").verify(0.0)
+    assert result.status == "error"

--- a/tests/unit/verification/test_scaling_complete.py
+++ b/tests/unit/verification/test_scaling_complete.py
@@ -174,3 +174,23 @@ def test_name_is_echoed_onto_result() -> None:
         ).verify(timeout_sec=5)
 
     assert result.name == "scale-to-two"
+
+
+def test_a_deployment_that_does_not_exist_is_a_fail_not_an_error() -> None:
+    # A deployment the apiserver reports as NotFound has observably not scaled,
+    # so it must count against correctness rather than dropping out of the
+    # denominator the way an unobserved check does.
+    exc = SubprocessError(
+        ["kubectl", "get", "deployment", "web"],
+        returncode=1,
+        stderr='Error from server (NotFound): deployments.apps "web" not found',
+    )
+    with patch(
+        "devops_bench.verification.verifiers.scaling_complete.get_resource",
+        side_effect=exc,
+    ):
+        result = ScalingCompleteVerifier(deployment="web", min_replicas=1).verify(timeout_sec=0)
+
+    assert result.status == "fail"
+    assert result.success is False
+    assert "not found" in result.reason


### PR DESCRIPTION
Found running `deploy-hello-app` end to end. The agent never created the namespace, and the objective checking it recorded `error`, not `fail`:

```
namespace-pss-enforced   error   weight 0.3333
  kubectl get namespace failed: command failed with exit code 1: kubectl get namespace hello-app -o json
  stderr: Error from server (NotFound): namespaces "hello-app" not found
```

## Why this is a scoring bug

`rollup.py:102` drops an errored entry from **both** the numerator and the denominator — correctly, since `error` is defined in `base.py:94` as *the absence of an observation*.

But `NotFound` **is** an observation, and an unambiguous one. Scoring it as unobserved means the most common way an agent fails an objective — never creating the resource — quietly shrinks the denominator instead of counting against it. Eleven passes plus one never-created resource reads as **11/11 = 1.0** rather than 11/12. It fails silently, and in the direction nobody audits.

## Why it only happens sometimes

`resource_property` already fails closed on an empty match:

```python
# Fail closed above the flattening. This is what keeps "zero objects
# existed" distinct from "objects existed but the path matched nothing".
if not objects:
    return "fail", f"no {self.kind} matched", raw
```

That is the intended behaviour. The problem is that absence only reaches that branch one of the two ways it can arrive:

| Query | kubectl | Lands on |
|---|---|---|
| selector — `get ns -l app=x` | exit 0, `{"items": []}` | the fail-closed branch ✅ |
| named — `get namespace hello-app` | exit 1, `NotFound` | the blanket `except` → `error` ❌ |

So the same condition scores differently depending on how the objective was written.

## The change

`is_not_found()` lives in `k8s/` next to `get_resource` — recognising kubectl's output is a kubectl concern, while the fail-versus-error *policy* stays in the verifiers. It matches the apiserver's `(NotFound)` reason code **in full, parentheses included**, so `bash: kubectl: command not found` still errors rather than scoring as an observed absence.

In `resource_property` the handler substitutes an empty payload and falls through, which reuses the existing semantics rather than duplicating them — so `absent` still **passes** when the resource is gone, and every other operator fails.

`scaling_complete` had the identical hole for its named deployment and is fixed alongside. `pod_healthy` queries by selector and was never affected.

## Tests

Four new cases, verified to actually catch the regression — reverting the fix fails exactly 3 and passes the rest:

- named resource absent → `fail` (was `error`)
- `absent` operator with the resource gone → `pass`
- connection refused → still `error`
- `command not found` → still `error` (guards the strict marker)

Note the pre-existing `test_subprocess_error_is_reported_in_reason` uses `stderr="not found"` and still expects `error` — it passes unchanged, which is a live check that the strict matching does not over-trigger.

1186 tests pass; ruff and boilerplate clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Kubernetes resources that do not exist, including both supported “not found” response formats.
  * Absence checks now pass correctly when a resource is missing, while existence checks fail as expected.
  * Missing deployments now produce a clear verification failure instead of an error.
  * Other retrieval failures continue to be reported as errors.

* **Tests**
  * Added coverage for missing resources, deployments, supported not-found responses, and unrelated failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->