### PR TITLE
Let a parallel child hand back a verdict it reached on time

### DIFF
--- a/devops_bench/verification/runner.py
+++ b/devops_bench/verification/runner.py
@@ -78,6 +78,15 @@ _SINGLE_SHOT_WAIT_CEILING_SEC = 120.0
 # path and the single-shot wait-ceiling path in :meth:`VerifierAgent._run_parallel`.
 _PARALLEL_INCOMPLETE_REASON = "evaluation did not complete before the deadline"
 
+# Children are handed the same deadline the parent's wait uses, and a child
+# that polls to the very end overshoots it slightly: ``poll_until`` clamps its
+# final sleep but then re-checks the predicate once more before giving up.
+# Waiting only to the deadline therefore races every child that spent its whole
+# budget, and a child that loses is recorded as never observed even though it
+# did reach a verdict. This is the handoff window: wide enough to collect a
+# result that landed on time, far too narrow to rescue a genuinely hung child.
+_CHILD_HANDOFF_GRACE_SEC = 1.0
+
 
 def _node_name(node: Any) -> str | None:
     """Echo the optional ``name`` label from a spec node, if any."""
@@ -493,7 +502,11 @@ class VerifierAgent:
         observed to pass or fail, so it is recorded with status "error"
         (reason :data:`_PARALLEL_INCOMPLETE_REASON`), not "fail": a hung
         ``kubectl`` call under assert mode must not read as an observed
-        safeguard VIOLATION. A leaf that unexpectedly raises is converted to a
+        safeguard VIOLATION. The converge wait adds
+        :data:`_CHILD_HANDOFF_GRACE_SEC` on top of the deadline so that a child
+        which polled to the very end still gets to hand its verdict back;
+        without it a converging objective whose children legitimately observed
+        "not there" was recorded as unobserved and dropped out of the score. A leaf that unexpectedly raises is converted to a
         failed child result so one bad leaf does not abort the rest of the
         group. Under ``single_shot``
         the wait is capped at :data:`_SINGLE_SHOT_WAIT_CEILING_SEC`; without
@@ -530,7 +543,7 @@ class VerifierAgent:
                     else _SINGLE_SHOT_WAIT_CEILING_SEC
                 )
             else:
-                wait_timeout = max(0.0, deadline - time.monotonic())
+                wait_timeout = max(0.0, deadline - time.monotonic()) + _CHILD_HANDOFF_GRACE_SEC
             done, _ = futures_wait(futs, timeout=wait_timeout)
             for f, i in futs.items():
                 if f not in done:

--- a/devops_bench/verification/runner.py
+++ b/devops_bench/verification/runner.py
@@ -85,7 +85,7 @@ _PARALLEL_INCOMPLETE_REASON = "evaluation did not complete before the deadline"
 # budget, and a child that loses is recorded as never observed even though it
 # did reach a verdict. This is the handoff window: wide enough to collect a
 # result that landed on time, far too narrow to rescue a genuinely hung child.
-_CHILD_HANDOFF_GRACE_SEC = 1.0
+_CHILD_HANDOFF_GRACE_SEC: float = 1.0
 
 
 def _node_name(node: Any) -> str | None:
@@ -543,7 +543,10 @@ class VerifierAgent:
                     else _SINGLE_SHOT_WAIT_CEILING_SEC
                 )
             else:
-                wait_timeout = max(0.0, deadline - time.monotonic()) + _CHILD_HANDOFF_GRACE_SEC
+                # Measured from the absolute handoff deadline, not from now:
+                # a nested group entered after ``deadline`` would otherwise wait a
+                # full grace period from its late start and outlive the parent.
+                wait_timeout = max(0.0, (deadline + _CHILD_HANDOFF_GRACE_SEC) - time.monotonic())
             done, _ = futures_wait(futs, timeout=wait_timeout)
             for f, i in futs.items():
                 if f not in done:

--- a/tests/unit/verification/test_runner.py
+++ b/tests/unit/verification/test_runner.py
@@ -418,3 +418,34 @@ def test_nested_parallel_inside_sequence(agent: VerifierAgent) -> None:
     assert res.success is True
     assert res.children[0].success is True
     assert len(res.children[0].children) == 2
+
+
+def test_a_converge_child_that_polls_to_the_deadline_reports_its_verdict(
+    agent: VerifierAgent,
+) -> None:
+    """A child that used its whole budget must not be recorded as unobserved.
+
+    Reproduces deploy-hello-app's ``disruption-and-scaling``: a converging
+    objective whose children poll for resources that never appear. Each child
+    reaches a real "not there" verdict right at the deadline. Waiting only to
+    the deadline raced them, so the group was scored "error" and dropped out of
+    both sides of the correctness fraction, inflating the run's score.
+    """
+    spec = {
+        "type": "parallel",
+        "checks": [
+            _leaf(succeed=False, tag="pdb", sleep_for=2.1),
+            _leaf(succeed=False, tag="hpa", sleep_for=2.1),
+        ],
+    }
+
+    # The budget must clear _MIN_LEAF_BUDGET_SECONDS so the leaves actually run
+    # rather than being short-circuited, and each leaf must outlast it slightly
+    # the way a real poll does.
+    res = agent.wait_for_condition(spec, timeout_sec=2.0)
+
+    assert res.status == "fail", "an observed absence must count as a fail, not an error"
+    assert [c.status for c in res.children] == ["fail", "fail"]
+    assert all(c.reason.startswith("leaf:") for c in res.children), (
+        "the children's real reasons must survive, not the placeholder"
+    )


### PR DESCRIPTION
A converging objective whose children poll for something that never appears is scored **`error`**, not `fail`.

## Root cause

`_run_parallel` hands its children the same `deadline` its own `futures_wait` uses. A child that polls to the very end overshoots it slightly — `poll_until` clamps its final sleep but then re-checks the predicate once more before giving up. The parent stopped waiting at exactly the deadline, so the two raced, and a child that lost kept the pre-seeded placeholder:

```
disruption-and-scaling  error  w=0.3334
  [0] failed: evaluation did not complete before the deadline;
  [1] failed: evaluation did not complete before the deadline
```

Both children had in fact reached a verdict. They just could not hand it back.

## Why it matters

`rollup.py` drops an errored entry from **both** the numerator and the denominator, so an objective the agent genuinely failed is deleted rather than counted — and the score goes **up**.

Seen live on `deploy-hello-app`. The agent created neither a PodDisruptionBudget nor a HorizontalPodAutoscaler; I confirmed that directly against the cluster mid-run (`0 pdb, 0 hpa`). Both children errored on the deadline:

| | c | OutcomeScore |
|---|---|---|
| as scored (error, excluded) | 3.0833 / 3.6666 = 0.8409 | **0.9170** |
| counting the observation | 3.0833 / 4.0 = 0.7708 | **0.8780** |

Same failure shape as #74: an observation the harness *did* make, discarded as if it had not been.

## The change

The converge wait now allows a one second handoff window past the deadline.

The asymmetry is deliberate and preserved. A **genuinely hung** child must keep erroring, because a stuck `kubectl` under assert mode must never read as an observed safeguard violation — that could zero a run through the catastrophic gate. One second is wide enough to collect a result that landed on time and far too narrow to rescue a hung child; the two existing hung-child tests (a 3.0s sleep against a 1.2s deadline, and the single-shot ceiling path) pass unchanged, which is what pins that boundary.

`single_shot` is untouched.

## Tests

One new regression test reproducing the real scenario: two children that poll just past a converge deadline and each reach a genuine "not there" verdict. Verified it actually catches the bug — reverting the fix fails exactly this test and nothing else.

The budget must clear `_MIN_LEAF_BUDGET_SECONDS` in that test, otherwise the leaves are short-circuited before they run and the race is never exercised. My first attempt made that mistake and passed for the wrong reason.

1194 tests pass; ruff and boilerplate clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parallel evaluation handling near time limits.
  * Preserved accurate child failure verdicts and reasons instead of incorrectly reporting deadline errors.
  * Ensured groups report the correct overall failure status when evaluations finish at the deadline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Fixes #67.
