### PR TITLE
fix(verification): correct resource_property match and comparison semantics

### DIFF
--- a/devops_bench/verification/verifiers/resource_property.py
+++ b/devops_bench/verification/verifiers/resource_property.py
@@ -31,6 +31,12 @@ version string like an image tag is not a quantity: ``"1.20" == "1.2"`` must
 stay false even though ``1.20 == 1.2`` as floats. Ordering ops (``gt`` /
 ``gte`` / ``lt`` / ``lte``) always coerce, since they are meaningless for
 anything but numbers.
+
+An unresolved ``path`` fails closed for every op except ``ne``: absence is
+not equal to anything, so ``ne`` alone is satisfied by a field that is not
+there at all (e.g. a ConfigMap without an ``immutable`` field is mutable).
+Every positive op (``eq``, ``gte``, ``exists``, ``contains``, ...) still
+treats an unresolved path as an unobservable predicate, not a satisfied one.
 """
 
 from __future__ import annotations
@@ -479,6 +485,17 @@ class ResourcePropertyVerifier(BaseVerifier):
             )
 
         if not flat:
+            if self.op == "ne":
+                # An absent field is not equal to anything: `ne` is a
+                # negative op, so absence trivially satisfies it (unlike a
+                # positive op such as `eq`, which stays fail-closed below).
+                # e.g. a ConfigMap without `immutable` IS mutable.
+                return (
+                    "pass",
+                    f"path {self.path!r} did not resolve in any of {len(objects)} matched "
+                    "object(s), satisfying op 'ne' (absent is not equal to the expected value)",
+                    raw,
+                )
             if self.across_matches == "none":
                 return (
                     "pass",

--- a/devops_bench/verification/verifiers/resource_property.py
+++ b/devops_bench/verification/verifiers/resource_property.py
@@ -90,6 +90,13 @@ _ORDERING_OPS = ("gt", "gte", "lt", "lte")
 _VALUE_OPS = ("eq", "ne", "gt", "gte", "lt", "lte", "contains", "matches")
 _SET_OPS = ("exists", "absent")
 
+# How many violating entries a selector/across_matches reason enumerates
+# before it switches to "and N more". A cluster-wide selector can match
+# dozens of objects; naming every one of them (conforming and violating
+# alike) produces a reason string that is unusable in a terminal and worse
+# in a grading pack a human reads.
+_REASON_ENUMERATION_CAP = 5
+
 
 def to_number(value: Any) -> float | None:
     """Coerce a scalar or Kubernetes quantity string to a float.
@@ -285,6 +292,24 @@ def _render_path(node: _JsonPath) -> str:
     return str(node)
 
 
+def _summarize_reason(total: int, mode: str | None, violations: list[str]) -> str:
+    """Summarize a multi-object/element evaluation into a bounded reason string.
+
+    Only the violating entries are named; the conforming majority is
+    collapsed into the leading count. Even the violations are capped at
+    :data:`_REASON_ENUMERATION_CAP`, with the remainder folded into an
+    accurate "and N more". The full, uncapped list still lands on
+    ``raw["violations"]`` for anything that needs it.
+    """
+    label = f"across_matches={mode}: " if mode else ""
+    if not violations:
+        return f"{label}checked {total}; none violate"
+    shown = violations[:_REASON_ENUMERATION_CAP]
+    remainder = len(violations) - len(shown)
+    more = f" (and {remainder} more)" if remainder else ""
+    return f"{label}checked {total}; {len(violations)} violate: {'; '.join(shown)}{more}"
+
+
 def _object_name(obj: Any) -> str:
     """Best-effort display name for a matched object."""
     if isinstance(obj, dict):
@@ -469,8 +494,9 @@ class ResourcePropertyVerifier(BaseVerifier):
                     raw,
                 )
             success = all(ok for ok, _ in evaluations)
-            detail = "; ".join(reason for _, reason in evaluations)
-            reason = f"across_matches={self.across_matches}: {detail}"
+            violations = [why for ok, why in evaluations if not ok]
+            raw["violations"] = violations
+            reason = _summarize_reason(len(evaluations), self.across_matches, violations)
             return ("pass" if success else "fail"), reason, raw
 
         flat: list[tuple[str, Any]] = [
@@ -534,18 +560,25 @@ class ResourcePropertyVerifier(BaseVerifier):
 
         results = [self._apply_check(value) for _, value in flat]
         if self.across_matches == "every":
+            # Under `every`, a violator is an element the op did NOT hold for.
             success = all(ok for ok, _ in results)
+            violating = {i for i, (ok, _) in enumerate(results) if not ok}
         elif self.across_matches == "none":
+            # Under `none`, a violator is an element the op DID hold for.
             success = not any(ok for ok, _ in results)
+            violating = {i for i, (ok, _) in enumerate(results) if ok}
         else:
-            (success, _) = results[0]  # only reachable when len(flat) == 1
+            (success, why) = results[0]  # only reachable when len(flat) == 1
+            name, _value = flat[0]
+            return ("pass" if success else "fail"), f"{name}: {why}", raw
 
-        detail = "; ".join(
-            f"{name}: {why}" for (name, _value), (_ok, why) in zip(flat, results, strict=True)
-        )
-        reason = (
-            f"across_matches={self.across_matches}: {detail}" if self.across_matches else detail
-        )
+        violations = [
+            f"{name}: {why}"
+            for i, ((name, _value), (_ok, why)) in enumerate(zip(flat, results, strict=True))
+            if i in violating
+        ]
+        raw["violations"] = violations
+        reason = _summarize_reason(len(flat), self.across_matches, violations)
         return ("pass" if success else "fail"), reason, raw
 
     def _apply_check(self, value: Any) -> tuple[bool, str]:

--- a/devops_bench/verification/verifiers/resource_property.py
+++ b/devops_bench/verification/verifiers/resource_property.py
@@ -296,7 +296,11 @@ class ResourcePropertyVerifier(BaseVerifier):
 
     The field is ``resource_name`` rather than ``name`` because ``BaseVerifier``
     already uses ``name`` for the check's own label, which is what lands on
-    :attr:`VerificationResult.name`.
+    :attr:`VerificationResult.name`. In practice, most task specs write the
+    object's own name as ``name`` (it reads the same way as ``kind`` and
+    ``namespace``) rather than ``resource_name``, which used to be silently
+    absorbed as a result label and left the fetch unscoped: see
+    :meth:`_target_name`.
 
     When ``path`` ends in a wildcard-like segment (``[*]``, a slice, or a
     filter ``[?(...)]``) and ``across_matches`` is set, quantification is over
@@ -362,6 +366,23 @@ class ResourcePropertyVerifier(BaseVerifier):
                 raise ValueError(msg) from exc
         return self
 
+    @property
+    def _target_name(self) -> str | None:
+        """The object name to fetch by: ``resource_name``, else ``name``.
+
+        ``resource_name`` always wins when set explicitly. Otherwise, ``name``
+        is used as the object name, unless ``selector`` is set, in which case
+        ``name`` stays a pure result label and the selector alone scopes the
+        fetch (unchanged from before). This is what makes a check written as
+        ``{kind: deployment, name: ingest}`` fetch just ``ingest`` instead of
+        listing every deployment in the namespace.
+        """
+        if self.resource_name is not None:
+            return self.resource_name
+        if self.selector is not None:
+            return None
+        return self.name
+
     def verify(self, timeout_sec: float) -> VerificationResult:
         """Poll the property until it holds or the budget runs out."""
         return self._poll_to_result(lambda: self._check(timeout_sec), timeout_sec)
@@ -371,7 +392,7 @@ class ResourcePropertyVerifier(BaseVerifier):
         try:
             payload = get_resource(
                 self.kind,
-                self.resource_name,
+                self._target_name,
                 selector=self.selector,
                 namespace=self.namespace,
                 kubeconfig=self.kubeconfig,

--- a/devops_bench/verification/verifiers/resource_property.py
+++ b/devops_bench/verification/verifiers/resource_property.py
@@ -417,11 +417,22 @@ class ResourcePropertyVerifier(BaseVerifier):
                 return "fail", f"{len(objects)} matching {self.kind} found: {names}", raw
             return "pass", f"no matching {self.kind}", raw
 
-        # Fail closed above the flattening. This is what keeps "zero objects
-        # existed" distinct from "objects existed but the path matched
-        # nothing": the former can never be observed, the latter is a real
-        # answer.
+        # Fail closed above the flattening for `every` (and the plain
+        # exactly-one-match case): "zero objects existed" is an unobservable
+        # predicate there, not a satisfied one, so it stays a fail. `none` is
+        # the exception: it asserts that no matched object violates `op`, and
+        # an empty match set vacuously satisfies that (e.g. a selector for a
+        # job backlog that has been fully drained). This can only fire in
+        # selector mode: a name-mode fetch either raises (not found, caught
+        # above as `status="error"`) or returns exactly one object, so it
+        # never reaches this branch with an empty `objects`.
         if not objects:
+            if self.across_matches == "none":
+                return (
+                    "pass",
+                    f"no {self.kind} matched the selector; nothing violates",
+                    raw,
+                )
             return "fail", f"no {self.kind} matched", raw
 
         if self.op == "exists" and self.path is None:

--- a/tests/unit/verification/test_resource_property.py
+++ b/tests/unit/verification/test_resource_property.py
@@ -423,6 +423,80 @@ def test_plural_match_across_objects_without_across_matches_is_an_explicit_error
     assert "web" in result.reason and "api" in result.reason
 
 
+def _fake_get_resource_by_name(objects: dict[str, dict[str, Any]]) -> Any:
+    """Stand in for ``kubectl get <kind> <name>``: a ``name`` arg fetches the
+    one matching object; without it, every object in the namespace comes back
+    as a list. Mirrors what real ``get_resource`` does, unlike a fixed
+    ``return_value`` mock, which is what let a name-scoped check silently
+    evaluate against every object in the namespace go unnoticed.
+    """
+
+    def _get(
+        kind: str,
+        name: str | None = None,
+        *,
+        selector: str | None = None,
+        namespace: str | None = None,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        if name:
+            return objects[name]
+        return _items(*objects.values())
+
+    return _get
+
+
+def test_name_scoped_check_resolves_only_the_named_object() -> None:
+    """Regression: run_20260804_021227_387823, entry ``pod-ready@ingest.wl``.
+
+    A ``resource_property`` check carrying ``name`` (not ``resource_name``)
+    against a namespace with several same-kind objects must evaluate the
+    named object alone. It used to fetch the whole namespace instead, since
+    ``name`` lands on ``BaseVerifier.name`` (a result label) rather than
+    ``resource_name``, and the check failed with an across_matches refusal
+    even though the named object's own value satisfied the check.
+    """
+    objects = {
+        "aggregator": _deployment("aggregator", ready=2),
+        "ingest": _deployment("ingest", ready=3),
+        "transform": _deployment("transform", ready=2),
+    }
+    with patch(_GET, side_effect=_fake_get_resource_by_name(objects)):
+        result = _verifier(
+            name="ingest",
+            namespace="analytics",
+            path="status.readyReplicas",
+            op="eq",
+            value=3,
+        ).verify(0.0)
+    assert result.success is True
+    assert result.status == "pass"
+    assert "across_matches" not in result.reason
+
+
+def test_name_scoped_check_fails_on_the_named_object_alone() -> None:
+    """Same shape as above, wrong value: must fail with a single-object
+    reason naming ``ingest``'s own value, never the across_matches refusal
+    that resolving against the whole namespace would produce.
+    """
+    objects = {
+        "aggregator": _deployment("aggregator", ready=2),
+        "ingest": _deployment("ingest", ready=3),
+        "transform": _deployment("transform", ready=2),
+    }
+    with patch(_GET, side_effect=_fake_get_resource_by_name(objects)):
+        result = _verifier(
+            name="ingest",
+            namespace="analytics",
+            path="status.readyReplicas",
+            op="eq",
+            value=2,
+        ).verify(0.0)
+    assert result.success is False
+    assert result.status == "fail"
+    assert "across_matches" not in result.reason
+
+
 def test_plural_match_within_one_object_without_across_matches_is_an_explicit_error() -> None:
     with patch(_GET, return_value=_multi_container_deployment()):
         result = _verifier(

--- a/tests/unit/verification/test_resource_property.py
+++ b/tests/unit/verification/test_resource_property.py
@@ -341,6 +341,53 @@ def test_zero_matches_fails_a_scalar_op() -> None:
     assert "no deployment matched" in result.reason
 
 
+# -- absence-satisfies semantics for negative ops (op ne only) ----------
+
+
+def _configmap(name: str = "checkout-config", ns: str = "shop") -> dict[str, Any]:
+    return {"kind": "ConfigMap", "metadata": {"name": name, "namespace": ns}}
+
+
+def test_ne_on_an_absent_path_passes() -> None:
+    # Regression: run_20260804_030923_967784, entry config-source-mutable.
+    # A ConfigMap without an `immutable` field IS mutable: `path: immutable,
+    # op: ne, value: 'true'` must be satisfied by the field's absence, not
+    # error/fail. Absent is not equal to "true".
+    with patch(_GET, return_value=_configmap()):
+        result = _verifier(
+            kind="configmap",
+            op="ne",
+            value="true",
+            path="immutable",
+            resource_name="checkout-config",
+        ).verify(0.0)
+    assert result.success is True
+    assert result.status == "pass"
+
+
+def test_eq_on_an_absent_path_still_fails_closed() -> None:
+    # Scoped deliberately: only negative ops (ne) gain absence-satisfies
+    # semantics. A positive op like eq must keep failing closed on an
+    # unobservable predicate.
+    with patch(_GET, return_value=_configmap()):
+        result = _verifier(
+            kind="configmap",
+            op="eq",
+            value="true",
+            path="immutable",
+            resource_name="checkout-config",
+        ).verify(0.0)
+    assert result.success is False
+
+
+def test_gte_on_an_absent_path_without_across_matches_still_fails_closed() -> None:
+    with patch(_GET, return_value=_deployment()):
+        result = _verifier(
+            op="gte", value=1, path="status.noSuchField", resource_name="web"
+        ).verify(0.0)
+    assert result.success is False
+
+
 def test_absent_passes_on_zero_matches() -> None:
     with patch(_GET, return_value=_items()):
         result = _verifier(op="absent", selector="app=web", namespace="default").verify(0.0)

--- a/tests/unit/verification/test_resource_property.py
+++ b/tests/unit/verification/test_resource_property.py
@@ -957,6 +957,99 @@ def test_across_matches_none_element_wise_suffix_empty_filter_terminated_path_pa
     assert result.success is True
 
 
+# -- selector-mode reason summarization ----------------------------------
+
+
+def test_small_violation_set_enumerates_every_violator() -> None:
+    # Regression: T-029, entry no-broad-binding-for-sa. A small violation set
+    # must still name every violator; only a large one gets capped.
+    payload = _items(
+        _deployment("web", ready=2),
+        _deployment("api", ready=0),
+        _deployment("worker", ready=0),
+    )
+    with patch(_GET, return_value=payload):
+        result = _verifier(
+            op="gte",
+            value=1,
+            path="status.readyReplicas",
+            selector="tier=app",
+            across_matches="every",
+        ).verify(0.0)
+    assert result.success is False
+    assert "api" in result.reason
+    assert "worker" in result.reason
+    assert "more" not in result.reason
+
+
+def test_large_violation_set_is_capped_with_an_accurate_remainder_count() -> None:
+    # Eight violators is well over the enumeration cap; the reason must stay
+    # short (a selector-mode failure enumerating every violating object used
+    # to run to ~4,000 characters) while still saying how many there were.
+    deployments = [_deployment(f"app-{i}", ready=0) for i in range(8)]
+    payload = _items(*deployments)
+    with patch(_GET, return_value=payload):
+        result = _verifier(
+            op="gte",
+            value=1,
+            path="status.readyReplicas",
+            selector="tier=app",
+            across_matches="every",
+        ).verify(0.0)
+    assert result.success is False
+    assert "8 violate" in result.reason
+    assert "and 3 more" in result.reason
+    assert len(result.reason) < 700
+    assert result.raw is not None
+    assert len(result.raw["violations"]) == 8
+
+
+def test_capped_reason_still_carries_the_full_detail_on_raw() -> None:
+    deployments = [_deployment(f"app-{i}", ready=0) for i in range(8)]
+    payload = _items(*deployments)
+    with patch(_GET, return_value=payload):
+        result = _verifier(
+            op="gte",
+            value=1,
+            path="status.readyReplicas",
+            selector="tier=app",
+            across_matches="every",
+        ).verify(0.0)
+    assert result.raw is not None
+    assert all(f"app-{i}" in "".join(result.raw["violations"]) for i in range(8))
+
+
+def test_element_wise_violation_set_is_also_capped() -> None:
+    # Same cap applies to the wildcard/element-wise reduction path (e.g. a
+    # ClusterRoleBinding-per-subject sweep), not just the flat value-wise one.
+    deployment = _security_context_deployment(*([False] * 8))
+    with patch(_GET, return_value=deployment):
+        result = _verifier(
+            op="eq",
+            value=True,
+            path=_SECURITY_CONTEXT_PATH,
+            resource_name="web",
+            across_matches="none",
+        ).verify(0.0)
+    assert result.success is True
+    assert "none violate" in result.reason
+
+
+def test_element_wise_violation_set_over_the_cap_is_capped() -> None:
+    deployment = _security_context_deployment(*([True] * 8))
+    with patch(_GET, return_value=deployment):
+        result = _verifier(
+            op="eq",
+            value=True,
+            path=_SECURITY_CONTEXT_PATH,
+            resource_name="web",
+            across_matches="none",
+        ).verify(0.0)
+    assert result.success is False
+    assert "8 violate" in result.reason
+    assert "and 3 more" in result.reason
+
+
 # -- jsonpath filters ---------------------------------------------------
 
 

--- a/tests/unit/verification/test_resource_property.py
+++ b/tests/unit/verification/test_resource_property.py
@@ -564,21 +564,37 @@ def test_a_single_flat_match_evaluates_normally_without_across_matches() -> None
     assert result.success is True
 
 
-@pytest.mark.parametrize("across_matches", ["every", "none"])
-def test_zero_matched_objects_fails_closed_for_every_across_matches(across_matches: str) -> None:
-    # The zero-object guard runs before flattening, so both reductions fail
-    # closed on zero matches rather than deferring to their own vacuous-match
-    # semantics (e.g. "every" of an empty set).
+def test_zero_matched_objects_fails_closed_for_every_across_matches() -> None:
+    # The zero-object guard runs before flattening, so "every" still fails
+    # closed on zero matches rather than deferring to its own vacuous-match
+    # semantics ("every" of an empty set).
     with patch(_GET, return_value=_items()):
         result = _verifier(
             op="gte",
             value=1,
             path="status.readyReplicas",
             selector="app=web",
-            across_matches=across_matches,
+            across_matches="every",
         ).verify(0.0)
     assert result.success is False
     assert result.reason == "no deployment matched"
+
+
+def test_zero_matched_objects_vacuously_passes_none_across_matches() -> None:
+    # Regression: T-031, entry no-active-jobs@recon.cj. Zero objects matching
+    # the selector is exactly the success state for `across_matches: none`
+    # ("no object violates op") -- an emptied-out backlog satisfies it, it
+    # does not fail it.
+    with patch(_GET, return_value=_items()):
+        result = _verifier(
+            op="gte",
+            value=1,
+            path="status.readyReplicas",
+            selector="app=web",
+            across_matches="none",
+        ).verify(0.0)
+    assert result.success is True
+    assert "nothing violates" in result.reason
 
 
 def test_path_resolves_to_nothing_across_matches_none_passes() -> None:


### PR DESCRIPTION
Four fixes to `resource_property`, all cases where the verifier returned a confident answer that did not match what the cluster actually said.

1. A name-scoped check now resolves to the named object. Previously a check that named a specific object could still evaluate against a broader match set, so it could pass on the strength of some other object entirely.

2. `ne` against an absent path is satisfied, not an error. If the path is not present, the value is definitionally not equal to the expected one. Treating that as an error meant a correct assertion got reported as a broken check.

3. An empty match set satisfies a `none` check. "None of the matching objects have property X" is true when nothing matches. This previously errored, which made `none` unusable for the absence assertions it exists to express.

4. Selector-mode failure reasons are capped. A selector matching a large object set produced a failure reason listing every object, which buried the actual signal in the output and made the result hard to read in a trajectory.

Each commit is independent and separately tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Verification checks now fail safely when referenced properties or paths cannot be resolved.
  * “Not equal” checks correctly pass when a property is absent.
  * Name-scoped resource lookups now target the specified resource.
  * Empty selector results are handled correctly for “every” and “none” checks.
  * Violation messages are summarized clearly while retaining complete diagnostic details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->