### PR TITLE
fix(verification): pin checks to the run's cluster and stop scoring a broken pass

### DIFF
--- a/devops_bench/core/context.py
+++ b/devops_bench/core/context.py
@@ -51,12 +51,19 @@ class ClusterInfo:
         project: Cloud project; None for local clusters.
         kubeconfig_path: Kubeconfig path; resolved from ``KUBECONFIG`` or
             ``~/.kube/config`` when not supplied.
+        context: Kubeconfig context naming this specific cluster (e.g.
+            ``kind-<cluster>`` or ``gke_<project>_<location>_<cluster>``).
+            A kubeconfig file alone does not pin a cluster: it can carry
+            several contexts, or none selected as current. ``None`` when the
+            provider could not resolve one, in which case callers fall back
+            to the ambient current-context.
     """
 
     name: str
     location: str | None = None
     project: str | None = None
     kubeconfig_path: str = field(default_factory=_resolve_kubeconfig)
+    context: str | None = None
 
     @classmethod
     def from_dict(cls, info: dict[str, Any]) -> ClusterInfo:
@@ -64,7 +71,7 @@ class ClusterInfo:
 
         Args:
             info: Mapping with a required ``name`` and optional ``location``,
-                ``project``, and ``kubeconfig_path``.
+                ``project``, ``kubeconfig_path``, and ``context``.
 
         Returns:
             The constructed instance, with ``kubeconfig_path`` resolved when absent.
@@ -74,6 +81,7 @@ class ClusterInfo:
             location=info.get("location"),
             project=info.get("project"),
             kubeconfig_path=_resolve_kubeconfig(info.get("kubeconfig_path")),
+            context=info.get("context"),
         )
 
 

--- a/devops_bench/evalharness/default.py
+++ b/devops_bench/evalharness/default.py
@@ -57,6 +57,7 @@ from devops_bench.evalharness.scenario import (
 from devops_bench.tasks import Task
 from devops_bench.verification import (
     MIN_LEAF_BUDGET_SECONDS,
+    BaseVerifier,
     VerificationEntry,
     VerifierAgent,
     parse_entries,
@@ -121,6 +122,60 @@ def _ensure_builtin_agents_registered() -> None:
             # raise a clear ``NotRegisteredError`` later if the user selects
             # an agent whose module did not load.
             _log.debug("optional agent module %s not importable: %s", module, exc)
+
+
+def _pin_verifier_leaves(node: Any, kubeconfig: str | None, context: str | None) -> None:
+    """Set ``kubeconfig``/``context`` on every leaf verifier under ``node``, recursively.
+
+    A leaf (``BaseVerifier``) is pinned directly. A compound node (sequence,
+    parallel, any, none) has no cluster identity of its own, so this recurses
+    into its ``checks`` instead of touching it.
+
+    Args:
+        node: A parsed verification spec node: a leaf verifier or a compound
+            node exposing ``checks``.
+        kubeconfig: Resolved kubeconfig path, or None to leave the verifier's
+            existing (usually unset) value alone.
+        context: Resolved kubeconfig context, or None to leave the verifier's
+            existing value alone.
+    """
+    if isinstance(node, BaseVerifier):
+        if kubeconfig is not None:
+            node.kubeconfig = kubeconfig
+        if context is not None:
+            node.context = context
+        return
+    for child in getattr(node, "checks", []):
+        _pin_verifier_leaves(child, kubeconfig, context)
+
+
+def _pin_verification_targets(
+    entries: list[VerificationEntry], kubeconfig: str | None, context: str | None
+) -> None:
+    """Pin every entry's verifier leaves to the run's own cluster.
+
+    Verifiers otherwise carry no cluster identity and fall through to
+    whatever the host's ambient kubeconfig current-context happens to be,
+    which is not necessarily the cluster this run just provisioned and the
+    agent just acted on. Called once, right after the entries are parsed, so
+    both the background chaos scenario's checks and the post-run
+    verification pass (which share these same entry objects) are pinned.
+
+    Args:
+        entries: The task's parsed verification entries, mutated in place.
+        kubeconfig: Resolved kubeconfig path for the run's cluster.
+        context: Resolved kubeconfig context for the run's cluster, or None
+            when it could not be resolved (verification then runs unpinned
+            against whatever context is ambient).
+    """
+    if context is None:
+        _log.warning(
+            "no kubeconfig context resolved for this run's cluster; verification "
+            "will run unpinned and may target the wrong cluster if the ambient "
+            "kubeconfig's current-context does not point at it"
+        )
+    for entry in entries:
+        _pin_verifier_leaves(entry.check, kubeconfig, context)
 
 
 class DefaultEvalHarness(Harness):
@@ -767,6 +822,15 @@ class DefaultEvalHarness(Harness):
                     len(verification_parse_errors),
                     verification_parse_errors,
                 )
+            # Pin every verifier leaf to this run's own cluster before anything
+            # evaluates a check, so a stray ambient current-context (or none
+            # selected at all) cannot make verification silently read a
+            # different cluster than the one the agent just acted on. This
+            # deliberately keeps the operator's admin credential
+            # (``cluster_info.kubeconfig_path`` / ``.context``) rather than the
+            # agent's own scoped ``/workspace/kubeconfig``: verification must be
+            # able to observe state the agent could not itself have written.
+            _pin_verification_targets(entries, cluster_info.kubeconfig_path, cluster_info.context)
             verification_mapping = {entry.name: entry for entry in entries}
 
             # Hand the background scenario its own context with an isolated

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -75,12 +75,27 @@ def _selector_args(selector: str | None) -> list[str]:
     return ["-l", selector] if selector else []
 
 
-def _run_kubectl(argv: list[str], kubeconfig: KubeconfigSource, **kwargs: Any) -> CompletedProcess:
+def _context_args(context: str | None) -> list[str]:
+    return ["--context", context] if context else []
+
+
+def _run_kubectl(
+    argv: list[str],
+    kubeconfig: KubeconfigSource,
+    *,
+    context: str | None = None,
+    **kwargs: Any,
+) -> CompletedProcess:
     """Run ``kubectl`` with the resolved kubeconfig overlaid on the environment.
 
     Args:
         argv: Full kubectl command and arguments, never a shell string.
         kubeconfig: Explicit path, a ``KubeconfigProvider``, or None.
+        context: Optional kubeconfig context to pin the call to (``--context``).
+            Pinning the file alone is not enough: a kubeconfig can carry
+            several contexts, or none selected as current, and an unpinned
+            context means the call silently reads whichever cluster the
+            ambient current-context happens to point at.
         **kwargs: Extra keyword arguments forwarded to ``core.subprocess.run``
             (e.g. ``timeout``).
 
@@ -92,7 +107,7 @@ def _run_kubectl(argv: list[str], kubeconfig: KubeconfigSource, **kwargs: Any) -
     """
     path = _resolve_kubeconfig(kubeconfig)
     extra_env = {"KUBECONFIG": path} if path else None
-    return run(argv, extra_env=extra_env, **kwargs)
+    return run([*argv, *_context_args(context)], extra_env=extra_env, **kwargs)
 
 
 def wait(
@@ -103,6 +118,7 @@ def wait(
     timeout_sec: float,
     namespace: str | None = None,
     kubeconfig: KubeconfigSource = None,
+    context: str | None = None,
 ) -> CompletedProcess:
     """Block until a resource satisfies a condition via ``kubectl wait``.
 
@@ -113,6 +129,7 @@ def wait(
         timeout_sec: Maximum seconds to wait (``--timeout=<n>s``).
         namespace: Optional namespace (``-n``).
         kubeconfig: Kubeconfig path or context-like object.
+        context: Optional kubeconfig context to pin the call to.
 
     Returns:
         The completed process.
@@ -129,7 +146,7 @@ def wait(
         f"--timeout={timeout_sec}s",
         *_namespace_args(namespace),
     ]
-    return _run_kubectl(argv, kubeconfig)
+    return _run_kubectl(argv, kubeconfig, context=context)
 
 
 def get_resource(
@@ -140,6 +157,7 @@ def get_resource(
     namespace: str | None = None,
     kubeconfig: KubeconfigSource = None,
     timeout: float | None = None,
+    context: str | None = None,
 ) -> dict[str, Any]:
     """Fetch a resource (or list) as parsed JSON via ``kubectl get -o json``.
 
@@ -152,6 +170,7 @@ def get_resource(
         timeout: Optional seconds before the subprocess is killed. ``None``
             (the default) blocks indefinitely, so pass one whenever the API
             server might accept a connection and never respond.
+        context: Optional kubeconfig context to pin the call to.
 
     Returns:
         The parsed JSON document.
@@ -170,7 +189,7 @@ def get_resource(
         "json",
         *_namespace_args(namespace),
     ]
-    completed = _run_kubectl(argv, kubeconfig, timeout=timeout)
+    completed = _run_kubectl(argv, kubeconfig, timeout=timeout, context=context)
     return json.loads(completed.stdout)
 
 
@@ -179,6 +198,7 @@ def apply(
     *,
     namespace: str | None = None,
     kubeconfig: KubeconfigSource = None,
+    context: str | None = None,
 ) -> CompletedProcess:
     """Apply a manifest file or directory via ``kubectl apply -f``.
 
@@ -186,6 +206,7 @@ def apply(
         path: Manifest file, directory, or URL passed to ``-f``.
         namespace: Optional namespace (``-n``).
         kubeconfig: Kubeconfig path or context-like object.
+        context: Optional kubeconfig context to pin the call to.
 
     Returns:
         The completed process.
@@ -194,7 +215,7 @@ def apply(
         SubprocessError: If kubectl exits non-zero or times out.
     """
     argv = ["kubectl", "apply", "-f", path, *_namespace_args(namespace)]
-    return _run_kubectl(argv, kubeconfig)
+    return _run_kubectl(argv, kubeconfig, context=context)
 
 
 def rollout_status(
@@ -203,6 +224,7 @@ def rollout_status(
     timeout_sec: float | None = None,
     namespace: str | None = None,
     kubeconfig: KubeconfigSource = None,
+    context: str | None = None,
 ) -> CompletedProcess:
     """Wait for a rollout to finish via ``kubectl rollout status``.
 
@@ -211,6 +233,7 @@ def rollout_status(
         timeout_sec: Optional maximum seconds to wait (``--timeout=<n>s``).
         namespace: Optional namespace (``-n``).
         kubeconfig: Kubeconfig path or context-like object.
+        context: Optional kubeconfig context to pin the call to.
 
     Returns:
         The completed process.
@@ -226,7 +249,7 @@ def rollout_status(
         *([f"--timeout={timeout_sec}s"] if timeout_sec is not None else []),
         *_namespace_args(namespace),
     ]
-    return _run_kubectl(argv, kubeconfig)
+    return _run_kubectl(argv, kubeconfig, context=context)
 
 
 @contextlib.contextmanager
@@ -238,6 +261,7 @@ def port_forward(
     namespace: str | None = None,
     settle_sec: float = _PORT_FORWARD_SETTLE_SEC,
     kubeconfig: KubeconfigSource = None,
+    context: str | None = None,
 ) -> Iterator[None]:
     """Hold a ``kubectl port-forward`` open for the duration of the ``with`` body.
 
@@ -256,6 +280,7 @@ def port_forward(
         namespace: Optional namespace (``-n``).
         settle_sec: Seconds to wait for the tunnel to establish before yielding.
         kubeconfig: Kubeconfig path or context-like object.
+        context: Optional kubeconfig context to pin the call to.
 
     Yields:
         ``None`` once the tunnel has had time to settle.
@@ -271,6 +296,7 @@ def port_forward(
         target,
         f"{local_port}:{remote}",
         *_namespace_args(namespace),
+        *_context_args(context),
     ]
     path = _resolve_kubeconfig(kubeconfig)
     # Reuse core.subprocess env semantics so this Popen path never drifts from

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -107,7 +107,13 @@ def _run_kubectl(
     """
     path = _resolve_kubeconfig(kubeconfig)
     extra_env = {"KUBECONFIG": path} if path else None
-    return run([*argv, *_context_args(context)], extra_env=extra_env, **kwargs)
+    ctx_args = _context_args(context)
+    if ctx_args and "--" in argv:
+        idx = argv.index("--")
+        argv = [*argv[:idx], *ctx_args, *argv[idx:]]
+    else:
+        argv = [*argv, *ctx_args]
+    return run(argv, extra_env=extra_env, **kwargs)
 
 
 def wait(

--- a/devops_bench/metrics/pipeline.py
+++ b/devops_bench/metrics/pipeline.py
@@ -152,12 +152,37 @@ def _finalize_outcome_score(scores: dict[str, Any]) -> None:
     recoverable sources emit a raw pass fraction; the ``[0.1, 1.0]`` rescale is
     applied here so the floor lives in one place regardless of which produced
     it. Records with no correctness signal at all (e.g. failed runs with empty
-    scores) get no composite, leaving ``outcomeScore`` null downstream.
+    scores) get no composite, leaving ``outcomeScore`` null downstream. A
+    record where deterministic verification was declared but every entry
+    errored also gets no composite, for the same reason: see the coverage
+    check below.
 
     Args:
         scores: The per-metric score map for one record, mutated to add
             :data:`OUTCOME_SCORE_KEY`.
     """
+    # ``VerificationCoverage`` is emitted unconditionally whenever the task
+    # declared deterministic verification (see ``VerificationMetric.applies``),
+    # even when every entry errored and ``VerificationCorrectness`` therefore
+    # never gets emitted. Its presence without a correctness score means
+    # verification was attempted and produced nothing, not that nothing was
+    # declared. An errored check is an unmeasured objective, not a satisfied
+    # one: falling through to the judged keys in that case would let a judge's
+    # reading of prose stand in for a deterministic check that failed to run,
+    # making a totally broken verification pass indistinguishable from a clean
+    # sweep. So this case is withheld rather than routed through the fallback
+    # chain below, which exists only for tasks that declared no deterministic
+    # verification at all.
+    if score_keys.VERIFICATION_COVERAGE_KEY in scores and (
+        _score_value(scores.get(score_keys.VERIFICATION_CORRECTNESS_KEY)) is None
+    ):
+        _log.warning(
+            "Withholding composite outcome score: deterministic verification "
+            "was declared but produced no correctness signal (see "
+            "VerificationCoverage)."
+        )
+        return
+
     correctness = _first_score(scores, _CORRECTNESS_KEYS)
     if correctness is None:
         return

--- a/devops_bench/providers/gcp.py
+++ b/devops_bench/providers/gcp.py
@@ -50,7 +50,9 @@ class GcpProvider(Provider):
             variables: OpenTofu input variables the cluster was provisioned with.
 
         Returns:
-            The cluster's :class:`~devops_bench.core.ClusterInfo`.
+            The cluster's :class:`~devops_bench.core.ClusterInfo`, carrying
+            the ``gke_<project>_<location>_<cluster>`` context ``gcloud``
+            wrote into the kubeconfig.
 
         Raises:
             ConfigError: If no project is resolvable from ``variables`` or the
@@ -99,7 +101,12 @@ class GcpProvider(Provider):
             )
 
         return ClusterInfo.from_dict(
-            {"name": cluster_name, "location": location, "project": project}
+            {
+                "name": cluster_name,
+                "location": location,
+                "project": project,
+                "context": context_name,
+            }
         )
 
     def resolve_variables(

--- a/devops_bench/providers/kind.py
+++ b/devops_bench/providers/kind.py
@@ -47,7 +47,10 @@ class KindProvider(Provider):
 
         Returns:
             The cluster's :class:`~devops_bench.core.ClusterInfo`; ``project``
-            falls back to ``local-kind`` when none is set.
+            falls back to ``local-kind`` when none is set. ``context`` is the
+            standard ``kind-<cluster_name>`` KinD writes into the kubeconfig,
+            matching what ``devops_bench.agents.sandbox`` already assumes when
+            it strips the ``kind-`` prefix.
         """
         project = variables.get("project_id") or _LOCAL_PROJECT
         return ClusterInfo.from_dict(
@@ -56,6 +59,7 @@ class KindProvider(Provider):
                 "location": location,
                 "project": project,
                 "kubeconfig_path": variables.get("kubeconfig_path"),
+                "context": f"kind-{cluster_name}",
             }
         )
 

--- a/devops_bench/verification/base.py
+++ b/devops_bench/verification/base.py
@@ -161,6 +161,11 @@ class BaseVerifier(BaseModel, ABC):
         kubeconfig: Optional path to a kubeconfig file, forwarded to the
             ``devops_bench.k8s`` wrappers so a check can target a specific
             cluster. When ``None`` the wrappers use the ambient kubeconfig.
+        context: Optional kubeconfig context, forwarded alongside
+            ``kubeconfig`` so a check pins the exact cluster rather than
+            whichever context the kubeconfig file happens to have selected as
+            current (or none). When ``None`` the wrappers use the ambient
+            current-context.
     """
 
     # Reject any key the concrete verifier does not declare. A typo'd or
@@ -170,6 +175,7 @@ class BaseVerifier(BaseModel, ABC):
 
     name: str | None = None
     kubeconfig: str | None = None
+    context: str | None = None
 
     @abstractmethod
     def verify(self, timeout_sec: float) -> VerificationResult:

--- a/devops_bench/verification/verifiers/pod_healthy.py
+++ b/devops_bench/verification/verifiers/pod_healthy.py
@@ -70,6 +70,7 @@ class PodHealthyVerifier(BaseVerifier):
                 timeout_sec=single_call_timeout(timeout_sec),
                 namespace=self.namespace,
                 kubeconfig=self.kubeconfig,
+                context=self.context,
             )
             return VerificationResult(
                 success=True,
@@ -127,6 +128,7 @@ class PodHealthyVerifier(BaseVerifier):
                 selector=self.selector,
                 namespace=self.namespace,
                 kubeconfig=self.kubeconfig,
+                context=self.context,
                 timeout=single_call_timeout(timeout_sec),
             )
         except Exception as exc:  # noqa: BLE001 - diagnostics path, never raises

--- a/devops_bench/verification/verifiers/resource_property.py
+++ b/devops_bench/verification/verifiers/resource_property.py
@@ -375,6 +375,7 @@ class ResourcePropertyVerifier(BaseVerifier):
                 selector=self.selector,
                 namespace=self.namespace,
                 kubeconfig=self.kubeconfig,
+                context=self.context,
                 timeout=single_call_timeout(timeout_sec),
             )
         except Exception as exc:  # noqa: BLE001 - a kubectl failure is a check error

--- a/devops_bench/verification/verifiers/scaling_complete.py
+++ b/devops_bench/verification/verifiers/scaling_complete.py
@@ -110,6 +110,7 @@ class ScalingCompleteVerifier(BaseVerifier):
                 self.deployment,
                 namespace=self.namespace,
                 kubeconfig=self.kubeconfig,
+                context=self.context,
                 timeout=single_call_timeout(timeout_sec),
             )
         except SubprocessError as exc:

--- a/tests/unit/k8s/test_k8s_kubectl.py
+++ b/tests/unit/k8s/test_k8s_kubectl.py
@@ -203,6 +203,32 @@ def test_run_context_without_cluster_omits_kubeconfig(mocker: MockerFixture) -> 
     assert mock_run.call_args.kwargs["extra_env"] is None
 
 
+def test_wait_threads_context_into_argv(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+
+    kubectl.wait("pod", timeout_sec=10, kubeconfig="/tmp/kc", context="kind-devops-bench-kind")
+
+    argv = mock_run.call_args.args[0]
+    assert argv == [
+        "kubectl",
+        "wait",
+        "--for=condition=Ready",
+        "pod",
+        "--timeout=10s",
+        "--context",
+        "kind-devops-bench-kind",
+    ]
+
+
+def test_wait_without_context_omits_context_flag(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+
+    kubectl.wait("pod", timeout_sec=10, kubeconfig="/tmp/kc")
+
+    argv = mock_run.call_args.args[0]
+    assert "--context" not in argv
+
+
 def test_get_resource_propagates_invalid_json(mocker: MockerFixture) -> None:
     mocker.patch(
         "devops_bench.k8s.kubectl.run",

--- a/tests/unit/metrics/test_metrics_pipeline.py
+++ b/tests/unit/metrics/test_metrics_pipeline.py
@@ -677,6 +677,45 @@ def test_finalize_correctness_falls_back_to_outcome_validity() -> None:
     assert scores[pipeline.OUTCOME_SCORE_KEY]["score"] == 0.7
 
 
+def test_finalize_withholds_composite_when_verification_declared_but_errored(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Regression: an all-errored verification pass must not fall back to the judge.
+
+    ``VerificationCoverage`` is present (deterministic verification was
+    declared and attempted) but ``VerificationCorrectness`` never got emitted
+    (every entry errored). Previously this fell through to
+    ``OutcomeValidity``, letting a judge's 1.0 stand in for a totally broken
+    check; now no composite is written at all.
+    """
+    scores = {
+        "VerificationCoverage": {"score": 0.0, "success": False},
+        "OutcomeValidity": {"score": 1.0, "success": True},
+    }
+    with caplog.at_level("WARNING"):
+        pipeline._finalize_outcome_score(scores)  # noqa: SLF001
+    assert pipeline.OUTCOME_SCORE_KEY not in scores
+    assert "VerificationCoverage" in caplog.text
+
+
+def test_finalize_no_verification_declared_still_falls_back_to_judge() -> None:
+    """A task with no deterministic verification keeps the legitimate judged fallback."""
+    scores = {"OutcomeValidity": {"score": 0.9, "success": True}}
+    pipeline._finalize_outcome_score(scores)  # noqa: SLF001
+    assert scores[pipeline.OUTCOME_SCORE_KEY]["score"] == pytest.approx(0.9)
+
+
+def test_finalize_coverage_and_correctness_present_ignores_judge() -> None:
+    """Coverage plus a real correctness score composes from the deterministic value."""
+    scores = {
+        "VerificationCoverage": {"score": 1.0, "success": True},
+        "VerificationCorrectness": {"score": 1.0, "success": True},
+        "OutcomeValidity": {"score": 0.0, "success": False},
+    }
+    pipeline._finalize_outcome_score(scores)  # noqa: SLF001
+    assert scores[pipeline.OUTCOME_SCORE_KEY]["score"] == pytest.approx(1.0)
+
+
 def test_finalize_skips_when_no_correctness_signal() -> None:
     # Failed / unscored record: no composite is written (outcomeScore stays null).
     scores = {"ToolInvocation": {"score": 0.5, "success": True}}

--- a/tests/unit/verification/test_scaling_complete.py
+++ b/tests/unit/verification/test_scaling_complete.py
@@ -19,6 +19,8 @@ The poll function and kubectl primitives are stubbed; no real cluster work.
 
 from __future__ import annotations
 
+import json
+import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -161,6 +163,32 @@ def test_get_resource_is_called_with_a_floored_timeout(
         ScalingCompleteVerifier(deployment="web", min_replicas=1).verify(timeout_sec=timeout_sec)
 
     assert mock_get.call_args.kwargs["timeout"] == expected_timeout
+
+
+def test_context_is_forwarded_into_kubectl_argv() -> None:
+    # Goes all the way down to the real ``devops_bench.k8s.kubectl.run`` seam
+    # (rather than stubbing ``get_resource``) so the wiring from the
+    # verifier's own ``context`` field through to the ``kubectl`` argv is
+    # actually exercised, not just the verifier's own kwargs.
+    deployment = {"status": {"readyReplicas": 3}}
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=json.dumps(deployment))
+    with patch("devops_bench.k8s.kubectl.run", return_value=completed) as mock_run:
+        ScalingCompleteVerifier(
+            deployment="web", min_replicas=1, context="kind-devops-bench-kind"
+        ).verify(timeout_sec=5)
+
+    argv = mock_run.call_args.args[0]
+    assert argv[-2:] == ["--context", "kind-devops-bench-kind"]
+
+
+def test_no_context_omits_context_flag_from_kubectl_argv() -> None:
+    deployment = {"status": {"readyReplicas": 3}}
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=json.dumps(deployment))
+    with patch("devops_bench.k8s.kubectl.run", return_value=completed) as mock_run:
+        ScalingCompleteVerifier(deployment="web", min_replicas=1).verify(timeout_sec=5)
+
+    argv = mock_run.call_args.args[0]
+    assert "--context" not in argv
 
 
 def test_name_is_echoed_onto_result() -> None:


### PR DESCRIPTION
Two related correctness problems in how a run's checks reach the cluster and how a broken run gets scored.

Checks were resolving their cluster through ambient kubeconfig context rather than the cluster the run actually provisioned. On a workstation with more than one cluster in kubeconfig, or when two runs overlap, a check could observe the wrong cluster and report a confident result about something it never touched. This threads the run's cluster identity through the context and the provider layer so every check is pinned to the cluster the run owns.

Separately, a run that failed to produce a usable result could still reach the judge and be scored as a pass. That turns an infrastructure failure into a silent correctness signal, which is the worst direction for the error to go. A broken run now stops before scoring instead.

Touches the context and provider plumbing, the verification base, and the `pod_healthy`, `resource_property`, and `scaling_complete` verifiers. Unit tests cover the pinning behavior and the withheld-score path.