### PR TITLE
fix(verification): distinguish error from fail in check reasons

### DIFF
--- a/devops_bench/verification/runner.py
+++ b/devops_bench/verification/runner.py
@@ -84,6 +84,17 @@ def _node_name(node: Any) -> str | None:
     return getattr(node, "name", None)
 
 
+def _non_success_verb(status: VerificationStatus) -> str:
+    """Return "errored" for a status of "error", else "failed".
+
+    Shared wording so every combinator's joined ``reason`` string tells an
+    unobserved child (never ran, could not be evaluated) apart from a
+    genuinely observed negative result, the same distinction
+    :meth:`VerifierAgent._run_sequence` already makes for its own reasons.
+    """
+    return "errored" if status == "error" else "failed"
+
+
 def _failed(node: Any, reason: str, status: VerificationStatus = "fail") -> VerificationResult:
     """Build a not-run-to-completion result for a node.
 
@@ -373,7 +384,7 @@ class VerifierAgent:
             if res.success:
                 reasons.append(f"[{i}] succeeded")
                 break
-            reasons.append(f"[{i}] failed: {res.reason}")
+            reasons.append(f"[{i}] {_non_success_verb(res.status)}: {res.reason}")
 
         status = _combine_disjunction([c.status for c in children])
         return VerificationResult(
@@ -442,7 +453,10 @@ class VerifierAgent:
             if res.success:
                 reasons.append(f"[{i}] unexpectedly succeeded: {res.reason}")
                 break
-            reasons.append(f"[{i}] did not hold, as required")
+            if res.status == "error":
+                reasons.append(f"[{i}] errored: {res.reason}")
+            else:
+                reasons.append(f"[{i}] did not hold, as required")
 
         status = _combine_negated_disjunction([c.status for c in children])
         return VerificationResult(
@@ -551,7 +565,8 @@ class VerifierAgent:
         # A parallel node runs every child, so the joined reason is the only
         # place the caller sees which child failed and why.
         reasons = [
-            f"[{i}] {'ok' if r.success else f'failed: {r.reason}'}" for i, r in enumerate(results)
+            f"[{i}] {'ok' if r.success else f'{_non_success_verb(r.status)}: {r.reason}'}"
+            for i, r in enumerate(results)
         ]
         return VerificationResult(
             success=status == "pass",

--- a/devops_bench/verification/verifiers/pod_healthy.py
+++ b/devops_bench/verification/verifiers/pod_healthy.py
@@ -111,6 +111,37 @@ class PodHealthyVerifier(BaseVerifier):
                     name=self.name,
                     raw=raw,
                 )
+            if not raw.get("items"):
+                # Zero pods matched the selector. Still a FAIL rather than an error,
+                # and deliberately so: the two possible causes are indistinguishable
+                # from inside the check. The workload may have been deleted (a real
+                # violation, and precisely what a safeguard like this exists to
+                # catch), or the selector may simply be wrong (a check bug). Turning
+                # this into an error to spare the second case would silently mask the
+                # first, which is the worse trade for a catastrophic safeguard.
+                #
+                # What we CAN do is stop reporting the two cases with the same words.
+                # Previously both produced "kubectl wait failed or timed out", which
+                # read as "the pods are unhealthy" and cost a real debugging session:
+                # a typo'd Kyverno selector (v1.12.7 has no app.kubernetes.io/name
+                # label) tripped a catastrophic safeguard and zeroed a run that had
+                # otherwise scored 1.0 with every genuine safeguard respected.
+                #
+                # The ambiguity is removable, but at seed time rather than here:
+                # assert every selector matches something on the freshly-seeded
+                # cluster, and a zero match later unambiguously means the agent
+                # removed it. Mirrors resource_property's "no {kind} matched".
+                where = f" in namespace {self.namespace!r}" if self.namespace else ""
+                return VerificationResult(
+                    success=False,
+                    elapsed_time=elapsed,
+                    reason=(
+                        f"no pods matched selector {self.selector!r}{where}: either the "
+                        f"workload is gone or the selector does not match it"
+                    ),
+                    name=self.name,
+                    raw=raw,
+                )
             return VerificationResult(
                 success=False,
                 elapsed_time=elapsed,

--- a/tests/unit/verification/test_combinators.py
+++ b/tests/unit/verification/test_combinators.py
@@ -505,3 +505,49 @@ def test_none_truth_table(checks: list[dict[str, Any]], expected: str) -> None:
     entry = _assert_entry({"type": "none", "checks": checks})
     result = VerifierAgent().run_entry(entry, timeout_sec=30)
     assert result.status == expected
+
+
+# --- an errored child must not short-circuit remaining children ------------
+#
+# `any` and `none` only ever stop a round early on a definitive success (any)
+# or a definitive pass (none) or a deadline; an errored child is neither, and
+# must not stop evaluation of its siblings. See runner.py's module docstring
+# and rollup.py: an entry that never even got a fair look at every child is
+# indistinguishable from one that genuinely failed every check.
+
+
+def test_any_round_evaluates_every_child_despite_an_earlier_error() -> None:
+    entry = _assert_entry({"type": "any", "checks": [_error_leaf("a"), _leaf(False, "b")]})
+    result = VerifierAgent().run_entry(entry, timeout_sec=30)
+    assert len(result.children) == 2
+    assert result.status == "error"
+
+
+def test_none_round_evaluates_every_child_despite_an_earlier_error() -> None:
+    entry = _assert_entry({"type": "none", "checks": [_error_leaf("a"), _leaf(False, "b")]})
+    result = VerifierAgent().run_entry(entry, timeout_sec=30)
+    assert len(result.children) == 2
+    assert result.status == "error"
+
+
+def test_any_round_reason_distinguishes_errored_from_failed_children() -> None:
+    entry = _assert_entry({"type": "any", "checks": [_leaf(False, "a"), _error_leaf("b")]})
+    result = VerifierAgent().run_entry(entry, timeout_sec=30)
+    assert "[0] failed:" in result.reason
+    assert "[1] errored:" in result.reason
+
+
+def test_none_round_reason_distinguishes_errored_from_failed_children() -> None:
+    entry = _assert_entry({"type": "none", "checks": [_leaf(False, "a"), _error_leaf("b")]})
+    result = VerifierAgent().run_entry(entry, timeout_sec=30)
+    assert "[0] did not hold, as required" in result.reason
+    assert "[1] errored:" in result.reason
+
+
+def test_parallel_reason_distinguishes_errored_from_failed_children() -> None:
+    agent = VerifierAgent()
+    result = agent.wait_for_condition(
+        {"type": "all", "checks": [_leaf(False, "a"), _error_leaf("b")]}, timeout_sec=5
+    )
+    assert "[0] failed:" in result.reason
+    assert "[1] errored:" in result.reason

--- a/tests/unit/verification/test_pod_healthy.py
+++ b/tests/unit/verification/test_pod_healthy.py
@@ -80,8 +80,13 @@ def test_fallback_reports_failure_when_no_pods_match() -> None:
         result = PodHealthyVerifier(selector="app=ghost").verify(timeout_sec=5)
 
     assert result.success is False
+    # Still a FAIL, not an error: a deleted workload is a real violation and the
+    # check cannot tell it apart from a wrong selector, so it fails closed.
     assert result.status == "fail"
-    assert "no match" in result.reason
+    # The reason must name the selector and say which two cases are in play, so a
+    # zero-match is not reported in the same words as "pods exist but are unhealthy".
+    assert "no pods matched selector" in result.reason
+    assert "app=ghost" in result.reason
 
 
 def test_fallback_fetch_failure_is_an_error_not_a_fail() -> None:


### PR DESCRIPTION
Two fixes where a check reported a reason that read as a real finding but was actually a check that never got to run.

`pod_healthy` now gives a distinct reason when its selector matches zero pods. Previously a selector that matched nothing was indistinguishable from a selector that matched unhealthy pods, so a typo in a label selector looked like a genuine failure of the workload.

The `any` and `none` combinators now distinguish an error from a fail in the reason they emit. A child check that errored and a child check that legitimately failed produced the same combinator reason, which made a broken check look like evidence about the cluster.

Both cases matter because these reasons feed the trajectory and the score. A check that could not run should not read as a check that ran and found something.