### PR TITLE
fix(models): the judge's Vertex client uses ADC even when agent API keys are set

### DIFF
--- a/devops_bench/models/gemini.py
+++ b/devops_bench/models/gemini.py
@@ -29,9 +29,11 @@ from devops_bench.models.base import MODELS, LLMClient
 try:
     from google import genai
     from google.genai import types
+    import google.auth as google_auth
 except ImportError:  # pragma: no cover - exercised only without the SDK
     genai = None
     types = None
+    google_auth = None
 
 __all__ = ["GeminiClientAdapter", "filter_schema_for_gemini"]
 
@@ -71,6 +73,24 @@ def _backoff_delay(attempt: int) -> float:
     """Full-jitter exponential backoff delay for ``attempt`` (0-based)."""
     ceiling = min(_MAX_DELAY_SEC, _BASE_DELAY_SEC * (2**attempt))
     return random.uniform(0.0, ceiling)
+
+
+def _vertex_client(*, project_id: str | None, location: str) -> Any:
+    """Build a Vertex-mode ``genai.Client`` authenticated with ADC, explicitly.
+
+    google-genai's Vertex mode silently prefers API-key/express auth over
+    Application Default Credentials whenever ``GOOGLE_API_KEY`` (or
+    ``GEMINI_API_KEY``) is present in the environment. Those are exactly the
+    variables exported for the sandboxed coding agent this client judges, so
+    without this, the judge's own Vertex calls would authenticate as the
+    agent rather than as the judge. Resolving ADC explicitly and handing the
+    credentials to the client closes that path: the client is never given a
+    chance to fall back to an env API key it was never told to look for.
+    """
+    credentials, _ = google_auth.default()
+    return genai.Client(
+        vertexai=True, project=project_id, location=location, credentials=credentials
+    )
 
 
 _SUPPORTED_SCHEMA_FIELDS = frozenset(
@@ -229,17 +249,21 @@ class GeminiClientAdapter(LLMClient):
 
         project_id = get_env("GCP_PROJECT_ID")
         location = get_env("GCP_VERTEX_LOCATION", "global")
+        # This is the judge's own explicit key input, not an ambient env var:
+        # judge auth must not depend on whatever the agent's own environment
+        # happens to carry (see _vertex_client for the Vertex-mode case where
+        # the SDK itself would otherwise reach for one).
         api_key = get_env("AGENT_API_KEY")
 
         # ``backend == "vertex"`` (the ``google-vertex`` provider) forces Vertex
         # AI regardless of an API key, so the provider — not key presence —
         # decides the backend. Otherwise infer as before.
         if backend == "vertex":
-            self.client = genai.Client(vertexai=True, project=project_id, location=location)
+            self.client = _vertex_client(project_id=project_id, location=location)
         elif api_key:
             self.client = genai.Client(api_key=api_key)
         elif project_id:
-            self.client = genai.Client(vertexai=True, project=project_id, location=location)
+            self.client = _vertex_client(project_id=project_id, location=location)
         else:
             self.client = genai.Client()
 

--- a/devops_bench/models/gemini.py
+++ b/devops_bench/models/gemini.py
@@ -27,9 +27,9 @@ from devops_bench.core.logging import get_logger
 from devops_bench.models.base import MODELS, LLMClient
 
 try:
+    import google.auth as google_auth
     from google import genai
     from google.genai import types
-    import google.auth as google_auth
 except ImportError:  # pragma: no cover - exercised only without the SDK
     genai = None
     types = None

--- a/tests/unit/models/test_models_gemini.py
+++ b/tests/unit/models/test_models_gemini.py
@@ -428,6 +428,10 @@ def test_registered_in_models_registry() -> None:
 @pytest.mark.parametrize("provider", ["gemini", "google", "google-vertex", "google_vertex"])
 def test_get_model_resolves_gemini_aliases(mocker: MockerFixture, provider: str) -> None:
     mocker.patch.object(gemini.genai, "Client")
+    # The google-vertex/google_vertex aliases route through _vertex_client,
+    # which resolves ADC; mocked unconditionally here since it is a no-op for
+    # the other aliases, which never call it.
+    mocker.patch.object(gemini.google_auth, "default", return_value=(object(), "proj"))
     mocker.patch.dict(os.environ, {}, clear=True)
 
     client = get_model(provider=provider)

--- a/tests/unit/models/test_models_gemini.py
+++ b/tests/unit/models/test_models_gemini.py
@@ -129,13 +129,51 @@ def test_client_selection_api_key(mocker: MockerFixture) -> None:
 
 def test_client_selection_vertex(mocker: MockerFixture) -> None:
     client_cls = mocker.patch.object(gemini.genai, "Client")
+    fake_creds = object()
+    mocker.patch.object(gemini.google_auth, "default", return_value=(fake_creds, "proj"))
     mocker.patch.dict(
         os.environ, {"GCP_PROJECT_ID": "proj", "GCP_VERTEX_LOCATION": "europe-west1"}, clear=True
     )
 
     GeminiClientAdapter()
 
-    client_cls.assert_called_once_with(vertexai=True, project="proj", location="europe-west1")
+    client_cls.assert_called_once_with(
+        vertexai=True, project="proj", location="europe-west1", credentials=fake_creds
+    )
+
+
+def test_vertex_client_resolves_adc_even_when_an_agent_api_key_is_in_the_environment(
+    mocker: MockerFixture,
+) -> None:
+    """Regression: the judge's Vertex client must never authenticate with the
+    agent's own API key.
+
+    google-genai's Vertex mode silently prefers API-key/express auth over ADC
+    whenever GOOGLE_API_KEY (or GEMINI_API_KEY) is present in the
+    environment. Those are exactly the variables exported for the sandboxed
+    coding agent this judge scores, so without explicit credentials the
+    judge's own Vertex calls would authenticate as the agent instead of
+    itself. Resolving ADC explicitly and handing it to the client closes
+    that path regardless of what the SDK would have inferred from the
+    environment on its own.
+    """
+    client_cls = mocker.patch.object(gemini.genai, "Client")
+    fake_creds = object()
+    mock_default = mocker.patch.object(
+        gemini.google_auth, "default", return_value=(fake_creds, "proj")
+    )
+    mocker.patch.dict(
+        os.environ,
+        {"GCP_PROJECT_ID": "proj", "GOOGLE_API_KEY": "agent-key-must-not-be-used"},
+        clear=True,
+    )
+
+    GeminiClientAdapter()
+
+    mock_default.assert_called_once()
+    client_cls.assert_called_once_with(
+        vertexai=True, project="proj", location="global", credentials=fake_creds
+    )
 
 
 def test_client_selection_default(mocker: MockerFixture) -> None:
@@ -150,13 +188,17 @@ def test_client_selection_default(mocker: MockerFixture) -> None:
 
 def test_backend_vertex_forces_vertex_even_with_api_key(mocker: MockerFixture) -> None:
     client_cls = mocker.patch.object(gemini.genai, "Client")
+    fake_creds = object()
+    mocker.patch.object(gemini.google_auth, "default", return_value=(fake_creds, "proj"))
     # An API key is present, but backend="vertex" (the google-vertex provider)
     # must still build the Vertex client — provider decides, not key presence.
     mocker.patch.dict(os.environ, {"AGENT_API_KEY": "k", "GCP_PROJECT_ID": "proj"}, clear=True)
 
     GeminiClientAdapter(backend="vertex")
 
-    client_cls.assert_called_once_with(vertexai=True, project="proj", location="global")
+    client_cls.assert_called_once_with(
+        vertexai=True, project="proj", location="global", credentials=fake_creds
+    )
 
 
 def test_backend_none_keeps_inference(mocker: MockerFixture) -> None:


### PR DESCRIPTION
The judge's Vertex client was picking up an agent's API key from the environment instead of using application default credentials.

This matters because the agent under evaluation and the judge scoring it are not the same principal and should not share credentials. When an agent API key was present in the environment, the judge would authenticate as that agent, which both crosses an isolation boundary and fails in any setup where the agent key has no access to the judge's model.

The judge now resolves credentials through ADC regardless of what agent keys are in the environment.