### PR TITLE
feat(verification): make the check timeout and total budget tunable by environment

### DIFF
--- a/devops_bench/evalharness/scenario.py
+++ b/devops_bench/evalharness/scenario.py
@@ -68,7 +68,10 @@ def _positive_int_env(name: str, default: int) -> int:
             is not strictly positive.
     """
     value = get_int(name, default)
-    assert value is not None
+    if value is None:
+        # Unreachable: get_int only returns None when default is None, and
+        # this function always passes a non-None default.
+        return default
     if value <= 0:
         raise ConfigError(f"environment variable {name!r} must be a positive integer: {value!r}")
     return value

--- a/devops_bench/evalharness/scenario.py
+++ b/devops_bench/evalharness/scenario.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import contextlib
 import copy
-import os
 import socket
 import threading
 import time
@@ -39,7 +38,7 @@ from devops_bench.chaos.faults.generate_load import (
     _ENV_TARGET_NAMESPACE,
     _LOCAL_PORT,
 )
-from devops_bench.core import get_logger
+from devops_bench.core import ConfigError, get_int, get_logger
 from devops_bench.core.context import RunContext
 from devops_bench.k8s import get_resource, poll_until
 from devops_bench.verification import VerificationEntry, VerifierAgent
@@ -52,6 +51,28 @@ __all__ = [
 ]
 
 _log = get_logger("evalharness.scenario")
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    """Parse a positive integer override from the environment.
+
+    Args:
+        name: Variable to read.
+        default: Returned when the variable is unset or blank.
+
+    Returns:
+        The parsed integer.
+
+    Raises:
+        ConfigError: If the value is set but not a valid integer, or if it
+            is not strictly positive.
+    """
+    value = get_int(name, default)
+    assert value is not None
+    if value <= 0:
+        raise ConfigError(f"environment variable {name!r} must be a positive integer: {value!r}")
+    return value
+
 
 # Per-entry budget for a converging entry: how long a single entry's (possibly
 # nested) checks may poll before giving up. Assert-mode entries ignore this,
@@ -70,15 +91,16 @@ _log = get_logger("evalharness.scenario")
 # meaningfully run, which reads as a failed check rather than as an unmeasured one.
 #
 # Both are overridable via BENCH_VERIFY_TIMEOUT_SEC and BENCH_VERIFY_TOTAL_BUDGET_SEC
-# for tuning without a code change.
-VERIFICATION_TIMEOUT_SEC = int(os.environ.get("BENCH_VERIFY_TIMEOUT_SEC", "120"))
+# for tuning without a code change. A malformed or non-positive override is
+# rejected at import with a ConfigError naming the variable.
+VERIFICATION_TIMEOUT_SEC = _positive_int_env("BENCH_VERIFY_TIMEOUT_SEC", 120)
 
 # Total wall-clock budget for the whole post-run verification pass, across
 # every entry. Without a cap, a task with many failing converge objectives
 # burns entries x VERIFICATION_TIMEOUT_SEC; this bounds the pass as a whole.
 # Assert-mode entries still always run, since a safeguard that goes unchecked
 # defeats the point of having it.
-VERIFICATION_TOTAL_BUDGET_SEC = int(os.environ.get("BENCH_VERIFY_TOTAL_BUDGET_SEC", "600"))
+VERIFICATION_TOTAL_BUDGET_SEC = _positive_int_env("BENCH_VERIFY_TOTAL_BUDGET_SEC", 600)
 
 # Seconds to wait for the target Service's external LoadBalancer IP to be
 # assigned by the cloud provider's load balancer controller. LB provisioning

--- a/devops_bench/evalharness/scenario.py
+++ b/devops_bench/evalharness/scenario.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import contextlib
 import copy
+import os
 import socket
 import threading
 import time
@@ -55,14 +56,29 @@ _log = get_logger("evalharness.scenario")
 # Per-entry budget for a converging entry: how long a single entry's (possibly
 # nested) checks may poll before giving up. Assert-mode entries ignore this,
 # since single_shot always evaluates once with a zero budget regardless.
-VERIFICATION_TIMEOUT_SEC = 120
+#
+# WHAT THIS BUDGET IS ACTUALLY FOR. Verification only ever runs AFTER the agent
+# has exited, so the only thing still changing the cluster is Kubernetes' own
+# controllers finishing whatever the agent's last action started. That is usually
+# seconds: a rollout completing, endpoints populating, a pod going Ready. But not
+# always: image pulls, PVC binding, and rollouts that have to pull can legitimately
+# take much longer, so the default stays at 120.
+#
+# The total budget below matters more than this per-entry timeout. It bounds the
+# whole pass, and if early entries consume it the later ones are starved and
+# report "evaluation did not complete before the deadline" without having
+# meaningfully run, which reads as a failed check rather than as an unmeasured one.
+#
+# Both are overridable via BENCH_VERIFY_TIMEOUT_SEC and BENCH_VERIFY_TOTAL_BUDGET_SEC
+# for tuning without a code change.
+VERIFICATION_TIMEOUT_SEC = int(os.environ.get("BENCH_VERIFY_TIMEOUT_SEC", "120"))
 
 # Total wall-clock budget for the whole post-run verification pass, across
 # every entry. Without a cap, a task with many failing converge objectives
-# burns entries x VERIFICATION_TIMEOUT_SEC (12 entries x 120s is 22+ minutes);
-# this bounds the pass as a whole. Assert-mode entries still always run, since
-# a safeguard that goes unchecked defeats the point of having it.
-VERIFICATION_TOTAL_BUDGET_SEC = 600
+# burns entries x VERIFICATION_TIMEOUT_SEC; this bounds the pass as a whole.
+# Assert-mode entries still always run, since a safeguard that goes unchecked
+# defeats the point of having it.
+VERIFICATION_TOTAL_BUDGET_SEC = int(os.environ.get("BENCH_VERIFY_TOTAL_BUDGET_SEC", "600"))
 
 # Seconds to wait for the target Service's external LoadBalancer IP to be
 # assigned by the cloud provider's load balancer controller. LB provisioning

--- a/tests/unit/evalharness/test_scenario.py
+++ b/tests/unit/evalharness/test_scenario.py
@@ -246,9 +246,7 @@ def test_scenario_resolves_verify_against_mapping() -> None:
     # ``check`` node) flowed straight to the VerifierAgent: the lookup is O(1),
     # never imports verification on the chaos side, and the entry's resolved
     # mode (converge vs assert) governs the check.
-    mock_run_entry.assert_called_once_with(
-        verification_entry, timeout_sec=VERIFICATION_TIMEOUT_SEC
-    )
+    mock_run_entry.assert_called_once_with(verification_entry, timeout_sec=VERIFICATION_TIMEOUT_SEC)
 
     chaos_report, perf_report = manager.get_reports()
     assert chaos_report["verification"]["success"] is True

--- a/tests/unit/evalharness/test_scenario.py
+++ b/tests/unit/evalharness/test_scenario.py
@@ -33,10 +33,12 @@ import pytest
 from devops_bench.chaos import ChaosResult, ChaosSpec
 from devops_bench.chaos.faults.generate_load import GenerateLoadFault
 from devops_bench.chaos.triggers.time_delay import TimeTrigger
+from devops_bench.core import ConfigError
 from devops_bench.core.context import RunContext
 from devops_bench.evalharness.scenario import (
     VERIFICATION_TIMEOUT_SEC,
     ScenarioManager,
+    _positive_int_env,
     pick_free_port,
 )
 from devops_bench.verification import VerificationResult, VerifierAgent
@@ -630,6 +632,41 @@ def test_scenario_skips_lb_resolution_for_local_cluster() -> None:
     assert _ENV_SKIP_PORT_FORWARD not in captured["env"]
     assert captured["env"][_ENV_TARGET_DEPLOYMENT] == "dep"
     assert captured["env"][_ENV_TARGET_NAMESPACE] == "ns"
+
+
+def test_positive_int_env_parses_valid_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BENCH_VERIFY_TIMEOUT_SEC", "45")
+    assert _positive_int_env("BENCH_VERIFY_TIMEOUT_SEC", 120) == 45
+
+
+def test_positive_int_env_unset_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BENCH_VERIFY_TIMEOUT_SEC", raising=False)
+    assert _positive_int_env("BENCH_VERIFY_TIMEOUT_SEC", 120) == 120
+
+
+def test_positive_int_env_unset_falls_back_to_default_for_total_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("BENCH_VERIFY_TOTAL_BUDGET_SEC", raising=False)
+    assert _positive_int_env("BENCH_VERIFY_TOTAL_BUDGET_SEC", 600) == 600
+
+
+def test_positive_int_env_non_numeric_raises_config_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BENCH_VERIFY_TIMEOUT_SEC", "not-a-number")
+    with pytest.raises(ConfigError, match="BENCH_VERIFY_TIMEOUT_SEC"):
+        _positive_int_env("BENCH_VERIFY_TIMEOUT_SEC", 120)
+
+
+def test_positive_int_env_zero_raises_config_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BENCH_VERIFY_TOTAL_BUDGET_SEC", "0")
+    with pytest.raises(ConfigError, match="BENCH_VERIFY_TOTAL_BUDGET_SEC"):
+        _positive_int_env("BENCH_VERIFY_TOTAL_BUDGET_SEC", 600)
+
+
+def test_positive_int_env_negative_raises_config_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BENCH_VERIFY_TIMEOUT_SEC", "-5")
+    with pytest.raises(ConfigError, match="BENCH_VERIFY_TIMEOUT_SEC"):
+        _positive_int_env("BENCH_VERIFY_TIMEOUT_SEC", 120)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/evalharness/test_scenario.py
+++ b/tests/unit/evalharness/test_scenario.py
@@ -34,7 +34,11 @@ from devops_bench.chaos import ChaosResult, ChaosSpec
 from devops_bench.chaos.faults.generate_load import GenerateLoadFault
 from devops_bench.chaos.triggers.time_delay import TimeTrigger
 from devops_bench.core.context import RunContext
-from devops_bench.evalharness.scenario import ScenarioManager, pick_free_port
+from devops_bench.evalharness.scenario import (
+    VERIFICATION_TIMEOUT_SEC,
+    ScenarioManager,
+    pick_free_port,
+)
 from devops_bench.verification import VerificationResult, VerifierAgent
 from devops_bench.verification.base import VERIFIERS, BaseVerifier
 from devops_bench.verification.spec import parse_entries
@@ -242,7 +246,9 @@ def test_scenario_resolves_verify_against_mapping() -> None:
     # ``check`` node) flowed straight to the VerifierAgent: the lookup is O(1),
     # never imports verification on the chaos side, and the entry's resolved
     # mode (converge vs assert) governs the check.
-    mock_run_entry.assert_called_once_with(verification_entry, timeout_sec=120)
+    mock_run_entry.assert_called_once_with(
+        verification_entry, timeout_sec=VERIFICATION_TIMEOUT_SEC
+    )
 
     chaos_report, perf_report = manager.get_reports()
     assert chaos_report["verification"]["success"] is True


### PR DESCRIPTION
The per-check timeout and the total verification budget were hardcoded, which made them impossible to adjust for a slow cluster or a task with a genuinely long convergence window.

The practical failure was a task timing out during verification and reporting a failure that was really just an impatient budget. Tuning it required editing the source.

Both values are now readable from the environment, with the existing values as defaults so behavior is unchanged unless a run opts in.