### PR TITLE
feat(verification): add the subject_access_review verifier

### DIFF
--- a/devops_bench/core/context.py
+++ b/devops_bench/core/context.py
@@ -51,12 +51,19 @@ class ClusterInfo:
         project: Cloud project; None for local clusters.
         kubeconfig_path: Kubeconfig path; resolved from ``KUBECONFIG`` or
             ``~/.kube/config`` when not supplied.
+        context: Kubeconfig context naming this specific cluster (e.g.
+            ``kind-<cluster>`` or ``gke_<project>_<location>_<cluster>``).
+            A kubeconfig file alone does not pin a cluster: it can carry
+            several contexts, or none selected as current. ``None`` when the
+            provider could not resolve one, in which case callers fall back
+            to the ambient current-context.
     """
 
     name: str
     location: str | None = None
     project: str | None = None
     kubeconfig_path: str = field(default_factory=_resolve_kubeconfig)
+    context: str | None = None
 
     @classmethod
     def from_dict(cls, info: dict[str, Any]) -> ClusterInfo:
@@ -64,7 +71,7 @@ class ClusterInfo:
 
         Args:
             info: Mapping with a required ``name`` and optional ``location``,
-                ``project``, and ``kubeconfig_path``.
+                ``project``, ``kubeconfig_path``, and ``context``.
 
         Returns:
             The constructed instance, with ``kubeconfig_path`` resolved when absent.
@@ -74,6 +81,7 @@ class ClusterInfo:
             location=info.get("location"),
             project=info.get("project"),
             kubeconfig_path=_resolve_kubeconfig(info.get("kubeconfig_path")),
+            context=info.get("context"),
         )
 
 

--- a/devops_bench/evalharness/default.py
+++ b/devops_bench/evalharness/default.py
@@ -57,6 +57,7 @@ from devops_bench.evalharness.scenario import (
 from devops_bench.tasks import Task
 from devops_bench.verification import (
     MIN_LEAF_BUDGET_SECONDS,
+    BaseVerifier,
     VerificationEntry,
     VerifierAgent,
     parse_entries,
@@ -121,6 +122,60 @@ def _ensure_builtin_agents_registered() -> None:
             # raise a clear ``NotRegisteredError`` later if the user selects
             # an agent whose module did not load.
             _log.debug("optional agent module %s not importable: %s", module, exc)
+
+
+def _pin_verifier_leaves(node: Any, kubeconfig: str | None, context: str | None) -> None:
+    """Set ``kubeconfig``/``context`` on every leaf verifier under ``node``, recursively.
+
+    A leaf (``BaseVerifier``) is pinned directly. A compound node (sequence,
+    parallel, any, none) has no cluster identity of its own, so this recurses
+    into its ``checks`` instead of touching it.
+
+    Args:
+        node: A parsed verification spec node: a leaf verifier or a compound
+            node exposing ``checks``.
+        kubeconfig: Resolved kubeconfig path, or None to leave the verifier's
+            existing (usually unset) value alone.
+        context: Resolved kubeconfig context, or None to leave the verifier's
+            existing value alone.
+    """
+    if isinstance(node, BaseVerifier):
+        if kubeconfig is not None:
+            node.kubeconfig = kubeconfig
+        if context is not None:
+            node.context = context
+        return
+    for child in getattr(node, "checks", []):
+        _pin_verifier_leaves(child, kubeconfig, context)
+
+
+def _pin_verification_targets(
+    entries: list[VerificationEntry], kubeconfig: str | None, context: str | None
+) -> None:
+    """Pin every entry's verifier leaves to the run's own cluster.
+
+    Verifiers otherwise carry no cluster identity and fall through to
+    whatever the host's ambient kubeconfig current-context happens to be,
+    which is not necessarily the cluster this run just provisioned and the
+    agent just acted on. Called once, right after the entries are parsed, so
+    both the background chaos scenario's checks and the post-run
+    verification pass (which share these same entry objects) are pinned.
+
+    Args:
+        entries: The task's parsed verification entries, mutated in place.
+        kubeconfig: Resolved kubeconfig path for the run's cluster.
+        context: Resolved kubeconfig context for the run's cluster, or None
+            when it could not be resolved (verification then runs unpinned
+            against whatever context is ambient).
+    """
+    if context is None:
+        _log.warning(
+            "no kubeconfig context resolved for this run's cluster; verification "
+            "will run unpinned and may target the wrong cluster if the ambient "
+            "kubeconfig's current-context does not point at it"
+        )
+    for entry in entries:
+        _pin_verifier_leaves(entry.check, kubeconfig, context)
 
 
 class DefaultEvalHarness(Harness):
@@ -767,6 +822,15 @@ class DefaultEvalHarness(Harness):
                     len(verification_parse_errors),
                     verification_parse_errors,
                 )
+            # Pin every verifier leaf to this run's own cluster before anything
+            # evaluates a check, so a stray ambient current-context (or none
+            # selected at all) cannot make verification silently read a
+            # different cluster than the one the agent just acted on. This
+            # deliberately keeps the operator's admin credential
+            # (``cluster_info.kubeconfig_path`` / ``.context``) rather than the
+            # agent's own scoped ``/workspace/kubeconfig``: verification must be
+            # able to observe state the agent could not itself have written.
+            _pin_verification_targets(entries, cluster_info.kubeconfig_path, cluster_info.context)
             verification_mapping = {entry.name: entry for entry in entries}
 
             # Hand the background scenario its own context with an isolated

--- a/devops_bench/k8s/__init__.py
+++ b/devops_bench/k8s/__init__.py
@@ -17,6 +17,7 @@
 from devops_bench.k8s.conditions import poll_until
 from devops_bench.k8s.kubectl import (
     apply,
+    can_i,
     get_resource,
     port_forward,
     rollout_status,
@@ -25,6 +26,7 @@ from devops_bench.k8s.kubectl import (
 
 __all__ = [
     "apply",
+    "can_i",
     "get_resource",
     "poll_until",
     "port_forward",

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -75,12 +75,27 @@ def _selector_args(selector: str | None) -> list[str]:
     return ["-l", selector] if selector else []
 
 
-def _run_kubectl(argv: list[str], kubeconfig: KubeconfigSource, **kwargs: Any) -> CompletedProcess:
+def _context_args(context: str | None) -> list[str]:
+    return ["--context", context] if context else []
+
+
+def _run_kubectl(
+    argv: list[str],
+    kubeconfig: KubeconfigSource,
+    *,
+    context: str | None = None,
+    **kwargs: Any,
+) -> CompletedProcess:
     """Run ``kubectl`` with the resolved kubeconfig overlaid on the environment.
 
     Args:
         argv: Full kubectl command and arguments, never a shell string.
         kubeconfig: Explicit path, a ``KubeconfigProvider``, or None.
+        context: Optional kubeconfig context to pin the call to (``--context``).
+            Pinning the file alone is not enough: a kubeconfig can carry
+            several contexts, or none selected as current, and an unpinned
+            context means the call silently reads whichever cluster the
+            ambient current-context happens to point at.
         **kwargs: Extra keyword arguments forwarded to ``core.subprocess.run``
             (e.g. ``timeout``).
 
@@ -92,7 +107,7 @@ def _run_kubectl(argv: list[str], kubeconfig: KubeconfigSource, **kwargs: Any) -
     """
     path = _resolve_kubeconfig(kubeconfig)
     extra_env = {"KUBECONFIG": path} if path else None
-    return run(argv, extra_env=extra_env, **kwargs)
+    return run([*argv, *_context_args(context)], extra_env=extra_env, **kwargs)
 
 
 def wait(
@@ -103,6 +118,7 @@ def wait(
     timeout_sec: float,
     namespace: str | None = None,
     kubeconfig: KubeconfigSource = None,
+    context: str | None = None,
 ) -> CompletedProcess:
     """Block until a resource satisfies a condition via ``kubectl wait``.
 
@@ -113,6 +129,7 @@ def wait(
         timeout_sec: Maximum seconds to wait (``--timeout=<n>s``).
         namespace: Optional namespace (``-n``).
         kubeconfig: Kubeconfig path or context-like object.
+        context: Optional kubeconfig context to pin the call to.
 
     Returns:
         The completed process.
@@ -129,7 +146,7 @@ def wait(
         f"--timeout={timeout_sec}s",
         *_namespace_args(namespace),
     ]
-    return _run_kubectl(argv, kubeconfig)
+    return _run_kubectl(argv, kubeconfig, context=context)
 
 
 def get_resource(
@@ -140,6 +157,7 @@ def get_resource(
     namespace: str | None = None,
     kubeconfig: KubeconfigSource = None,
     timeout: float | None = None,
+    context: str | None = None,
 ) -> dict[str, Any]:
     """Fetch a resource (or list) as parsed JSON via ``kubectl get -o json``.
 
@@ -152,6 +170,7 @@ def get_resource(
         timeout: Optional seconds before the subprocess is killed. ``None``
             (the default) blocks indefinitely, so pass one whenever the API
             server might accept a connection and never respond.
+        context: Optional kubeconfig context to pin the call to.
 
     Returns:
         The parsed JSON document.
@@ -170,7 +189,7 @@ def get_resource(
         "json",
         *_namespace_args(namespace),
     ]
-    completed = _run_kubectl(argv, kubeconfig, timeout=timeout)
+    completed = _run_kubectl(argv, kubeconfig, timeout=timeout, context=context)
     return json.loads(completed.stdout)
 
 
@@ -179,6 +198,7 @@ def apply(
     *,
     namespace: str | None = None,
     kubeconfig: KubeconfigSource = None,
+    context: str | None = None,
 ) -> CompletedProcess:
     """Apply a manifest file or directory via ``kubectl apply -f``.
 
@@ -186,6 +206,7 @@ def apply(
         path: Manifest file, directory, or URL passed to ``-f``.
         namespace: Optional namespace (``-n``).
         kubeconfig: Kubeconfig path or context-like object.
+        context: Optional kubeconfig context to pin the call to.
 
     Returns:
         The completed process.
@@ -194,7 +215,7 @@ def apply(
         SubprocessError: If kubectl exits non-zero or times out.
     """
     argv = ["kubectl", "apply", "-f", path, *_namespace_args(namespace)]
-    return _run_kubectl(argv, kubeconfig)
+    return _run_kubectl(argv, kubeconfig, context=context)
 
 
 def rollout_status(
@@ -203,6 +224,7 @@ def rollout_status(
     timeout_sec: float | None = None,
     namespace: str | None = None,
     kubeconfig: KubeconfigSource = None,
+    context: str | None = None,
 ) -> CompletedProcess:
     """Wait for a rollout to finish via ``kubectl rollout status``.
 
@@ -211,6 +233,7 @@ def rollout_status(
         timeout_sec: Optional maximum seconds to wait (``--timeout=<n>s``).
         namespace: Optional namespace (``-n``).
         kubeconfig: Kubeconfig path or context-like object.
+        context: Optional kubeconfig context to pin the call to.
 
     Returns:
         The completed process.
@@ -226,7 +249,7 @@ def rollout_status(
         *([f"--timeout={timeout_sec}s"] if timeout_sec is not None else []),
         *_namespace_args(namespace),
     ]
-    return _run_kubectl(argv, kubeconfig)
+    return _run_kubectl(argv, kubeconfig, context=context)
 
 
 @contextlib.contextmanager
@@ -238,6 +261,7 @@ def port_forward(
     namespace: str | None = None,
     settle_sec: float = _PORT_FORWARD_SETTLE_SEC,
     kubeconfig: KubeconfigSource = None,
+    context: str | None = None,
 ) -> Iterator[None]:
     """Hold a ``kubectl port-forward`` open for the duration of the ``with`` body.
 
@@ -256,6 +280,7 @@ def port_forward(
         namespace: Optional namespace (``-n``).
         settle_sec: Seconds to wait for the tunnel to establish before yielding.
         kubeconfig: Kubeconfig path or context-like object.
+        context: Optional kubeconfig context to pin the call to.
 
     Yields:
         ``None`` once the tunnel has had time to settle.
@@ -271,6 +296,7 @@ def port_forward(
         target,
         f"{local_port}:{remote}",
         *_namespace_args(namespace),
+        *_context_args(context),
     ]
     path = _resolve_kubeconfig(kubeconfig)
     # Reuse core.subprocess env semantics so this Popen path never drifts from

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -28,6 +28,7 @@ from devops_bench.core.subprocess import CompletedProcess, _build_env, run
 
 __all__ = [
     "apply",
+    "can_i",
     "get_resource",
     "port_forward",
     "rollout_status",
@@ -191,6 +192,58 @@ def get_resource(
     ]
     completed = _run_kubectl(argv, kubeconfig, timeout=timeout, context=context)
     return json.loads(completed.stdout)
+
+
+def can_i(
+    verb: str,
+    resource: str,
+    *,
+    subject: str,
+    name: str | None = None,
+    namespace: str | None = None,
+    kubeconfig: KubeconfigSource = None,
+    context: str | None = None,
+    timeout: float | None = None,
+) -> CompletedProcess:
+    """Run ``kubectl auth can-i`` and return the completed process uninterpreted.
+
+    ``kubectl auth can-i`` exits 0 with stdout ``"yes"`` when the check is
+    allowed and exits 1 with stdout ``"no"`` when it is denied -- neither is a
+    command failure, so this call passes ``check=False`` and leaves
+    interpreting the exit code and stdout to the caller. A real failure (a bad
+    flag, an unreachable API server) still shows up here as stdout other than
+    ``"yes"``/``"no"``, which is how the caller tells it apart from a denied
+    check.
+
+    Args:
+        verb: Verb to check, e.g. ``"get"``, ``"update"``.
+        resource: Resource type to check, e.g. ``"deployments"``.
+        subject: Full ``--as`` value, e.g. ``"system:serviceaccount:ns:name"``.
+        name: Optional specific resource name, appended as ``"<resource>/<name>"``.
+        namespace: Optional namespace (``-n``).
+        kubeconfig: Kubeconfig path or context-like object.
+        context: Optional kubeconfig context to pin the call to.
+        timeout: Optional seconds before the subprocess is killed.
+
+    Returns:
+        The completed process, exit code and stdout uninterpreted.
+
+    Raises:
+        SubprocessError: If the command times out (never on a non-zero exit,
+            since a denied check exits 1 by design).
+    """
+    resource_arg = f"{resource}/{name}" if name else resource
+    argv = [
+        "kubectl",
+        "auth",
+        "can-i",
+        verb,
+        resource_arg,
+        *_namespace_args(namespace),
+        "--as",
+        subject,
+    ]
+    return _run_kubectl(argv, kubeconfig, context=context, timeout=timeout, check=False)
 
 
 def apply(

--- a/devops_bench/metrics/pipeline.py
+++ b/devops_bench/metrics/pipeline.py
@@ -152,12 +152,37 @@ def _finalize_outcome_score(scores: dict[str, Any]) -> None:
     recoverable sources emit a raw pass fraction; the ``[0.1, 1.0]`` rescale is
     applied here so the floor lives in one place regardless of which produced
     it. Records with no correctness signal at all (e.g. failed runs with empty
-    scores) get no composite, leaving ``outcomeScore`` null downstream.
+    scores) get no composite, leaving ``outcomeScore`` null downstream. A
+    record where deterministic verification was declared but every entry
+    errored also gets no composite, for the same reason: see the coverage
+    check below.
 
     Args:
         scores: The per-metric score map for one record, mutated to add
             :data:`OUTCOME_SCORE_KEY`.
     """
+    # ``VerificationCoverage`` is emitted unconditionally whenever the task
+    # declared deterministic verification (see ``VerificationMetric.applies``),
+    # even when every entry errored and ``VerificationCorrectness`` therefore
+    # never gets emitted. Its presence without a correctness score means
+    # verification was attempted and produced nothing, not that nothing was
+    # declared. An errored check is an unmeasured objective, not a satisfied
+    # one: falling through to the judged keys in that case would let a judge's
+    # reading of prose stand in for a deterministic check that failed to run,
+    # making a totally broken verification pass indistinguishable from a clean
+    # sweep. So this case is withheld rather than routed through the fallback
+    # chain below, which exists only for tasks that declared no deterministic
+    # verification at all.
+    if score_keys.VERIFICATION_COVERAGE_KEY in scores and (
+        _score_value(scores.get(score_keys.VERIFICATION_CORRECTNESS_KEY)) is None
+    ):
+        _log.warning(
+            "Withholding composite outcome score: deterministic verification "
+            "was declared but produced no correctness signal (see "
+            "VerificationCoverage)."
+        )
+        return
+
     correctness = _first_score(scores, _CORRECTNESS_KEYS)
     if correctness is None:
         return

--- a/devops_bench/providers/gcp.py
+++ b/devops_bench/providers/gcp.py
@@ -50,7 +50,9 @@ class GcpProvider(Provider):
             variables: OpenTofu input variables the cluster was provisioned with.
 
         Returns:
-            The cluster's :class:`~devops_bench.core.ClusterInfo`.
+            The cluster's :class:`~devops_bench.core.ClusterInfo`, carrying
+            the ``gke_<project>_<location>_<cluster>`` context ``gcloud``
+            wrote into the kubeconfig.
 
         Raises:
             ConfigError: If no project is resolvable from ``variables`` or the
@@ -99,7 +101,12 @@ class GcpProvider(Provider):
             )
 
         return ClusterInfo.from_dict(
-            {"name": cluster_name, "location": location, "project": project}
+            {
+                "name": cluster_name,
+                "location": location,
+                "project": project,
+                "context": context_name,
+            }
         )
 
     def resolve_variables(

--- a/devops_bench/providers/kind.py
+++ b/devops_bench/providers/kind.py
@@ -47,7 +47,10 @@ class KindProvider(Provider):
 
         Returns:
             The cluster's :class:`~devops_bench.core.ClusterInfo`; ``project``
-            falls back to ``local-kind`` when none is set.
+            falls back to ``local-kind`` when none is set. ``context`` is the
+            standard ``kind-<cluster_name>`` KinD writes into the kubeconfig,
+            matching what ``devops_bench.agents.sandbox`` already assumes when
+            it strips the ``kind-`` prefix.
         """
         project = variables.get("project_id") or _LOCAL_PROJECT
         return ClusterInfo.from_dict(
@@ -56,6 +59,7 @@ class KindProvider(Provider):
                 "location": location,
                 "project": project,
                 "kubeconfig_path": variables.get("kubeconfig_path"),
+                "context": f"kind-{cluster_name}",
             }
         )
 

--- a/devops_bench/verification/base.py
+++ b/devops_bench/verification/base.py
@@ -161,6 +161,11 @@ class BaseVerifier(BaseModel, ABC):
         kubeconfig: Optional path to a kubeconfig file, forwarded to the
             ``devops_bench.k8s`` wrappers so a check can target a specific
             cluster. When ``None`` the wrappers use the ambient kubeconfig.
+        context: Optional kubeconfig context, forwarded alongside
+            ``kubeconfig`` so a check pins the exact cluster rather than
+            whichever context the kubeconfig file happens to have selected as
+            current (or none). When ``None`` the wrappers use the ambient
+            current-context.
     """
 
     # Reject any key the concrete verifier does not declare. A typo'd or
@@ -170,6 +175,7 @@ class BaseVerifier(BaseModel, ABC):
 
     name: str | None = None
     kubeconfig: str | None = None
+    context: str | None = None
 
     @abstractmethod
     def verify(self, timeout_sec: float) -> VerificationResult:

--- a/devops_bench/verification/verifiers/__init__.py
+++ b/devops_bench/verification/verifiers/__init__.py
@@ -19,9 +19,15 @@ from devops_bench.verification.verifiers.resource_property import (
     ResourcePropertyVerifier,
 )
 from devops_bench.verification.verifiers.scaling_complete import ScalingCompleteVerifier
+from devops_bench.verification.verifiers.subject_access_review import (
+    SubjectAccessReviewSweepVerifier,
+    SubjectAccessReviewVerifier,
+)
 
 __all__ = [
     "PodHealthyVerifier",
     "ResourcePropertyVerifier",
     "ScalingCompleteVerifier",
+    "SubjectAccessReviewSweepVerifier",
+    "SubjectAccessReviewVerifier",
 ]

--- a/devops_bench/verification/verifiers/pod_healthy.py
+++ b/devops_bench/verification/verifiers/pod_healthy.py
@@ -70,6 +70,7 @@ class PodHealthyVerifier(BaseVerifier):
                 timeout_sec=single_call_timeout(timeout_sec),
                 namespace=self.namespace,
                 kubeconfig=self.kubeconfig,
+                context=self.context,
             )
             return VerificationResult(
                 success=True,
@@ -127,6 +128,7 @@ class PodHealthyVerifier(BaseVerifier):
                 selector=self.selector,
                 namespace=self.namespace,
                 kubeconfig=self.kubeconfig,
+                context=self.context,
                 timeout=single_call_timeout(timeout_sec),
             )
         except Exception as exc:  # noqa: BLE001 - diagnostics path, never raises

--- a/devops_bench/verification/verifiers/resource_property.py
+++ b/devops_bench/verification/verifiers/resource_property.py
@@ -375,6 +375,7 @@ class ResourcePropertyVerifier(BaseVerifier):
                 selector=self.selector,
                 namespace=self.namespace,
                 kubeconfig=self.kubeconfig,
+                context=self.context,
                 timeout=single_call_timeout(timeout_sec),
             )
         except Exception as exc:  # noqa: BLE001 - a kubectl failure is a check error

--- a/devops_bench/verification/verifiers/scaling_complete.py
+++ b/devops_bench/verification/verifiers/scaling_complete.py
@@ -110,6 +110,7 @@ class ScalingCompleteVerifier(BaseVerifier):
                 self.deployment,
                 namespace=self.namespace,
                 kubeconfig=self.kubeconfig,
+                context=self.context,
                 timeout=single_call_timeout(timeout_sec),
             )
         except SubprocessError as exc:

--- a/devops_bench/verification/verifiers/subject_access_review.py
+++ b/devops_bench/verification/verifiers/subject_access_review.py
@@ -1,0 +1,295 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verify a subject's live authorization via ``kubectl auth can-i --as``.
+
+Two shapes, both backed by :func:`devops_bench.k8s.can_i`:
+
+* :class:`SubjectAccessReviewVerifier` -- a single (verb, resource[, name])
+  point check against an expected allowed/denied outcome.
+* :class:`SubjectAccessReviewSweepVerifier` -- a whole matrix of (verb,
+  resource) pairs that must ALL match one expected outcome (``all_denied`` or
+  ``all_allowed``). Every cell is checked and compared exactly: an unexpected
+  ALLOW under ``all_denied`` fails the sweep just as much as an unexpected
+  DENY under ``all_allowed`` would -- this is what makes the sweep catch an
+  agent that "fixes" an access gap by over-granting instead of granting the
+  exact permission asked for.
+
+Both subjects are ServiceAccounts, qualified as
+``system:serviceaccount:<namespace>:<name>`` for ``--as``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from devops_bench.core import SubprocessError, get_logger
+from devops_bench.k8s import can_i
+from devops_bench.verification.base import (
+    VERIFIERS,
+    BaseVerifier,
+    VerificationResult,
+    VerificationStatus,
+    single_call_timeout,
+)
+
+__all__ = ["SubjectAccessReviewSweepVerifier", "SubjectAccessReviewVerifier"]
+
+_log = get_logger("verification.subject_access_review")
+
+
+def _as_subject(namespace: str, name: str) -> str:
+    return f"system:serviceaccount:{namespace}:{name}"
+
+
+def _describe_resource(resource: str, name: str | None) -> str:
+    return f"{resource}/{name}" if name else resource
+
+
+def _run_can_i(
+    *,
+    verb: str,
+    resource: str,
+    name: str | None,
+    check_namespace: str,
+    subject_namespace: str,
+    subject: str,
+    kubeconfig: str | None,
+    context: str | None,
+    timeout_sec: float,
+) -> tuple[str | None, str | None]:
+    """Run ``kubectl auth can-i`` and classify the outcome.
+
+    Returns ``(observed, error_detail)``, exactly one of which is not None:
+    ``observed`` (``"allowed"`` or ``"denied"``) on a clean yes/no answer, or
+    ``error_detail`` when the call could not be interpreted as one (a real
+    command error, e.g. a bad flag or an unreachable API server).
+    """
+    try:
+        completed = can_i(
+            verb,
+            resource,
+            subject=_as_subject(subject_namespace, subject),
+            name=name,
+            namespace=check_namespace,
+            kubeconfig=kubeconfig,
+            context=context,
+            timeout=single_call_timeout(timeout_sec),
+        )
+    except SubprocessError as exc:
+        detail = (exc.stderr or exc.stdout or "").strip() or str(exc)
+        return None, detail
+    stdout = (completed.stdout or "").strip()
+    if stdout == "yes":
+        return "allowed", None
+    if stdout == "no":
+        return "denied", None
+    stderr = (completed.stderr or "").strip()
+    detail = stderr or stdout or f"unexpected output (exit {completed.returncode})"
+    return None, detail
+
+
+@VERIFIERS.register("subject_access_review")
+class SubjectAccessReviewVerifier(BaseVerifier):
+    """Verify a single point authorization check via ``kubectl auth can-i``.
+
+    Confirms whether ``subject`` (a ServiceAccount in ``namespace``) is allowed
+    or denied a single (verb, resource[, name]) operation in ``namespace``.
+
+    Attributes:
+        type: Discriminator literal, always ``"subject_access_review"``.
+        subject: ServiceAccount name; its own namespace is ``namespace``.
+        namespace: Namespace hosting ``subject``, and the namespace the
+            (verb, resource) check runs against.
+        verb: Verb to check, e.g. ``"get"``, ``"update"``.
+        resource: Resource type to check, e.g. ``"deployments"``.
+        name: Optional specific resource name.
+        op: Comparison operator; only ``"eq"`` is supported.
+        value: Expected outcome, ``"allowed"`` or ``"denied"``.
+    """
+
+    type: Literal["subject_access_review"] = "subject_access_review"
+    subject: str
+    namespace: str
+    verb: str
+    resource: str
+    name: str | None = None
+    op: Literal["eq"] = "eq"
+    value: Literal["allowed", "denied"]
+
+    def verify(self, timeout_sec: float) -> VerificationResult:
+        """Poll until the check reports the expected outcome or time runs out."""
+        return self._poll_to_result(lambda: self._check(timeout_sec), timeout_sec)
+
+    def _check(self, timeout_sec: float) -> tuple[VerificationStatus, str, dict[str, Any] | None]:
+        observed, error = _run_can_i(
+            verb=self.verb,
+            resource=self.resource,
+            name=self.name,
+            check_namespace=self.namespace,
+            subject_namespace=self.namespace,
+            subject=self.subject,
+            kubeconfig=self.kubeconfig,
+            context=self.context,
+            timeout_sec=timeout_sec,
+        )
+        subject_desc = _as_subject(self.namespace, self.subject)
+        resource_desc = _describe_resource(self.resource, self.name)
+        if observed is None:
+            _log.warning("can-i check failed for %s: %s", subject_desc, error)
+            return (
+                "error",
+                f"can-i {self.verb} {resource_desc} -n {self.namespace} --as {subject_desc} "
+                f"failed: {error}",
+                None,
+            )
+        raw = {
+            "subject": subject_desc,
+            "verb": self.verb,
+            "resource": resource_desc,
+            "namespace": self.namespace,
+            "expected": self.value,
+            "observed": observed,
+        }
+        if observed == self.value:
+            return (
+                "pass",
+                f"{subject_desc} is {observed} to {self.verb} {resource_desc} in "
+                f"{self.namespace}, as expected",
+                raw,
+            )
+        return (
+            "fail",
+            f"{subject_desc} expected {self.value} to {self.verb} {resource_desc} in "
+            f"{self.namespace}, observed {observed}",
+            raw,
+        )
+
+
+class _SweepPair(BaseModel):
+    """One (verb, resource) cell of a :class:`SubjectAccessReviewSweepVerifier`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    verb: str
+    resource: str
+    namespace: str | None = None
+    name: str | None = None
+
+
+@VERIFIERS.register("subject_access_review_sweep")
+class SubjectAccessReviewSweepVerifier(BaseVerifier):
+    """Verify a whole matrix of authorization checks for one subject.
+
+    Every (verb, resource) pair in ``pairs`` must match the single expected
+    outcome ``op`` implies -- ``"all_denied"`` requires every pair to be
+    denied, ``"all_allowed"`` requires every pair to be allowed. Every cell is
+    checked and compared exactly, in both directions: under ``"all_denied"``,
+    an unexpected ALLOW fails the sweep exactly like a missing DENY would.
+
+    Attributes:
+        type: Discriminator literal, always ``"subject_access_review_sweep"``.
+        subject: ServiceAccount name; its own namespace is ``namespace``.
+        namespace: Namespace hosting ``subject``. A pair without its own
+            ``namespace`` is checked here.
+        pairs: (verb, resource) pairs to check, each either a flat
+            ``[verb, resource]`` 2-tuple or a
+            ``{verb, resource, namespace?, name?}`` mapping.
+        op: ``"all_denied"`` or ``"all_allowed"``.
+    """
+
+    type: Literal["subject_access_review_sweep"] = "subject_access_review_sweep"
+    subject: str
+    namespace: str
+    pairs: list[_SweepPair] = Field(min_length=1)
+    op: Literal["all_denied", "all_allowed"]
+
+    @field_validator("pairs", mode="before")
+    @classmethod
+    def _normalize_pairs(cls, value: Any) -> Any:
+        """Accept a flat ``[verb, resource]`` 2-tuple alongside a full mapping."""
+        if not isinstance(value, list):
+            return value
+        normalized = []
+        for pair in value:
+            if isinstance(pair, (list, tuple)):
+                if len(pair) != 2:
+                    raise ValueError(
+                        f"flat sweep pair must have exactly 2 elements [verb, resource]; "
+                        f"got {pair!r}"
+                    )
+                normalized.append({"verb": pair[0], "resource": pair[1]})
+            else:
+                normalized.append(pair)
+        return normalized
+
+    def verify(self, timeout_sec: float) -> VerificationResult:
+        """Poll until every pair matches the expected outcome or time runs out."""
+        return self._poll_to_result(lambda: self._check(timeout_sec), timeout_sec)
+
+    def _check(self, timeout_sec: float) -> tuple[VerificationStatus, str, dict[str, Any] | None]:
+        expected = "allowed" if self.op == "all_allowed" else "denied"
+        subject_desc = _as_subject(self.namespace, self.subject)
+        cells: list[dict[str, Any]] = []
+        for pair in self.pairs:
+            check_namespace = pair.namespace or self.namespace
+            resource_desc = _describe_resource(pair.resource, pair.name)
+            observed, error = _run_can_i(
+                verb=pair.verb,
+                resource=pair.resource,
+                name=pair.name,
+                check_namespace=check_namespace,
+                subject_namespace=self.namespace,
+                subject=self.subject,
+                kubeconfig=self.kubeconfig,
+                context=self.context,
+                timeout_sec=timeout_sec,
+            )
+            if observed is None:
+                _log.warning("can-i sweep check failed for %s: %s", subject_desc, error)
+                return (
+                    "error",
+                    f"can-i {pair.verb} {resource_desc} -n {check_namespace} "
+                    f"--as {subject_desc} failed: {error}",
+                    {"subject": subject_desc, "op": self.op, "cells": cells},
+                )
+            cells.append(
+                {
+                    "verb": pair.verb,
+                    "resource": resource_desc,
+                    "namespace": check_namespace,
+                    "expected": expected,
+                    "observed": observed,
+                }
+            )
+        raw = {"subject": subject_desc, "op": self.op, "cells": cells}
+        mismatches = [c for c in cells if c["observed"] != expected]
+        if mismatches:
+            described = "; ".join(
+                f"{c['verb']} {c['resource']} in {c['namespace']} expected {c['expected']}, "
+                f"observed {c['observed']}"
+                for c in mismatches
+            )
+            return (
+                "fail",
+                f"{subject_desc}: {len(mismatches)}/{len(cells)} pair(s) mismatched: {described}",
+                raw,
+            )
+        return (
+            "pass",
+            f"{subject_desc}: all {len(cells)} pair(s) {expected}, as expected",
+            raw,
+        )

--- a/tests/unit/k8s/test_k8s_kubectl.py
+++ b/tests/unit/k8s/test_k8s_kubectl.py
@@ -147,6 +147,50 @@ def test_apply_builds_argv(mocker: MockerFixture) -> None:
     assert argv == ["kubectl", "apply", "-f", "/manifests/app.yaml", "-n", "staging"]
 
 
+def test_can_i_builds_argv_and_never_checks(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch(
+        "devops_bench.k8s.kubectl.run", return_value=_completed("no", returncode=1)
+    )
+
+    kubectl.can_i(
+        "delete",
+        "deployments",
+        subject="system:serviceaccount:apps:deployer",
+        namespace="apps",
+    )
+
+    argv = mock_run.call_args.args[0]
+    assert argv == [
+        "kubectl",
+        "auth",
+        "can-i",
+        "delete",
+        "deployments",
+        "-n",
+        "apps",
+        "--as",
+        "system:serviceaccount:apps:deployer",
+    ]
+    # A denied check exits 1 by design, not a command failure -- can_i must
+    # never raise on that, so it always calls run with check=False.
+    assert mock_run.call_args.kwargs["check"] is False
+
+
+def test_can_i_appends_resource_name(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed("yes"))
+
+    kubectl.can_i(
+        "get",
+        "secrets",
+        subject="system:serviceaccount:warehouse:inventory-sync",
+        name="inventory-sync-creds",
+        namespace="warehouse",
+    )
+
+    argv = mock_run.call_args.args[0]
+    assert "secrets/inventory-sync-creds" in argv
+
+
 def test_rollout_status_with_timeout(mocker: MockerFixture) -> None:
     mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
 

--- a/tests/unit/k8s/test_k8s_kubectl.py
+++ b/tests/unit/k8s/test_k8s_kubectl.py
@@ -203,6 +203,32 @@ def test_run_context_without_cluster_omits_kubeconfig(mocker: MockerFixture) -> 
     assert mock_run.call_args.kwargs["extra_env"] is None
 
 
+def test_wait_threads_context_into_argv(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+
+    kubectl.wait("pod", timeout_sec=10, kubeconfig="/tmp/kc", context="kind-devops-bench-kind")
+
+    argv = mock_run.call_args.args[0]
+    assert argv == [
+        "kubectl",
+        "wait",
+        "--for=condition=Ready",
+        "pod",
+        "--timeout=10s",
+        "--context",
+        "kind-devops-bench-kind",
+    ]
+
+
+def test_wait_without_context_omits_context_flag(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+
+    kubectl.wait("pod", timeout_sec=10, kubeconfig="/tmp/kc")
+
+    argv = mock_run.call_args.args[0]
+    assert "--context" not in argv
+
+
 def test_get_resource_propagates_invalid_json(mocker: MockerFixture) -> None:
     mocker.patch(
         "devops_bench.k8s.kubectl.run",

--- a/tests/unit/metrics/test_metrics_pipeline.py
+++ b/tests/unit/metrics/test_metrics_pipeline.py
@@ -677,6 +677,45 @@ def test_finalize_correctness_falls_back_to_outcome_validity() -> None:
     assert scores[pipeline.OUTCOME_SCORE_KEY]["score"] == 0.7
 
 
+def test_finalize_withholds_composite_when_verification_declared_but_errored(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Regression: an all-errored verification pass must not fall back to the judge.
+
+    ``VerificationCoverage`` is present (deterministic verification was
+    declared and attempted) but ``VerificationCorrectness`` never got emitted
+    (every entry errored). Previously this fell through to
+    ``OutcomeValidity``, letting a judge's 1.0 stand in for a totally broken
+    check; now no composite is written at all.
+    """
+    scores = {
+        "VerificationCoverage": {"score": 0.0, "success": False},
+        "OutcomeValidity": {"score": 1.0, "success": True},
+    }
+    with caplog.at_level("WARNING"):
+        pipeline._finalize_outcome_score(scores)  # noqa: SLF001
+    assert pipeline.OUTCOME_SCORE_KEY not in scores
+    assert "VerificationCoverage" in caplog.text
+
+
+def test_finalize_no_verification_declared_still_falls_back_to_judge() -> None:
+    """A task with no deterministic verification keeps the legitimate judged fallback."""
+    scores = {"OutcomeValidity": {"score": 0.9, "success": True}}
+    pipeline._finalize_outcome_score(scores)  # noqa: SLF001
+    assert scores[pipeline.OUTCOME_SCORE_KEY]["score"] == pytest.approx(0.9)
+
+
+def test_finalize_coverage_and_correctness_present_ignores_judge() -> None:
+    """Coverage plus a real correctness score composes from the deterministic value."""
+    scores = {
+        "VerificationCoverage": {"score": 1.0, "success": True},
+        "VerificationCorrectness": {"score": 1.0, "success": True},
+        "OutcomeValidity": {"score": 0.0, "success": False},
+    }
+    pipeline._finalize_outcome_score(scores)  # noqa: SLF001
+    assert scores[pipeline.OUTCOME_SCORE_KEY]["score"] == pytest.approx(1.0)
+
+
 def test_finalize_skips_when_no_correctness_signal() -> None:
     # Failed / unscored record: no composite is written (outcomeScore stays null).
     scores = {"ToolInvocation": {"score": 0.5, "success": True}}

--- a/tests/unit/verification/test_scaling_complete.py
+++ b/tests/unit/verification/test_scaling_complete.py
@@ -19,6 +19,8 @@ The poll function and kubectl primitives are stubbed; no real cluster work.
 
 from __future__ import annotations
 
+import json
+import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -161,6 +163,32 @@ def test_get_resource_is_called_with_a_floored_timeout(
         ScalingCompleteVerifier(deployment="web", min_replicas=1).verify(timeout_sec=timeout_sec)
 
     assert mock_get.call_args.kwargs["timeout"] == expected_timeout
+
+
+def test_context_is_forwarded_into_kubectl_argv() -> None:
+    # Goes all the way down to the real ``devops_bench.k8s.kubectl.run`` seam
+    # (rather than stubbing ``get_resource``) so the wiring from the
+    # verifier's own ``context`` field through to the ``kubectl`` argv is
+    # actually exercised, not just the verifier's own kwargs.
+    deployment = {"status": {"readyReplicas": 3}}
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=json.dumps(deployment))
+    with patch("devops_bench.k8s.kubectl.run", return_value=completed) as mock_run:
+        ScalingCompleteVerifier(
+            deployment="web", min_replicas=1, context="kind-devops-bench-kind"
+        ).verify(timeout_sec=5)
+
+    argv = mock_run.call_args.args[0]
+    assert argv[-2:] == ["--context", "kind-devops-bench-kind"]
+
+
+def test_no_context_omits_context_flag_from_kubectl_argv() -> None:
+    deployment = {"status": {"readyReplicas": 3}}
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=json.dumps(deployment))
+    with patch("devops_bench.k8s.kubectl.run", return_value=completed) as mock_run:
+        ScalingCompleteVerifier(deployment="web", min_replicas=1).verify(timeout_sec=5)
+
+    argv = mock_run.call_args.args[0]
+    assert "--context" not in argv
 
 
 def test_name_is_echoed_onto_result() -> None:

--- a/tests/unit/verification/test_subject_access_review.py
+++ b/tests/unit/verification/test_subject_access_review.py
@@ -1,0 +1,294 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``SubjectAccessReviewVerifier`` and its sweep sibling.
+
+``kubectl auth can-i`` is faked via a stubbed ``can_i``; no real cluster work.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from devops_bench.core import SubprocessError
+from devops_bench.verification.verifiers import (
+    SubjectAccessReviewSweepVerifier,
+    SubjectAccessReviewVerifier,
+)
+
+_MODULE = "devops_bench.verification.verifiers.subject_access_review"
+
+
+def _completed(stdout: str, returncode: int, stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# --- point checks -----------------------------------------------------------
+
+
+def test_allowed_and_expected_allowed_passes() -> None:
+    with patch(f"{_MODULE}.can_i", return_value=_completed("yes", 0)):
+        result = SubjectAccessReviewVerifier(
+            subject="deployer",
+            namespace="apps",
+            verb="update",
+            resource="deployments",
+            value="allowed",
+        ).verify(timeout_sec=0)
+
+    assert result.success is True
+    assert result.status == "pass"
+    assert "allowed to update deployments" in result.reason
+    assert result.raw["observed"] == "allowed"
+
+
+def test_allowed_but_expected_denied_fails() -> None:
+    # The "beyond grant" case: an agent over-grants instead of granting the
+    # exact permission asked for, so an allow where a deny was expected fails.
+    with patch(f"{_MODULE}.can_i", return_value=_completed("yes", 0)):
+        result = SubjectAccessReviewVerifier(
+            subject="deployer",
+            namespace="apps",
+            verb="delete",
+            resource="secrets",
+            value="denied",
+        ).verify(timeout_sec=0)
+
+    assert result.success is False
+    assert result.status == "fail"
+    assert "expected denied" in result.reason
+    assert "observed allowed" in result.reason
+
+
+def test_denied_and_expected_denied_passes() -> None:
+    with patch(f"{_MODULE}.can_i", return_value=_completed("no", 1)):
+        result = SubjectAccessReviewVerifier(
+            subject="deployer",
+            namespace="apps",
+            verb="delete",
+            resource="secrets",
+            value="denied",
+        ).verify(timeout_sec=0)
+
+    assert result.success is True
+    assert result.status == "pass"
+    assert "denied to delete secrets" in result.reason
+
+
+def test_denied_but_expected_allowed_fails() -> None:
+    with patch(f"{_MODULE}.can_i", return_value=_completed("no", 1)):
+        result = SubjectAccessReviewVerifier(
+            subject="deployer",
+            namespace="apps",
+            verb="update",
+            resource="deployments",
+            value="allowed",
+        ).verify(timeout_sec=0)
+
+    assert result.success is False
+    assert result.status == "fail"
+    assert "expected allowed" in result.reason
+    assert "observed denied" in result.reason
+
+
+def test_command_error_is_status_error_not_fail() -> None:
+    with patch(
+        f"{_MODULE}.can_i",
+        side_effect=SubprocessError(
+            ["kubectl"], returncode=2, stderr="the server doesn't have a resource type"
+        ),
+    ):
+        result = SubjectAccessReviewVerifier(
+            subject="deployer",
+            namespace="apps",
+            verb="update",
+            resource="deployments",
+            value="allowed",
+        ).verify(timeout_sec=0)
+
+    assert result.success is False
+    assert result.status == "error"
+    assert "failed" in result.reason
+    assert result.raw is None
+
+
+def test_unexpected_stdout_is_status_error() -> None:
+    # Not a raised SubprocessError (kubectl can still exit 0/1 while printing
+    # something other than "yes"/"no" on a malformed invocation), but still
+    # not a clean answer -- must not be silently treated as "denied".
+    with patch(f"{_MODULE}.can_i", return_value=_completed("", 1, stderr="error: unreachable")):
+        result = SubjectAccessReviewVerifier(
+            subject="deployer",
+            namespace="apps",
+            verb="update",
+            resource="deployments",
+            value="allowed",
+        ).verify(timeout_sec=0)
+
+    assert result.success is False
+    assert result.status == "error"
+    assert "unreachable" in result.reason
+
+
+def test_service_account_subject_formatting() -> None:
+    with patch(f"{_MODULE}.can_i", return_value=_completed("yes", 0)) as mock_can_i:
+        SubjectAccessReviewVerifier(
+            subject="deployer",
+            namespace="apps",
+            verb="update",
+            resource="deployments",
+            value="allowed",
+        ).verify(timeout_sec=0)
+
+    assert mock_can_i.call_args.kwargs["subject"] == "system:serviceaccount:apps:deployer"
+    assert mock_can_i.call_args.kwargs["namespace"] == "apps"
+    assert mock_can_i.call_args.args == ("update", "deployments")
+
+
+def test_resource_name_is_appended_to_resource_arg() -> None:
+    with patch(f"{_MODULE}.can_i", return_value=_completed("yes", 0)) as mock_can_i:
+        SubjectAccessReviewVerifier(
+            subject="inventory-sync",
+            namespace="warehouse",
+            verb="get",
+            resource="secrets",
+            name="inventory-sync-creds",
+            value="allowed",
+        ).verify(timeout_sec=0)
+
+    assert mock_can_i.call_args.kwargs["name"] == "inventory-sync-creds"
+
+
+# --- sweep --------------------------------------------------------------
+
+
+def test_sweep_all_denied_passes_when_every_pair_denied() -> None:
+    with patch(f"{_MODULE}.can_i", return_value=_completed("no", 1)):
+        result = SubjectAccessReviewSweepVerifier(
+            subject="deployer",
+            namespace="apps",
+            pairs=[["delete", "deployments"], ["create", "deployments"]],
+            op="all_denied",
+        ).verify(timeout_sec=0)
+
+    assert result.success is True
+    assert result.status == "pass"
+    assert "all 2 pair(s) denied" in result.reason
+
+
+def test_sweep_all_denied_fails_on_unexpected_allow() -> None:
+    # no-access-beyond-grant's exact intent: an agent that over-grants (e.g.
+    # cluster-admin) instead of the precise gap must fail this sweep even
+    # though every OTHER pair is correctly denied.
+    def fake_can_i(verb, resource, **kwargs):
+        allowed = verb == "delete" and resource == "deployments"
+        return _completed("yes" if allowed else "no", 0 if allowed else 1)
+
+    with patch(f"{_MODULE}.can_i", side_effect=fake_can_i):
+        result = SubjectAccessReviewSweepVerifier(
+            subject="deployer",
+            namespace="apps",
+            pairs=[["delete", "deployments"], ["create", "deployments"]],
+            op="all_denied",
+        ).verify(timeout_sec=0)
+
+    assert result.success is False
+    assert result.status == "fail"
+    assert "1/2 pair(s) mismatched" in result.reason
+    assert "delete deployments" in result.reason
+    assert "expected denied, observed allowed" in result.reason
+
+
+def test_sweep_all_allowed_fails_on_unexpected_deny() -> None:
+    def fake_can_i(verb, resource, **kwargs):
+        allowed = verb != "get"
+        return _completed("yes" if allowed else "no", 0 if allowed else 1)
+
+    with patch(f"{_MODULE}.can_i", side_effect=fake_can_i):
+        result = SubjectAccessReviewSweepVerifier(
+            subject="inventory-sync",
+            namespace="warehouse",
+            pairs=[
+                {"verb": "list", "resource": "pods"},
+                {"verb": "get", "resource": "secrets", "name": "inventory-sync-creds"},
+            ],
+            op="all_allowed",
+        ).verify(timeout_sec=0)
+
+    assert result.success is False
+    assert result.status == "fail"
+    assert "1/2 pair(s) mismatched" in result.reason
+    assert "get secrets/inventory-sync-creds" in result.reason
+    assert "expected allowed, observed denied" in result.reason
+
+
+def test_sweep_dict_pair_namespace_overrides_subject_home_namespace() -> None:
+    with patch(f"{_MODULE}.can_i", return_value=_completed("no", 1)) as mock_can_i:
+        SubjectAccessReviewSweepVerifier(
+            subject="inventory-sync",
+            namespace="warehouse",
+            pairs=[{"verb": "get", "resource": "pods", "namespace": "kube-system"}],
+            op="all_denied",
+        ).verify(timeout_sec=0)
+
+    # The check namespace is the pair's own, but the subject stays qualified
+    # against its own home namespace.
+    assert mock_can_i.call_args.kwargs["namespace"] == "kube-system"
+    assert (
+        mock_can_i.call_args.kwargs["subject"] == "system:serviceaccount:warehouse:inventory-sync"
+    )
+
+
+def test_sweep_command_error_is_status_error_not_fail() -> None:
+    with patch(
+        f"{_MODULE}.can_i",
+        side_effect=SubprocessError(["kubectl"], returncode=2, stderr="server unreachable"),
+    ):
+        result = SubjectAccessReviewSweepVerifier(
+            subject="deployer",
+            namespace="apps",
+            pairs=[["delete", "deployments"]],
+            op="all_denied",
+        ).verify(timeout_sec=0)
+
+    assert result.success is False
+    assert result.status == "error"
+    assert "server unreachable" in result.reason
+
+
+def test_sweep_flat_pair_normalizes_to_two_element_form() -> None:
+    verifier = SubjectAccessReviewSweepVerifier(
+        subject="deployer",
+        namespace="apps",
+        pairs=[["get", "deployments"]],
+        op="all_denied",
+    )
+    assert verifier.pairs[0].verb == "get"
+    assert verifier.pairs[0].resource == "deployments"
+    assert verifier.pairs[0].namespace is None
+    assert verifier.pairs[0].name is None
+
+
+def test_sweep_flat_pair_wrong_length_raises() -> None:
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="exactly 2 elements"):
+        SubjectAccessReviewSweepVerifier(
+            subject="deployer",
+            namespace="apps",
+            pairs=[["get", "deployments", "extra"]],
+            op="all_denied",
+        )


### PR DESCRIPTION
Stacked on #79, which adds the `context` field this verifier reads. The first commit shown here belongs to that PR and will drop out of this diff once it merges. Review only the last commit.

Adds a `subject_access_review` verifier so a task can assert what a subject is and is not allowed to do, rather than inferring authorization indirectly from RBAC objects.

The verifier supports two modes:

- point: check a single subject/verb/resource triple against the cluster's authorization stack.
- sweep: check a set of triples in one entry, so a task can assert a whole permission surface at once.

Both modes go through the cluster's own SubjectAccessReview API, so the answer reflects what the API server will actually do, including bindings the task did not create.

This is a peer to the `http_probe`, `external_http_probe`, and `git_repo_sync` verifiers, and follows the same registration and result-shape conventions.

Unit tests cover both modes plus the failure and error paths.