### PR TITLE
Add project roadmap and devops-bench contribution tracks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,16 @@ _As contributors and maintainers of this project, and in the interest of fosteri
 
 We have full documentation on how to get started contributing here:
 
-<!---
-If your repo has certain guidelines for contribution, put them here ahead of the general k8s resources
--->
+### DevOps Bench Contribution Tracks
+
+Before diving into the general Kubernetes contributor docs below, here's where devops-bench-specific work lives. See [roadmap.md](roadmap.md) for the current backlog these tracks feed into.
+
+| Track | Description | Good First Issues & Opportunities |
+| --- | --- | --- |
+| **Task & Scenario Authorship** | Build and certify complex multi-step incident challenges under `tasks/`, tagged to the operator persona(s) they target. | Convert historical SRE postmortems into reproducible Kind scenarios; define declarative `devops_bench/verification/` rubrics (service readiness, data consistency). |
+| **Harnesses & Models** | Add support for open-source AI harnesses or new inference providers under `devops_bench/agents/` and `devops_bench/models/`. | Add CLI/API adapters for community frameworks; optimize prompt instrumentation and token efficiency reporting. |
+| **Infrastructure & Providers** | Enhance local sandboxing (`devops_bench/deployers/`, Kind/vCluster integration) or add cloud providers alongside the existing GCP support in `devops_bench/providers/`, to widen vendor-neutral coverage. | Lightweight vCluster lifecycle automation; contribute an AWS or Azure infra provider matching `devops_bench/providers/base.py`. |
+| **Verification & Judge Extensions** | Strengthen deterministic state checkers and automated evaluation metrics under `devops_bench/verification/` and `devops_bench/metrics/`. | Implement new Kubernetes condition verifiers; standardize Pass@N confidence interval reporting. |
 
 - [Contributor License Agreement](https://git.k8s.io/community/CLA.md) - Kubernetes projects require that you sign a Contributor License Agreement (CLA) before we can accept your pull requests
 - [Kubernetes Contributor Guide](https://k8s.dev/guide) - Main contributor documentation, or you can just jump directly to the [contributing page](https://k8s.dev/docs/guide/contributing/)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A standardized benchmarking suite to evaluate how well different agents or models perform specific DevOps tasks. Its goal is to provide an open-source, reproducible way to transparently assess agent performance across various infrastructure platforms and operational environments.
 
+See the [project roadmap](roadmap.md) for current initiatives and how to get involved.
+
 ## Community, discussion, contribution, and support
 
 Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).

--- a/roadmap.md
+++ b/roadmap.md
@@ -19,7 +19,7 @@ The evaluation loop: scenario management, deployers, verifiers, and result repor
 * **OSS Visualization Dashboard** `📅 Planned`
   * Inspect agent trajectories, step logs, and assertions locally and in presubmit, for regression tracking across runs.
 * **Multi-Iteration Pass@k Scoring** `📅 Planned`
-  * Land multi-iteration runs so Pass@5 (at least one of 5 attempts succeeds) and Pass^5 (all 5 succeed) reliability metrics become computable — the result schema already carries a continuous `outcome_score` designed for this; iteration execution itself hasn't landed yet.
+  * Land multi-iteration execution and Pass@k aggregation so Pass@5 (at least one of 5 attempts succeeds) and Pass^5 (all 5 succeed) reliability metrics become computable. The result schema already carries a continuous `outcome_score` designed for this, but both pieces remain pending: `build_rows()` still hard-codes `iteration=0`, and aggregation only de-duplicates rows today — it doesn't yet define a success threshold or compute Pass@k.
 
 ---
 
@@ -28,7 +28,7 @@ The evaluation loop: scenario management, deployers, verifiers, and result repor
 CLI agent adapters (`devops_bench/agents/`) and model inference clients (`devops_bench/models/`).
 
 * **Expand Community Harness Support** `⏳ In Progress`
-  * Add CLI/API adapters for additional open-source agent harnesses beyond the current OpenClaw, Antigravity, and Gemini CLI integrations.
+  * Add CLI/API adapters for additional open-source agent harnesses beyond the current OpenClaw, Antigravity, and Gemini CLI integrations — Hermes, Claude Code, and Codex adapters are next.
 * **Multi-Model Compatibility Leaderboard** `⏳ In Progress`
   * Publish per-harness × per-model pass rates so results are comparable across model-agnostic harnesses and single-vendor harnesses alike.
 
@@ -37,10 +37,8 @@ Current harness × model support:
 | Harness | Opus | Sonnet | Gemini-Flash | Gemini-Pro | GPT-5.5 | GLM-5 | Supported Models |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | OpenClaw *(model-agnostic)* | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6 |
-| Hermes *(model-agnostic)* | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6 |
 | Antigravity | ✓ | ✓ | ✓ | ✓ | | | 4 |
-| Claude Code | ✓ | ✓ | | | | | 2 |
-| Codex | | | | | ✓ | | 1 |
+| Gemini CLI | | | ✓ | ✓ | | | 2 |
 
 ---
 
@@ -81,7 +79,7 @@ Scenario authorship under `tasks/`, tagged by the operator persona(s) each task 
 Elevates the benchmark from single-agent scenarios to direct competition between two agents on opposing or shared objectives. Gated on the Core Harness and Task Library foundations landing first.
 
 * **Game-Theoretic Duel Framework** `📅 Planned`
-  * Introduce standardized token/budget efficiency metrics (`$/Uptime` vs. `$/Downtime`) across continuous, multi-turn evaluations where two agents compete for control of the same environment.
+  * Introduce standardized token/budget efficiency metrics across continuous, multi-turn evaluations where two agents compete for control of the same environment.
 
 ---
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,107 @@
+# DevOps Bench & Arena: Roadmap
+
+*SIG: Kubernetes SIG-Apps · Status: Incubating*
+
+DevOps Bench is an evaluation harness and scenario suite that measures whether autonomous DevOps/SRE agents can operate real Kubernetes clusters correctly — across any cloud, on-prem, or bare-metal environment — by verifying live cluster and cloud state after the agent acts, rather than grading against static text or a reference diff. It's organized around the day-2 operator personas that actually carry pagers — Cluster/Platform Operators, Database & Stateful Workload Operators, Security & Compliance Operators, Cost/FinOps Operators, and Application SREs — and every task, deployer, and verifier targets a common provider-agnostic interface so results are comparable across Kind, vCluster, and any cloud's managed Kubernetes.
+
+This roadmap tracks initiatives for **DevOps Bench** (the static benchmark) and **DevOps Arena** (adversarial, live-chaos evaluation). See [CONTRIBUTING.md](CONTRIBUTING.md) for how to pick up any of these.
+
+---
+
+### 🏗️ Core Harness & Orchestration
+
+The evaluation loop: scenario management, deployers, verifiers, and result reporting.
+
+* **Catastrophic vs. Recoverable Failure Taxonomy** `⏳ In Progress`
+  * Define and codify what counts as a catastrophic (unrecoverable) vs. recoverable failure per task, so scoring reflects blast radius, not just pass/fail.
+* **vCluster Sandboxing** `⏳ In Progress`
+  * Stand up vCluster as a fast, vendor-neutral evaluation environment alongside Kind, for cheaper parallel eval runs.
+* **OSS Visualization Dashboard** `📅 Planned`
+  * Inspect agent trajectories, step logs, and assertions locally and in presubmit, for regression tracking across runs.
+
+---
+
+### 🤖 Agent Harnesses & Model Integrations
+
+CLI agent adapters (`devops_bench/agents/`) and model inference clients (`devops_bench/models/`).
+
+* **Expand Community Harness Support** `⏳ In Progress`
+  * Add CLI/API adapters for additional open-source agent harnesses beyond the current OpenClaw, Antigravity, and Gemini CLI integrations.
+* **Multi-Model Compatibility Leaderboard** `⏳ In Progress`
+  * Publish per-harness × per-model pass rates so results are comparable across model-agnostic harnesses and single-vendor harnesses alike.
+
+Current harness × model support:
+
+| Harness | Opus | Sonnet | G-Flash | G-Pro | GPT-5.5 | GLM-5 | Cells |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| OpenClaw *(model-agnostic)* | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6 |
+| Hermes *(model-agnostic)* | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6 |
+| Antigravity | ✓ | ✓ | ✓ | ✓ | | | 4 |
+| Claude Code | ✓ | ✓ | | | | | 2 |
+| Codex | | | | | ✓ | | 1 |
+
+---
+
+### ☁️ Infrastructure Providers & Vendor Neutrality
+
+Every task runs unmodified against any provider behind `devops_bench/providers/base.py` and `devops_bench/deployers/base.py` — no scenario logic is hard-coded to one vendor's APIs.
+
+* **GCP Provider** `✅ Completed` — see Completed section.
+* **Kind Provider (local/default)** `✅ Completed` — see Completed section.
+* **AWS Provider** `📅 Planned`
+  * Land an AWS infra provider matching the existing `devops_bench/providers/base.py` interface, for cross-cloud parity with GCP and Kind.
+* **Azure Provider** `📅 Planned`
+  * Same as above, for Azure.
+* **100-Task Global Leaderboard, Broken Out by Provider** `📅 Planned`
+  * Publish results across open-source harnesses, frontier models, *and* infra providers (GCP, AWS, Azure), so "does this hold up on my cloud" is answerable directly from the data.
+
+---
+
+### 📋 Task Library & Operator Personas
+
+Scenario authorship under `tasks/`, tagged by the operator persona(s) each task targets.
+
+* **Task Authorship & Scoring Framework** `⏳ In Progress`
+  * Publish a framework for contributing new persona-tagged tasks with declarative `devops_bench/verification/` rubrics.
+* **Scale Complex Scenario Coverage** `⏳ In Progress`
+  * Expand beyond the current CVE remediation, OPA remediation, spot rebalancing, migration/upgrade, multi-region failover, and secret rotation tasks toward full persona coverage.
+
+---
+
+### 🥊 DevOps Arena — Adversarial & Self-Improving Operations
+
+Elevates the benchmark from static scenarios to live environments under active perturbation. All initiatives below are gated on the Core Harness and Task Library foundations landing first.
+
+* **Rogue Developer Simulation** `📅 Planned`
+  * Inject synchronized GitOps corruption, invalid container tags, broken RBAC policies, and subtle configuration drift directly into repository sources. Tracks debugging accuracy and reconciliation speed.
+* **Stealth Attacker & Compliance Security** `📅 Planned`
+  * Evaluate security response to unauthorized network policies, container escape risks, and secret exposure — without causing application service disruption.
+* **Closed-Loop Self-Improvement** `📅 Planned`
+  * Evaluate whether an agent can permanently harden a cluster by generating reusable lint rules, custom admission policies, and incident runbooks after encountering an exploit.
+* **Game-Theoretic Duel Framework** `📅 Planned`
+  * Introduce standardized token/budget efficiency metrics ($/Uptime vs. $/Downtime) across continuous, multi-turn adversarial evaluations.
+
+---
+
+## Completed
+
+* **Base Metrics & K8s Wrappers** `✅ Completed`
+  * Foundational metrics and Kubernetes client wrappers shared across the pipeline.
+* **Packaged Skills & Tasks** `✅ Completed`
+  * Initial `tasks/` library and `skills/` runbooks for authoring and running evals.
+* **Model Inference Clients & CLI Agents** `✅ Completed`
+  * Claude, Gemini, and Ollama model clients; OpenClaw, Antigravity, and Gemini CLI agent adapters.
+* **Chaos & Verification Base Frameworks** `✅ Completed`
+  * `devops_bench/chaos/` and `devops_bench/verification/` base interfaces.
+* **GEval Pipeline, Default Kind Stack & Eval Reporter** `✅ Completed`
+  * Default local evaluation path via Kind, with LLM-judge (GEval) scoring and result reporting.
+* **Evaluation Orchestration Loop** `✅ Completed`
+  * Full loop connecting scenario management, deployers, verifiers, and result reporting.
+* **CLI Entrypoints** `✅ Completed`
+  * `python -m devops_bench` entrypoints for running single evals and matrices.
+* **End-to-End Integration Test Suite** `✅ Completed`
+  * Full pipeline execution verified across all components.
+* **GCP Infra Provider** `✅ Completed`
+  * `devops_bench/providers/gcp.py` — first cloud provider implementation.
+* **Kind Infra Provider** `✅ Completed`
+  * `devops_bench/providers/kind.py` — default local sandboxing.

--- a/roadmap.md
+++ b/roadmap.md
@@ -2,13 +2,13 @@
 
 *SIG: Kubernetes SIG-Apps · Status: Incubating*
 
-DevOps Bench is an evaluation harness and scenario suite that measures whether autonomous DevOps/SRE agents can operate real Kubernetes clusters correctly — across any cloud, on-prem, or bare-metal environment — by verifying live cluster and cloud state after the agent acts, rather than grading against static text or a reference diff. It's organized around the day-2 operator personas that actually carry pagers — Cluster/Platform Operators, Database & Stateful Workload Operators, Security & Compliance Operators, Cost/FinOps Operators, and Application SREs — and every task, deployer, and verifier targets a common provider-agnostic interface so results are comparable across Kind, vCluster, and any cloud's managed Kubernetes.
+DevOps Bench is an evaluation harness and scenario suite that measures whether autonomous DevOps/SRE agents can operate real Kubernetes clusters correctly — with a provider-agnostic design targeting any cloud, on-prem, or bare-metal environment — by verifying live cluster and cloud state after the agent acts, rather than grading against static text or a reference diff. It's organized around the day-2 operator personas that actually carry pagers — Cluster/Platform Operators, Database & Stateful Workload Operators, Security & Compliance Operators, Cost/FinOps Operators, and Application SREs — and every task, deployer, and verifier targets a common provider-agnostic interface so results are comparable across Kind, vCluster, and any cloud's managed Kubernetes.
 
 This roadmap tracks initiatives for **DevOps Bench** (the static benchmark) and **DevOps Arena** (adversarial, live-chaos evaluation). See [CONTRIBUTING.md](CONTRIBUTING.md) for how to pick up any of these.
 
 ---
 
-### 🏗️ Core Harness & Orchestration
+## 🏗️ Core Harness & Orchestration
 
 The evaluation loop: scenario management, deployers, verifiers, and result reporting.
 
@@ -21,7 +21,7 @@ The evaluation loop: scenario management, deployers, verifiers, and result repor
 
 ---
 
-### 🤖 Agent Harnesses & Model Integrations
+## 🤖 Agent Harnesses & Model Integrations
 
 CLI agent adapters (`devops_bench/agents/`) and model inference clients (`devops_bench/models/`).
 
@@ -32,7 +32,7 @@ CLI agent adapters (`devops_bench/agents/`) and model inference clients (`devops
 
 Current harness × model support:
 
-| Harness | Opus | Sonnet | G-Flash | G-Pro | GPT-5.5 | GLM-5 | Cells |
+| Harness | Opus | Sonnet | Gemini-Flash | Gemini-Pro | GPT-5.5 | GLM-5 | Supported Models |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | OpenClaw *(model-agnostic)* | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6 |
 | Hermes *(model-agnostic)* | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6 |
@@ -42,9 +42,9 @@ Current harness × model support:
 
 ---
 
-### ☁️ Infrastructure Providers & Vendor Neutrality
+## ☁️ Infrastructure Providers & Vendor Neutrality
 
-Every task runs unmodified against any provider behind `devops_bench/providers/base.py` and `devops_bench/deployers/base.py` — no scenario logic is hard-coded to one vendor's APIs.
+Every task is written against the provider-agnostic `devops_bench/providers/base.py` and `devops_bench/deployers/base.py` interfaces — no scenario logic is hard-coded to one vendor's APIs, so a task runs unmodified on any provider that implements them.
 
 * **GCP Provider** `✅ Completed` — see Completed section.
 * **Kind Provider (local/default)** `✅ Completed` — see Completed section.
@@ -57,7 +57,7 @@ Every task runs unmodified against any provider behind `devops_bench/providers/b
 
 ---
 
-### 📋 Task Library & Operator Personas
+## 📋 Task Library & Operator Personas
 
 Scenario authorship under `tasks/`, tagged by the operator persona(s) each task targets.
 
@@ -68,7 +68,7 @@ Scenario authorship under `tasks/`, tagged by the operator persona(s) each task 
 
 ---
 
-### 🥊 DevOps Arena — Adversarial & Self-Improving Operations
+## 🥊 DevOps Arena — Adversarial & Self-Improving Operations
 
 Elevates the benchmark from static scenarios to live environments under active perturbation. All initiatives below are gated on the Core Harness and Task Library foundations landing first.
 
@@ -79,7 +79,7 @@ Elevates the benchmark from static scenarios to live environments under active p
 * **Closed-Loop Self-Improvement** `📅 Planned`
   * Evaluate whether an agent can permanently harden a cluster by generating reusable lint rules, custom admission policies, and incident runbooks after encountering an exploit.
 * **Game-Theoretic Duel Framework** `📅 Planned`
-  * Introduce standardized token/budget efficiency metrics ($/Uptime vs. $/Downtime) across continuous, multi-turn adversarial evaluations.
+  * Introduce standardized token/budget efficiency metrics (`$/Uptime` vs. `$/Downtime`) across continuous, multi-turn adversarial evaluations.
 
 ---
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -4,7 +4,7 @@
 
 DevOps Bench is an evaluation harness and scenario suite that measures whether autonomous DevOps/SRE agents can operate real Kubernetes clusters correctly — with a provider-agnostic design targeting any cloud, on-prem, or bare-metal environment — by verifying live cluster and cloud state after the agent acts, rather than grading against static text or a reference diff. It's organized around the day-2 operator personas that actually carry pagers — Cluster/Platform Operators, Database & Stateful Workload Operators, Security & Compliance Operators, Cost/FinOps Operators, and Application SREs — and every task, deployer, and verifier targets a common provider-agnostic interface so results are comparable across Kind, vCluster, and any cloud's managed Kubernetes.
 
-This roadmap tracks initiatives for **DevOps Bench** (the static benchmark) and **DevOps Arena** (adversarial, live-chaos evaluation). See [CONTRIBUTING.md](CONTRIBUTING.md) for how to pick up any of these.
+This roadmap tracks initiatives for **DevOps Bench** (the static, single-agent benchmark) and **DevOps Arena** (agent-vs-agent competitive evaluation). See [CONTRIBUTING.md](CONTRIBUTING.md) for how to pick up any of these.
 
 ---
 
@@ -18,6 +18,8 @@ The evaluation loop: scenario management, deployers, verifiers, and result repor
   * Stand up vCluster as a fast, vendor-neutral evaluation environment alongside Kind, for cheaper parallel eval runs.
 * **OSS Visualization Dashboard** `📅 Planned`
   * Inspect agent trajectories, step logs, and assertions locally and in presubmit, for regression tracking across runs.
+* **Multi-Iteration Pass@k Scoring** `📅 Planned`
+  * Land multi-iteration runs so Pass@5 (at least one of 5 attempts succeeds) and Pass^5 (all 5 succeed) reliability metrics become computable — the result schema already carries a continuous `outcome_score` designed for this; iteration execution itself hasn't landed yet.
 
 ---
 
@@ -48,6 +50,8 @@ Every task is written against the provider-agnostic `devops_bench/providers/base
 
 * **GCP Provider** `✅ Completed` — see Completed section.
 * **Kind Provider (local/default)** `✅ Completed` — see Completed section.
+* **vCluster Provider** `⏳ In Progress`
+  * Land a vCluster-backed infra provider matching `devops_bench/providers/base.py`, for fast, low-cost virtual clusters alongside GCP and Kind.
 * **AWS Provider** `📅 Planned`
   * Land an AWS infra provider matching the existing `devops_bench/providers/base.py` interface, for cross-cloud parity with GCP and Kind.
 * **Azure Provider** `📅 Planned`
@@ -59,27 +63,25 @@ Every task is written against the provider-agnostic `devops_bench/providers/base
 
 ## 📋 Task Library & Operator Personas
 
-Scenario authorship under `tasks/`, tagged by the operator persona(s) each task targets.
+Scenario authorship under `tasks/`, tagged by the operator persona(s) each task targets. Scenario coverage spans three broad verification categories: resource-state assertions (JSONPath checks against any Kubernetes object), health/readiness checks (pod and workload conditions), and scaling/capacity checks — rolling up into the benchmark's three signals (correctness, recoverable safety, catastrophic outcome).
 
 * **Task Authorship & Scoring Framework** `⏳ In Progress`
   * Publish a framework for contributing new persona-tagged tasks with declarative `devops_bench/verification/` rubrics.
 * **Scale Complex Scenario Coverage** `⏳ In Progress`
   * Expand beyond the current CVE remediation, OPA remediation, spot rebalancing, migration/upgrade, multi-region failover, and secret rotation tasks toward full persona coverage.
+* **Fault-Injection Scenario Coverage (Agent vs. System)** `📅 Planned`
+  * Build on the completed `devops_bench/chaos/` base to inject faults into live scenarios — GitOps corruption, invalid container tags, broken RBAC policies, configuration drift, unauthorized network policies, container escapes, secret exposure — measuring an agent's diagnostic accuracy and reconciliation speed under real fault conditions.
+* **Closed-Loop Self-Improvement** `📅 Planned`
+  * Evaluate whether an agent can permanently harden a cluster by generating reusable lint rules, custom admission policies, and incident runbooks after encountering an injected fault.
 
 ---
 
-## 🥊 DevOps Arena — Adversarial & Self-Improving Operations
+## 🥊 DevOps Arena — Agent vs. Agent Competitive Evaluation
 
-Elevates the benchmark from static scenarios to live environments under active perturbation. All initiatives below are gated on the Core Harness and Task Library foundations landing first.
+Elevates the benchmark from single-agent scenarios to direct competition between two agents on opposing or shared objectives. Gated on the Core Harness and Task Library foundations landing first.
 
-* **Rogue Developer Simulation** `📅 Planned`
-  * Inject synchronized GitOps corruption, invalid container tags, broken RBAC policies, and subtle configuration drift directly into repository sources. Tracks debugging accuracy and reconciliation speed.
-* **Stealth Attacker & Compliance Security** `📅 Planned`
-  * Evaluate security response to unauthorized network policies, container escape risks, and secret exposure — without causing application service disruption.
-* **Closed-Loop Self-Improvement** `📅 Planned`
-  * Evaluate whether an agent can permanently harden a cluster by generating reusable lint rules, custom admission policies, and incident runbooks after encountering an exploit.
 * **Game-Theoretic Duel Framework** `📅 Planned`
-  * Introduce standardized token/budget efficiency metrics (`$/Uptime` vs. `$/Downtime`) across continuous, multi-turn adversarial evaluations.
+  * Introduce standardized token/budget efficiency metrics (`$/Uptime` vs. `$/Downtime`) across continuous, multi-turn evaluations where two agents compete for control of the same environment.
 
 ---
 


### PR DESCRIPTION
Publish a roadmap.md tracking Bench and Arena initiatives by theme, and fill in CONTRIBUTING.md's repo-specific section with the four contribution tracks (task authorship, harnesses/models, infra providers, verification) so new contributors know where to start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contribution tracks outlining opportunities for task authorship, harnesses, models, infrastructure, providers, and verification extensions.
  * Added a roadmap covering evaluation orchestration, agent and model integrations, provider support, task coverage, live-chaos initiatives, leaderboards, and completed platform capabilities.
  * Added a roadmap link and instructions for getting involved to the project README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->