### PR TITLE
feat(agents): support multiple MCP servers, fail unreachable ones, copy whole skill bundles

### DIFF
--- a/devops_bench/agents/api/agent.py
+++ b/devops_bench/agents/api/agent.py
@@ -51,11 +51,12 @@ _log = get_logger("agents.api.agent")
 
 
 class ToolNameConflictError(RuntimeError):
-    """Two granted MCP servers advertise the same tool name.
+    """One tool name is claimed twice — by two granted MCP servers, or by a
+    discovered skill and a granted server.
 
     Raised once the servers are up, since the advertised names are only known
-    then. Fatal for the run: routing the call to whichever server happened to
-    be listed first would score the arm against a toolset nobody chose.
+    then. Fatal for the run: serving whichever source happened to be resolved
+    first would score the arm against a toolset nobody chose.
     """
 
 
@@ -393,7 +394,8 @@ async def _run_async(
         per-tool dispatch failures recorded by the dispatcher.
 
     Raises:
-        ToolNameConflictError: If two granted servers advertise the same tool.
+        ToolNameConflictError: If two granted servers advertise the same tool,
+            or a discovered skill tool carries a granted server's tool name.
     """
     errors: list[str] = []
     skill_tools, skill_resources, skill_names = await asyncio.to_thread(
@@ -408,6 +410,17 @@ async def _run_async(
             for binding in mcp_bindings
         ]
         mcp_tools, routes = await _route_tools(sessions)
+        # Skill names are checked against the routed MCP names for the same
+        # reason two servers are checked against each other: the model would be
+        # handed one name twice, and the dispatcher's skill-first rule would
+        # serve the skill while the MCP tool it shadows never runs.
+        clash = sorted(routes.keys() & skill_resources.keys())
+        if clash:
+            raise ToolNameConflictError(
+                f"skill tools {clash} collide with tools advertised by a granted MCP "
+                "server; the grant is rejected rather than serving the skill and "
+                "leaving the server's tool unreachable"
+            )
         loop_result = await run_tool_loop(
             client=client,
             goal=prompt,

--- a/devops_bench/agents/api/agent.py
+++ b/devops_bench/agents/api/agent.py
@@ -22,27 +22,42 @@ entries.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import shlex
 import time
 from collections import deque
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from devops_bench.agents.api.mcp import MCPClient, extract_tool_text
 from devops_bench.agents.api.skills import (
-    SkillToolInfo,
     discover_skill_tools,
 )
 from devops_bench.agents.base import AGENTS, AgentHarness
 from devops_bench.agents.config import AgentConfig
 from devops_bench.agents.result import AgentResult, ToolCall
+from devops_bench.agents.shared.mcp_probe import child_env
 from devops_bench.core import get_logger
 from devops_bench.models import LLMClient, get_model
 from devops_bench.models.utils.loop import LoopResult, ToolDispatcher, run_tool_loop
 
-__all__ = ["ApiAgent", "fold_trajectory", "extract_tokens"]
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from devops_bench.agents.capabilities import McpBinding
+
+__all__ = ["ApiAgent", "ToolNameConflictError", "fold_trajectory", "extract_tokens"]
 
 _log = get_logger("agents.api.agent")
+
+
+class ToolNameConflictError(RuntimeError):
+    """Two granted MCP servers advertise the same tool name.
+
+    Raised once the servers are up, since the advertised names are only known
+    then. Fatal for the run: routing the call to whichever server happened to
+    be listed first would score the arm against a toolset nobody chose.
+    """
+
 
 # Safety cap on agent turns; overridable via ``AgentConfig.max_turns``. Set high
 # because API agents legitimately take many tool-use turns — it only guards
@@ -227,7 +242,7 @@ def _first_int_attr(obj: Any, *names: str) -> int:
 
 
 def _build_dispatch(
-    mcp_client: MCPClient | None,
+    routes: Mapping[str, MCPClient],
     skill_resources: dict[str, str],
     errors: list[str],
 ) -> ToolDispatcher:
@@ -240,7 +255,8 @@ def _build_dispatch(
     on the next turn.
 
     Args:
-        mcp_client: Active :class:`MCPClient`, or ``None`` when MCP is off.
+        routes: Tool name to the session serving it, from :func:`_route_tools`.
+            Empty when no MCP server was granted.
         skill_resources: Map of skill tool name to the skill file's content
             (captured at discovery); populated by
             :func:`devops_bench.agents.api.skills.discover_skill_tools`.
@@ -259,10 +275,16 @@ def _build_dispatch(
             if name in skill_resources:
                 _log.info("Serving skill tool %s from discovery-time content", name)
                 return skill_resources[name]
+            mcp_client = routes.get(name)
             if mcp_client is None:
+                # Both cases are a name the model invented; they are worth
+                # distinguishing because the causes differ — a missing grant
+                # versus a tool no granted server advertises.
                 msg = (
                     f"Error: tool {name!r} requested but no MCP server is "
                     "configured for this agent."
+                    if not routes
+                    else f"Error: tool {name!r} is not advertised by any granted MCP server."
                 )
                 errors.append(msg)
                 return msg
@@ -287,51 +309,79 @@ def _build_dispatch(
     return dispatch
 
 
-async def _gather_tools(
-    mcp_client: MCPClient | None,
-    skill_tools: list[SkillToolInfo],
-) -> list[Any]:
-    """Return the combined MCP + skill tool list passed to ``format_tools``.
+def _open_server(binding: McpBinding) -> MCPClient:
+    """Build the (not yet entered) client for one granted server.
+
+    ``shlex.join`` round-trips :class:`MCPClient`'s own ``shlex.split`` so a
+    spaced argv token (``("uv run", "mcp-server")``) is rebuilt as a single
+    quoted word. ``child_env`` owns the runner-env read so this module stays
+    free of one.
+    """
+    return MCPClient(
+        shlex.join(binding.command),
+        env=child_env(binding) if binding.env else None,
+        cwd=binding.cwd or None,
+    )
+
+
+async def _route_tools(
+    sessions: list[tuple[McpBinding, MCPClient]],
+) -> tuple[list[Any], dict[str, MCPClient]]:
+    """List every server's tools and map each tool name to its owning session.
 
     Args:
-        mcp_client: Active MCP client, or ``None`` when MCP is off.
-        skill_tools: Skill tool descriptors from
-            :func:`discover_skill_tools`.
+        sessions: The open ``(binding, client)`` pairs, in grant order.
 
     Returns:
-        A list of tool objects (MCP-native or :class:`SkillToolInfo`) in MCP
-        order followed by skill order. Both are duck-typed (``name``,
-        ``description``, ``inputSchema``) so adapters' ``format_tools`` handles
-        them uniformly.
+        A ``(tools, routes)`` pair. ``tools`` is every server's advertised tool
+        in grant order, ready to concatenate with the skill tools;  ``routes``
+        maps a tool name to the client that serves it.
+
+    Raises:
+        ToolNameConflictError: If two servers advertise the same tool name.
     """
     tools: list[Any] = []
-    if mcp_client is not None:
-        tools_result = await mcp_client.list_tools()
-        tools.extend(tools_result.tools)
-    tools.extend(skill_tools)
-    return tools
+    routes: dict[str, MCPClient] = {}
+    owners: dict[str, str] = {}
+    for binding, mcp_client in sessions:
+        server = binding.name or "<unnamed>"
+        listed = await mcp_client.list_tools()
+        for tool in listed.tools:
+            name = getattr(tool, "name", "")
+            if name in routes:
+                raise ToolNameConflictError(
+                    f"servers {owners[name]!r} and {server!r} both advertise tool {name!r}; "
+                    "a call to it would be ambiguous, so the grant is rejected rather than "
+                    "routed to whichever server was listed first"
+                )
+            routes[name] = mcp_client
+            owners[name] = server
+            tools.append(tool)
+    return tools, routes
 
 
 async def _run_async(
     client: LLMClient,
     prompt: str,
-    mcp_server_path: str | None,
+    mcp_bindings: tuple[McpBinding, ...],
     skills_paths: tuple[str, ...],
     rules_text: str | None,
     max_turns: int,
 ) -> tuple[LoopResult, list[str], list[str]]:
     """Drive the tool-use loop and return its ``(LoopResult, errors, skills)``.
 
-    Opens an MCP session when ``mcp_server_path`` is set and discovers local
-    skills when ``skills_paths`` is non-empty — the two are independent. The
-    tool list is formatted by the caller and passed to :func:`run_tool_loop`
-    pre-formatted.
+    Opens one session per granted server and discovers local skills when
+    ``skills_paths`` is non-empty — the two are independent, and either may be
+    empty. Every session's tools are advertised together, and a call is routed
+    back to the server that advertised it. The tool list is formatted here and
+    passed to :func:`run_tool_loop` pre-formatted.
 
     Args:
         client: Neutral LLM client.
         prompt: Task prompt seeding the loop.
-        mcp_server_path: Command launching the MCP server, or ``None`` to skip
-            MCP entirely.
+        mcp_bindings: The MCP servers to launch — each binding's ``command``,
+            declared ``env`` (``${VAR}`` references resolved against the runner
+            env) and ``cwd``. Empty skips MCP entirely.
         skills_paths: Filesystem locations to discover local skills under.
         rules_text: Operator-brief text (the ``AgentRules.text`` payload)
             handed to the provider as the ``system_instruction``; ``None`` /
@@ -341,39 +391,32 @@ async def _run_async(
     Returns:
         A ``(loop_result, errors, skill_names)`` tuple. ``errors`` carries any
         per-tool dispatch failures recorded by the dispatcher.
+
+    Raises:
+        ToolNameConflictError: If two granted servers advertise the same tool.
     """
     errors: list[str] = []
     skill_tools, skill_resources, skill_names = await asyncio.to_thread(
         discover_skill_tools, skills_paths
     )
-    system_instruction = rules_text or None
 
-    if not mcp_server_path:
-        formatted = client.format_tools(skill_tools)
-        dispatch = _build_dispatch(None, skill_resources, errors)
+    # One stack for every session, so a failure opening server N still tears
+    # down the N-1 already running rather than orphaning their subprocesses.
+    async with contextlib.AsyncExitStack() as stack:
+        sessions = [
+            (binding, await stack.enter_async_context(_open_server(binding)))
+            for binding in mcp_bindings
+        ]
+        mcp_tools, routes = await _route_tools(sessions)
         loop_result = await run_tool_loop(
             client=client,
             goal=prompt,
-            tools=formatted,
-            system_instruction=system_instruction,
-            dispatch=dispatch,
+            tools=client.format_tools([*mcp_tools, *skill_tools]),
+            system_instruction=rules_text or None,
+            dispatch=_build_dispatch(routes, skill_resources, errors),
             max_turns=max_turns,
         )
-        return loop_result, errors, skill_names
-
-    async with MCPClient(mcp_server_path) as mcp_client:
-        tools = await _gather_tools(mcp_client, skill_tools)
-        formatted = client.format_tools(tools)
-        dispatch = _build_dispatch(mcp_client, skill_resources, errors)
-        loop_result = await run_tool_loop(
-            client=client,
-            goal=prompt,
-            tools=formatted,
-            system_instruction=system_instruction,
-            dispatch=dispatch,
-            max_turns=max_turns,
-        )
-        return loop_result, errors, skill_names
+    return loop_result, errors, skill_names
 
 
 @AGENTS.register("api")
@@ -384,9 +427,9 @@ class ApiAgent(AgentHarness):
     :class:`~devops_bench.agents.config.AgentConfig` — no environment reads
     happen inside this class. Capability gates:
 
-    * **MCP on/off** is driven by ``config.capabilities.mcp`` (presence of an
+    * **MCP on/off** is driven by ``config.capabilities.mcp_servers``: every
       :class:`~devops_bench.agents.capabilities.McpBinding` with a non-empty
-      ``command``).
+      ``command`` is launched and its tools advertised together.
     * **Skills on/off** is driven by ``config.capabilities.skills.paths``
       independently of MCP — an agent may run with skills only, MCP only,
       both, or neither.
@@ -434,27 +477,17 @@ class ApiAgent(AgentHarness):
         max_turns = (
             self.config.max_turns if self.config.max_turns is not None else _DEFAULT_MAX_TURNS
         )
-        mcp_servers = self.config.capabilities.mcp_servers
-        if len(mcp_servers) > 1:
-            _log.warning(
-                "API agent honors only the first MCP binding; ignoring %d additional server(s)",
-                len(mcp_servers) - 1,
-            )
-        mcp_binding = self.config.capabilities.mcp
-        # Only open an MCPClient when an MCP binding carries a launch command;
-        # an empty-command binding is treated as "no MCP". ``shlex.join``
-        # round-trips ``MCPClient``'s ``shlex.split`` so a spaced argv token
-        # (``("uv run", "mcp-server")``) is rebuilt as a single quoted word.
-        mcp_server_path = (
-            shlex.join(mcp_binding.command) if mcp_binding and mcp_binding.command else None
-        )
+        # Every granted server is launched. A command-less binding names a
+        # server the *CLI* agents host in-process; there is nothing for this
+        # agent to connect to, so it is not a server here.
+        launchable = tuple(b for b in self.config.capabilities.mcp_servers if b.command)
         skills_paths = self.config.capabilities.skills.paths
         rules_text = self.config.capabilities.rules.text
 
         run_coro = _run_async(
             llm_client,
             prompt,
-            mcp_server_path,
+            launchable,
             skills_paths,
             rules_text,
             max_turns,
@@ -478,6 +511,8 @@ class ApiAgent(AgentHarness):
             if timeout is None or elapsed < timeout:
                 raise
             return AgentResult.errored(f"API agent timed out after {timeout}s", latency=elapsed)
+        except ToolNameConflictError as exc:
+            return AgentResult.errored(f"MCP tool name conflict: {exc}")
 
         trajectory, orphan_errors = _fold_with_extraction_errors(loop_result.contents)
         tokens = extract_tokens(loop_result.response)

--- a/devops_bench/agents/api/mcp.py
+++ b/devops_bench/agents/api/mcp.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import shlex
+from collections.abc import Mapping
 from contextlib import AsyncExitStack
 from types import TracebackType
 from typing import Any
@@ -37,6 +38,11 @@ class MCPClient:
 
     Attributes:
         server_path: Command used to launch the MCP server over stdio.
+        env: Full environment the server is spawned with, or ``None`` to leave
+            the SDK's minimal default in place. A binding declaring ``env`` must
+            supply the whole environment here, not just its own keys — the SDK
+            replaces rather than merges.
+        cwd: Directory to spawn the server in, or ``None`` for the caller's.
         session: The active ``ClientSession`` once entered, else ``None``.
 
     Raises:
@@ -45,8 +51,16 @@ class MCPClient:
         ValueError: If ``server_path`` is empty or whitespace-only (on enter).
     """
 
-    def __init__(self, server_path: str) -> None:
+    def __init__(
+        self,
+        server_path: str,
+        *,
+        env: Mapping[str, str] | None = None,
+        cwd: str | None = None,
+    ) -> None:
         self.server_path = server_path
+        self.env = None if env is None else dict(env)
+        self.cwd = cwd or None
         self.exit_stack = AsyncExitStack()
         self.session: Any = None
 
@@ -70,7 +84,12 @@ class MCPClient:
                 "MCP server_path is empty; set AGENT_TARGET/MCP_SERVER_PATH to the "
                 "MCP server command."
             )
-        server_params = StdioServerParameters(command=parts[0], args=parts[1:])
+        # ``env=None`` leaves the SDK's minimal default environment in place;
+        # a supplied mapping replaces it outright, so the caller passes a full
+        # environment rather than just the binding's declared keys.
+        server_params = StdioServerParameters(
+            command=parts[0], args=parts[1:], env=self.env, cwd=self.cwd
+        )
         # Unwind anything already entered (e.g. the spawned server subprocess)
         # when a later setup step fails — __aexit__ never runs if __aenter__
         # raises, so cleanup must happen here.

--- a/devops_bench/agents/capabilities/aggregate.py
+++ b/devops_bench/agents/capabilities/aggregate.py
@@ -46,9 +46,9 @@ class AllCapabilities:
     def mcp(self) -> McpBinding | None:
         """Return the first MCP binding, or ``None`` when MCP is disabled.
 
-        Gotcha:
-            Only the first binding is honored; servers 2..N are dropped —
-            iterate ``mcp_servers`` for all.
+        Convenience for the common single-server grant. Agents drive every
+        granted server, so anything acting on the grant must iterate
+        ``mcp_servers`` rather than read this.
         """
         return self.mcp_servers[0] if self.mcp_servers else None
 

--- a/devops_bench/agents/capabilities/mcp.py
+++ b/devops_bench/agents/capabilities/mcp.py
@@ -39,8 +39,9 @@ class McpBinding:
             :class:`~devops_bench.agents.api.mcp.MCPClient`.
         env: Environment pairs the server is launched with, as a tuple of
             ``(name, value)`` so the binding stays hashable. A value may carry
-            ``${VAR}`` / ``$VAR`` references resolved from the runner's
-            environment; references are written through to the CLI's config
+            ``${VAR}`` references (braces required — a bare ``$VAR`` stays
+            literal) resolved from the runner's environment; references are
+            written through to the CLI's config
             file **unexpanded** so a credential never lands in the agent's
             workspace, which is collected wholesale into the run's artifacts.
         cwd: Working directory the server is launched in. Empty inherits the

--- a/devops_bench/agents/capabilities/mcp.py
+++ b/devops_bench/agents/capabilities/mcp.py
@@ -40,10 +40,24 @@ class McpBinding:
         env: Environment pairs the server is launched with, as a tuple of
             ``(name, value)`` so the binding stays hashable. A value may carry
             ``${VAR}`` references (braces required — a bare ``$VAR`` stays
-            literal) resolved from the runner's environment; references are
-            written through to the CLI's config
-            file **unexpanded** so a credential never lands in the agent's
-            workspace, which is collected wholesale into the run's artifacts.
+            literal) resolved from the runner's environment.
+
+            Two things expand those references, and which one runs depends on
+            who launches the server:
+
+            * The harness, via
+              :func:`~devops_bench.agents.shared.mcp_probe.expand_env`, when it
+              spawns the server itself — the preflight probe and the API agent.
+              The resolved value exists only in that child process.
+            * The CLI, for a server the binary spawns. The reference is written
+              into the CLI's config file **unexpanded** and the CLI resolves it
+              from its own environment, so a credential never lands in the
+              agent's workspace — which is collected wholesale into the run's
+              artifacts.
+
+            Both read the same runner env, so the two paths agree on the value;
+            only the expansion point differs. A secret-named value must be a
+            reference rather than a literal, enforced when the grant is parsed.
         cwd: Working directory the server is launched in. Empty inherits the
             agent's working directory (the per-run workspace).
         tools: Tool names this server exposes to the agent. The Gemini CLI

--- a/devops_bench/agents/capabilities/mcp.py
+++ b/devops_bench/agents/capabilities/mcp.py
@@ -37,6 +37,14 @@ class McpBinding:
         command: argv-style command launching the MCP server, or ``()`` when
             the agent runs MCP in-process. The API agent feeds this to
             :class:`~devops_bench.agents.api.mcp.MCPClient`.
+        env: Environment pairs the server is launched with, as a tuple of
+            ``(name, value)`` so the binding stays hashable. A value may carry
+            ``${VAR}`` / ``$VAR`` references resolved from the runner's
+            environment; references are written through to the CLI's config
+            file **unexpanded** so a credential never lands in the agent's
+            workspace, which is collected wholesale into the run's artifacts.
+        cwd: Working directory the server is launched in. Empty inherits the
+            agent's working directory (the per-run workspace).
         tools: Tool names this server exposes to the agent. The Gemini CLI
             passes these via ``--allowed-tools``; the API agent advertises
             whatever the live MCP server lists (this field acts as
@@ -45,6 +53,8 @@ class McpBinding:
 
     name: str = ""
     command: tuple[str, ...] = ()
+    env: tuple[tuple[str, str], ...] = ()
+    cwd: str = ""
     tools: tuple[str, ...] = ()
 
 

--- a/devops_bench/agents/cli/antigravity/agent.py
+++ b/devops_bench/agents/cli/antigravity/agent.py
@@ -29,6 +29,7 @@ from devops_bench.agents import config as agents_config
 from devops_bench.agents import result as agents_result
 from devops_bench.agents.cli.antigravity import parsing
 from devops_bench.agents.shared import cli_capabilities
+from devops_bench.agents.shared.mcp_probe import McpUnreachableError, preflight_mcp
 from devops_bench.core import subprocess as devops_subprocess
 
 if TYPE_CHECKING:
@@ -276,6 +277,18 @@ class AgyCliAgent(base.AgentHarness):
                 (agy_config_dir / "settings.json").write_text(
                     json.dumps(settings, indent=2), encoding="utf-8"
                 )
+
+            # Same gate the other CLI harnesses run: a granted server that never
+            # starts leaves agy falling back to shell tools while the run is
+            # still scored as an MCP arm.
+            try:
+                preflight_mcp(
+                    caps.mcp_servers,
+                    base_env={**os.environ, **env_overlay},
+                    cwd=workdir,
+                )
+            except McpUnreachableError as exc:
+                return agents_result.AgentResult.errored(f"MCP preflight failed: {exc}")
 
             # Copy (not symlink) the OAuth token into the workspace: agy may
             # refresh it in place during a run, and a symlink shared across

--- a/devops_bench/agents/cli/gemini_cli/agent.py
+++ b/devops_bench/agents/cli/gemini_cli/agent.py
@@ -78,6 +78,9 @@ _MCP_NOT_LISTED = "<not listed>"
 # Seconds for ``gemini mcp list``. It starts the binary and dials each server
 # but makes no model call, so it is fast relative to a run.
 _MCP_LIST_TIMEOUT_SEC = 120.0
+# Cap on the CLI output quoted back when ``gemini mcp list`` itself fails, so a
+# stack trace does not become the whole run's error message.
+_LISTING_TAIL_CHARS = 800
 
 
 def _build_settings(mcp_servers: tuple[McpBinding, ...], *, skills_enabled: bool) -> dict:
@@ -165,6 +168,14 @@ def _mcp_gate_failure(
     # 0.56 prints the whole listing on stderr, not stdout; read both so the gate
     # does not depend on which stream the CLI happens to use.
     listing = _ANSI_SGR.sub("", f"{completed.stdout or ''}\n{completed.stderr or ''}")
+
+    # A non-zero exit means the CLI never got as far as dialling the servers —
+    # malformed settings.json, an unknown flag, a bad auth config. The listing is
+    # then an error message, and parsing it for status rows would report the
+    # generic "not listed" instead of the cause the CLI already printed.
+    if completed.returncode != 0:
+        detail = listing.strip()[-_LISTING_TAIL_CHARS:]
+        return f"'gemini mcp list' exited {completed.returncode}: {detail or '<no output>'}"
 
     broken: dict[str, str] = {}
     for name in expected:

--- a/devops_bench/agents/cli/gemini_cli/agent.py
+++ b/devops_bench/agents/cli/gemini_cli/agent.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -47,6 +48,7 @@ from devops_bench.agents.shared.cli_capabilities import (
     build_mcp_servers,
     materialize_skills,
 )
+from devops_bench.agents.shared.mcp_probe import McpUnreachableError, preflight_mcp
 from devops_bench.core import SubprocessError, get_logger
 from devops_bench.core.model_providers import resolve_provider
 from devops_bench.core.subprocess import run
@@ -67,6 +69,15 @@ _GEMINI_SETTINGS_FILE = "settings.json"
 _GEMINI_SKILLS_DIR = "skills"
 
 _log = get_logger("agents.cli.gemini_cli")
+
+# ANSI SGR sequences, stripped before parsing: the CLI colourises its status
+# words when FORCE_COLOR is set, which would otherwise defeat the row match.
+_ANSI_SGR = re.compile(r"\x1b\[[0-9;]*m")
+_MCP_CONNECTED = "connected"
+_MCP_NOT_LISTED = "<not listed>"
+# Seconds for ``gemini mcp list``. It starts the binary and dials each server
+# but makes no model call, so it is fast relative to a run.
+_MCP_LIST_TIMEOUT_SEC = 120.0
 
 
 def _build_settings(mcp_servers: tuple[McpBinding, ...], *, skills_enabled: bool) -> dict:
@@ -91,6 +102,108 @@ def _build_settings(mcp_servers: tuple[McpBinding, ...], *, skills_enabled: bool
     return settings
 
 
+def _status_rows(listing: str, name: str) -> list[str]:
+    """Return the status word of every ``gemini mcp list`` row for ``name``.
+
+    One row looks like ``✓ facts: /usr/bin/python server.py (stdio) - Connected``.
+    The pattern is built from the expected name rather than a generic
+    name-matching regex, because a generic one both misses names holding
+    characters outside a word-character class (config keys are arbitrary JSON
+    strings) and
+    conflates ``gke`` with ``gke:prod`` — under which a disabled ``gke`` could be
+    overwritten by a connected ``gke:prod`` and read as connected. Requiring
+    whitespace after the name's colon keeps the two apart.
+    """
+    row = re.compile(rf"^\W*{re.escape(name)}:\s.*\s-\s+(\S+)\s*$", re.MULTILINE)
+    return [match.group(1) for match in row.finditer(listing)]
+
+
+def _verify_cli_sees_mcp(
+    target: str,
+    workdir: Path,
+    expected: tuple[str, ...],
+    *,
+    env_overlay: dict[str, str],
+    timeout: float = _MCP_LIST_TIMEOUT_SEC,
+) -> str:
+    """Return why the CLI cannot use ``expected`` in ``workdir``, or ``""``.
+
+    A reachable server is not the same as a *usable* one. Gemini gates MCP on
+    folder trust, and an untrusted workspace disables every configured server
+    **without emitting anything on the run's stderr** — the model simply has no
+    MCP tools and answers from the shell. ``gemini mcp list`` is the only view
+    that reports the post-trust state, so it is the gate here.
+
+    The row status must read ``Connected`` for every expected server. Anything
+    else — ``Disabled`` (untrusted), ``Disconnected`` (server failed), or a row
+    that no longer parses because the output format changed — is a failure, so
+    a future format change fails loud instead of passing silently.
+
+    Args:
+        target: Path to the ``gemini`` binary.
+        workdir: Workspace whose ``.gemini/settings.json`` is under test.
+        expected: Server names that must be connected.
+        env_overlay: Env overlay the run itself uses, so ``${VAR}`` references
+            in the settings resolve the same way here.
+        timeout: Seconds before the listing is abandoned.
+
+    Returns:
+        A human-readable reason, or ``""`` when every expected server is
+        connected.
+    """
+    try:
+        completed = run(
+            [target, "mcp", "list"],
+            extra_env=env_overlay,
+            cwd=workdir,
+            check=False,
+            timeout=timeout,
+        )
+    except (SubprocessError, OSError) as exc:
+        return f"could not run 'gemini mcp list': {exc}"
+
+    # 0.56 prints the whole listing on stderr, not stdout; read both so the gate
+    # does not depend on which stream the CLI happens to use.
+    listing = _ANSI_SGR.sub("", f"{completed.stdout or ''}\n{completed.stderr or ''}")
+
+    broken: dict[str, str] = {}
+    for name in expected:
+        statuses = _status_rows(listing, name)
+        if not statuses:
+            broken[name] = _MCP_NOT_LISTED
+        elif any(status.lower() != _MCP_CONNECTED for status in statuses):
+            # Every row for a name must agree; a duplicate that disagrees is a
+            # failure rather than something the last row gets to overwrite.
+            broken[name] = "/".join(sorted(set(statuses)))
+    if not broken:
+        return ""
+    detail = ", ".join(f"{name} ({status})" for name, status in sorted(broken.items()))
+    return f"the CLI does not report these servers as connected: {detail}"
+
+
+def _probe_failure_detail(
+    mcp_servers: tuple[McpBinding, ...],
+    *,
+    env_overlay: dict[str, str],
+    workdir: Path,
+) -> str:
+    """Return why a server is unusable, as a suffix for the gate's message.
+
+    ``gemini mcp list`` reports *that* a server is unusable, never why. The stdio
+    probe supplies the cause (the server's own stderr), so it is run only once
+    the gate has already failed — on the happy path the CLI's own launch is the
+    single source of truth and the probe would be a redundant second launch of
+    every server, paid on every run of the matrix.
+    """
+    try:
+        preflight_mcp(mcp_servers, base_env={**os.environ, **env_overlay}, cwd=workdir)
+    except McpUnreachableError as exc:
+        return f"; {exc}"
+    # Reachable but unusable is the folder-trust case: the servers answer this
+    # probe fine and the CLI still refuses to enable them.
+    return "; every server answered a direct stdio probe, so this is a CLI-side gate (folder trust)"
+
+
 def _build_argv(
     target: str,
     prompt: str,
@@ -110,11 +223,12 @@ def _build_argv(
     included, reaches the parser since argv bypasses the shell), and ``-e none``
     loads an extension literally named "none" rather than disabling.
 
-    Note: MCP servers only load when the workspace is *trusted*. The per-run temp
-    cwd is untrusted by default, so the bastion sets
-    ``security.folderTrust.enabled = false`` in the user-level
-    ``~/.gemini/settings.json`` (``--skip-trust`` alone does not lift the MCP
-    gate). See ``scripts/bastion/vm-setup.sh``.
+    Note: MCP servers only load when the workspace is *trusted*, and the per-run
+    temp cwd is untrusted by default. ``--skip-trust`` does **not** lift the MCP
+    gate (verified on 0.56: the run gets no MCP tools and no warning), so the
+    host must trust the workspace — via a ``~/.gemini/trustedFolders.json``
+    entry, or the user-level ``security.folderTrust.enabled = false`` where that
+    still works. :func:`_verify_cli_sees_mcp` fails the run when it does not.
 
     Args:
         target: Path to the ``gemini`` binary (already user-expanded).
@@ -248,6 +362,16 @@ class GeminiCliAgent(AgentHarness):
                 (gemini_dir / _GEMINI_SETTINGS_FILE).write_text(
                     json.dumps(settings, indent=2), encoding="utf-8"
                 )
+
+            expected = tuple(build_mcp_servers(caps.mcp_servers))
+            if expected:
+                reason = _verify_cli_sees_mcp(target, workdir, expected, env_overlay=env_overlay)
+                if reason:
+                    detail = _probe_failure_detail(
+                        caps.mcp_servers, env_overlay=env_overlay, workdir=workdir
+                    )
+                    return AgentResult.errored(f"MCP preflight failed: {reason}{detail}")
+
             try:
                 completed = run(
                     argv,

--- a/devops_bench/agents/cli/gemini_cli/agent.py
+++ b/devops_bench/agents/cli/gemini_cli/agent.py
@@ -118,7 +118,7 @@ def _status_rows(listing: str, name: str) -> list[str]:
     return [match.group(1) for match in row.finditer(listing)]
 
 
-def _verify_cli_sees_mcp(
+def _mcp_gate_failure(
     target: str,
     workdir: Path,
     expected: tuple[str, ...],
@@ -228,7 +228,7 @@ def _build_argv(
     gate (verified on 0.56: the run gets no MCP tools and no warning), so the
     host must trust the workspace — via a ``~/.gemini/trustedFolders.json``
     entry, or the user-level ``security.folderTrust.enabled = false`` where that
-    still works. :func:`_verify_cli_sees_mcp` fails the run when it does not.
+    still works. :func:`_mcp_gate_failure` fails the run when it does not.
 
     Args:
         target: Path to the ``gemini`` binary (already user-expanded).
@@ -365,7 +365,7 @@ class GeminiCliAgent(AgentHarness):
 
             expected = tuple(build_mcp_servers(caps.mcp_servers))
             if expected:
-                reason = _verify_cli_sees_mcp(target, workdir, expected, env_overlay=env_overlay)
+                reason = _mcp_gate_failure(target, workdir, expected, env_overlay=env_overlay)
                 if reason:
                     detail = _probe_failure_detail(
                         caps.mcp_servers, env_overlay=env_overlay, workdir=workdir

--- a/devops_bench/agents/cli/openclaw/agent.py
+++ b/devops_bench/agents/cli/openclaw/agent.py
@@ -74,6 +74,7 @@ from devops_bench.agents.shared.cli_capabilities import (
     build_mcp_servers,
     materialize_skills,
 )
+from devops_bench.agents.shared.mcp_probe import McpUnreachableError, preflight_mcp
 from devops_bench.core import SubprocessError, get_logger
 from devops_bench.core.errors import ConfigError
 from devops_bench.core.model_providers import resolve_provider
@@ -442,6 +443,21 @@ class OpenClawAgent(AgentHarness):
         with agent_workdir(workspace_path, prefix="oc-run-") as workdir:
             state_dir = workdir / _OPENCLAW_STATE_DIRNAME
             state_dir.mkdir(parents=True, exist_ok=True)
+
+            try:
+                # Inside the workdir so the probe launches each server exactly as
+                # oc will: a relative path in a binding's args resolves the same
+                # way in both, instead of probing green and failing under the CLI.
+                # openclaw has no `mcp list` equivalent, so this is the only gate.
+                preflight_mcp(
+                    caps.mcp_servers,
+                    base_env={**os.environ, **_build_env(self.config)},
+                    cwd=workdir,
+                )
+            except McpUnreachableError as exc:
+                # Fatal: a granted-but-dead server leaves oc running tool-less and
+                # exiting 0, which would score as a clean MCP arm.
+                return AgentResult.errored(f"MCP preflight failed: {exc}")
 
             materialize_skills(state_dir / _OPENCLAW_SKILLS_DIRNAME, caps.skills.paths)
 

--- a/devops_bench/agents/cli/openclaw/agent.py
+++ b/devops_bench/agents/cli/openclaw/agent.py
@@ -443,6 +443,7 @@ class OpenClawAgent(AgentHarness):
         with agent_workdir(workspace_path, prefix="oc-run-") as workdir:
             state_dir = workdir / _OPENCLAW_STATE_DIRNAME
             state_dir.mkdir(parents=True, exist_ok=True)
+            env_overlay = _build_env(self.config)
 
             try:
                 # Inside the workdir so the probe launches each server exactly as
@@ -451,7 +452,7 @@ class OpenClawAgent(AgentHarness):
                 # openclaw has no `mcp list` equivalent, so this is the only gate.
                 preflight_mcp(
                     caps.mcp_servers,
-                    base_env={**os.environ, **_build_env(self.config)},
+                    base_env={**os.environ, **env_overlay},
                     cwd=workdir,
                 )
             except McpUnreachableError as exc:
@@ -461,7 +462,6 @@ class OpenClawAgent(AgentHarness):
 
             materialize_skills(state_dir / _OPENCLAW_SKILLS_DIRNAME, caps.skills.paths)
 
-            env_overlay = _build_env(self.config)
             env_overlay["OPENCLAW_STATE_DIR"] = str(state_dir)
 
             config_payload = _build_openclaw_config(self.config, caps.mcp_servers)

--- a/devops_bench/agents/config.py
+++ b/devops_bench/agents/config.py
@@ -16,9 +16,12 @@
 
 from __future__ import annotations
 
+import json
+import os
 import shlex
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from devops_bench.agents.capabilities import (
     AgentRules,
@@ -26,7 +29,7 @@ from devops_bench.agents.capabilities import (
     McpBinding,
     SkillBinding,
 )
-from devops_bench.core import get_env, get_int
+from devops_bench.core import ConfigError, get_env, get_int
 
 __all__ = ["AgentConfig"]
 
@@ -38,31 +41,147 @@ def _parse_csv(raw: str | None) -> tuple[str, ...]:
     return tuple(item.strip() for item in raw.split(",") if item.strip())
 
 
+def _load_mcp_config(raw: str) -> dict:
+    """Load ``AGENT_MCP_CONFIG`` from inline JSON or from a file path.
+
+    A value starting with ``{`` is inline JSON; anything else is a path. Both
+    forms exist because the two call sites differ: a one-off local run passes
+    the document inline, while the matrix joins its env with ``;`` and evaluates
+    it over ssh, where a quoted JSON blob does not survive.
+
+    Args:
+        raw: The variable's value, already known to be non-empty.
+
+    Returns:
+        The parsed document.
+
+    Raises:
+        ConfigError: If the path is missing or the JSON is malformed.
+    """
+    text = raw.strip()
+    if not text.startswith("{"):
+        path = Path(os.path.expanduser(text))
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ConfigError(f"AGENT_MCP_CONFIG path is unreadable: {exc}") from exc
+    try:
+        document = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"AGENT_MCP_CONFIG is not valid JSON: {exc}") from exc
+    if not isinstance(document, dict):
+        raise ConfigError("AGENT_MCP_CONFIG must be a JSON object")
+    return document
+
+
+def _parse_mcp_config(raw: str, default_tools: tuple[str, ...]) -> tuple[McpBinding, ...]:
+    """Build MCP bindings from the standard ``mcpServers`` document.
+
+    The schema is the one Claude Code (``--mcp-config``), Cursor, and the wider
+    ecosystem already read, so a server config can be copied between them
+    unchanged::
+
+        {"mcpServers": {"github": {"command": "npx",
+                                   "args": ["-y", "@modelcontextprotocol/server-github"],
+                                   "env": {"GITHUB_TOKEN": "${GITHUB_TOKEN}"}}}}
+
+    ``tools`` is an optional per-server extension (ignored by other readers)
+    naming the tools to pre-approve; servers omitting it inherit
+    ``default_tools`` from ``AGENT_ALLOWED_TOOLS``.
+
+    Args:
+        raw: The raw ``AGENT_MCP_CONFIG`` value (inline JSON or a path).
+        default_tools: Tool names applied to servers that declare none.
+
+    Returns:
+        One binding per entry, in document order.
+
+    Raises:
+        ConfigError: If the document is malformed or an entry has no ``command``.
+    """
+    servers = _load_mcp_config(raw).get("mcpServers")
+    if servers is None:
+        raise ConfigError("AGENT_MCP_CONFIG has no 'mcpServers' key")
+    if not isinstance(servers, dict):
+        raise ConfigError("AGENT_MCP_CONFIG 'mcpServers' must be a JSON object")
+    if not servers:
+        # An arm that grants nothing leaves AGENT_MCP_CONFIG unset. Setting it to
+        # an empty document instead yields a no-MCP run that still reports as an
+        # MCP arm — the silent-pass this whole path exists to prevent.
+        raise ConfigError("AGENT_MCP_CONFIG 'mcpServers' is empty; unset the variable instead")
+
+    bindings: list[McpBinding] = []
+    for name, entry in servers.items():
+        if not isinstance(entry, dict):
+            raise ConfigError(f"AGENT_MCP_CONFIG server {name!r} must be a JSON object")
+        command = entry.get("command")
+        if not isinstance(command, str) or not command:
+            raise ConfigError(f"AGENT_MCP_CONFIG server {name!r} needs a non-empty 'command'")
+        args = entry.get("args") or []
+        if not isinstance(args, list) or not all(isinstance(a, str) for a in args):
+            raise ConfigError(f"AGENT_MCP_CONFIG server {name!r} 'args' must be a list of strings")
+        env = entry.get("env") or {}
+        if not isinstance(env, dict) or not all(
+            isinstance(k, str) and isinstance(v, str) for k, v in env.items()
+        ):
+            raise ConfigError(f"AGENT_MCP_CONFIG server {name!r} 'env' must be a string mapping")
+        tools = entry.get("tools")
+        if tools is not None and (
+            not isinstance(tools, list) or not all(isinstance(t, str) for t in tools)
+        ):
+            raise ConfigError(f"AGENT_MCP_CONFIG server {name!r} 'tools' must be a list of strings")
+        cwd = entry.get("cwd") or ""
+        if not isinstance(cwd, str):
+            raise ConfigError(f"AGENT_MCP_CONFIG server {name!r} 'cwd' must be a string")
+        bindings.append(
+            McpBinding(
+                name=name,
+                command=(command, *args),
+                env=tuple(env.items()),
+                cwd=cwd,
+                tools=tuple(tools) if tools is not None else default_tools,
+            )
+        )
+    return tuple(bindings)
+
+
 def _build_capabilities_from_env(env: Mapping[str, str] | None) -> AllCapabilities:
     """Build an :class:`AllCapabilities` aggregate from ``AGENT_*`` env vars.
 
-    Reads ``AGENT_MCP_SERVER`` (shell-quoted argv) and ``AGENT_ALLOWED_TOOLS``
-    (CSV) into a single :class:`McpBinding` when either is set;
-    ``AGENT_SKILLS_PATHS`` (CSV) into a :class:`SkillBinding`; and
-    ``AGENT_RULES_TEXT`` into :class:`AgentRules`. A missing variable yields
-    the default (empty) shape, so the function never raises on unset values
-    and a fully unset env produces a default :class:`AllCapabilities`.
+    MCP servers come from ``AGENT_MCP_CONFIG`` (a standard ``mcpServers``
+    document, inline or a path — see :func:`_parse_mcp_config`) which supports
+    any number of servers with their own env and cwd. ``AGENT_MCP_SERVER``
+    (shell-quoted argv) remains the single-server shorthand and is read only
+    when ``AGENT_MCP_CONFIG`` is unset. ``AGENT_ALLOWED_TOOLS`` (CSV) supplies
+    the tool list for servers that declare none. ``AGENT_SKILLS_PATHS`` (CSV)
+    becomes a :class:`SkillBinding` and ``AGENT_RULES_TEXT`` becomes
+    :class:`AgentRules`. A missing variable yields the default (empty) shape,
+    so a fully unset env produces a default :class:`AllCapabilities`.
 
     Args:
         env: Optional mapping read from (defaults to ``os.environ``).
 
     Returns:
         A populated :class:`AllCapabilities`.
+
+    Raises:
+        ConfigError: If ``AGENT_MCP_CONFIG`` is set but malformed. A broken
+            capability grant fails loud rather than running an MCP arm with no
+            MCP server.
     """
-    mcp_command_raw = get_env("AGENT_MCP_SERVER", env=env) or ""
-    mcp_command = tuple(shlex.split(mcp_command_raw)) if mcp_command_raw else ()
     allowed_tools = _parse_csv(get_env("AGENT_ALLOWED_TOOLS", env=env))
+    mcp_config_raw = (get_env("AGENT_MCP_CONFIG", env=env) or "").strip()
 
     mcp_servers: tuple[McpBinding, ...] = ()
-    if mcp_command or allowed_tools:
-        # ``name="default"`` is generic: env-driven from_env has no catalog to
-        # pull a real name from, and the agent never inspects it.
-        mcp_servers = (McpBinding(name="default", command=mcp_command, tools=allowed_tools),)
+    if mcp_config_raw:
+        mcp_servers = _parse_mcp_config(mcp_config_raw, allowed_tools)
+    else:
+        mcp_command_raw = get_env("AGENT_MCP_SERVER", env=env) or ""
+        mcp_command = tuple(shlex.split(mcp_command_raw)) if mcp_command_raw else ()
+        if mcp_command or allowed_tools:
+            # ``name="default"`` is generic: the shorthand carries no name and
+            # the agent never inspects it.
+            mcp_servers = (McpBinding(name="default", command=mcp_command, tools=allowed_tools),)
 
     skills_paths = _parse_csv(get_env("AGENT_SKILLS_PATHS", env=env))
     skills = SkillBinding(paths=skills_paths)
@@ -124,10 +243,10 @@ class AgentConfig:
         Reads ``AGENT_MODEL`` / ``AGENT_PROVIDER`` / ``AGENT_API_KEY`` /
         ``AGENT_TARGET`` / ``AGENT_TIMEOUT_SEC`` / ``AGENT_MAX_TURNS`` /
         ``AGENT_EXTRA_FLAGS`` and delegates capability construction
-        (``AGENT_MCP_SERVER`` / ``AGENT_ALLOWED_TOOLS`` / ``AGENT_SKILLS_PATHS`` /
-        ``AGENT_RULES_TEXT``) to :func:`_build_capabilities_from_env`. A missing
-        variable yields the dataclass default — this method never raises on unset
-        variables.
+        (``AGENT_MCP_CONFIG`` / ``AGENT_MCP_SERVER`` / ``AGENT_ALLOWED_TOOLS`` /
+        ``AGENT_SKILLS_PATHS`` / ``AGENT_RULES_TEXT``) to
+        :func:`_build_capabilities_from_env`. A missing variable yields the
+        dataclass default — this method never raises on unset variables.
 
         Args:
             env: Optional mapping to read from (defaults to ``os.environ``).
@@ -135,6 +254,9 @@ class AgentConfig:
 
         Returns:
             A populated :class:`AgentConfig`.
+
+        Raises:
+            ConfigError: If ``AGENT_MCP_CONFIG`` is set but malformed.
         """
         timeout = get_int("AGENT_TIMEOUT_SEC", env=env)
         max_turns = get_int("AGENT_MAX_TURNS", env=env)

--- a/devops_bench/agents/config.py
+++ b/devops_bench/agents/config.py
@@ -56,7 +56,8 @@ def _load_mcp_config(raw: str) -> dict:
         The parsed document.
 
     Raises:
-        ConfigError: If the path is missing or the JSON is malformed.
+        ConfigError: If the path is missing, undecodable, or the JSON is
+            malformed.
     """
     text = raw.strip()
     if not text.startswith("{"):
@@ -65,6 +66,8 @@ def _load_mcp_config(raw: str) -> dict:
             text = path.read_text(encoding="utf-8")
         except OSError as exc:
             raise ConfigError(f"AGENT_MCP_CONFIG path is unreadable: {exc}") from exc
+        except UnicodeError as exc:
+            raise ConfigError(f"AGENT_MCP_CONFIG file is not valid UTF-8: {exc}") from exc
     try:
         document = json.loads(text)
     except json.JSONDecodeError as exc:

--- a/devops_bench/agents/config.py
+++ b/devops_bench/agents/config.py
@@ -117,10 +117,12 @@ def _parse_mcp_config(raw: str, default_tools: tuple[str, ...]) -> tuple[McpBind
         command = entry.get("command")
         if not isinstance(command, str) or not command:
             raise ConfigError(f"AGENT_MCP_CONFIG server {name!r} needs a non-empty 'command'")
-        args = entry.get("args") or []
+        args = entry.get("args")
+        args = [] if args is None else args
         if not isinstance(args, list) or not all(isinstance(a, str) for a in args):
             raise ConfigError(f"AGENT_MCP_CONFIG server {name!r} 'args' must be a list of strings")
-        env = entry.get("env") or {}
+        env = entry.get("env")
+        env = {} if env is None else env
         if not isinstance(env, dict) or not all(
             isinstance(k, str) and isinstance(v, str) for k, v in env.items()
         ):
@@ -130,7 +132,8 @@ def _parse_mcp_config(raw: str, default_tools: tuple[str, ...]) -> tuple[McpBind
             not isinstance(tools, list) or not all(isinstance(t, str) for t in tools)
         ):
             raise ConfigError(f"AGENT_MCP_CONFIG server {name!r} 'tools' must be a list of strings")
-        cwd = entry.get("cwd") or ""
+        cwd = entry.get("cwd")
+        cwd = "" if cwd is None else cwd
         if not isinstance(cwd, str):
             raise ConfigError(f"AGENT_MCP_CONFIG server {name!r} 'cwd' must be a string")
         bindings.append(

--- a/devops_bench/agents/config.py
+++ b/devops_bench/agents/config.py
@@ -80,8 +80,10 @@ class _McpServerSpec(BaseModel):
     junk argument and report the resulting failure as unreachability.
 
     Attributes:
-        command: The server binary. Required and non-empty — a binding with no
-            command is "no MCP", which is a grant that scores as an MCP arm.
+        command: The server binary. Required, and must hold a non-whitespace
+            character — a binding with no command is "no MCP", which is a grant
+            that scores as an MCP arm, and an all-whitespace one splits to the
+            same nothing.
         args: Arguments appended to ``command``.
         env: Declared child env; secret-named values must be ``${VAR}``
             references, enforced by :func:`_reject_literal_secrets`.
@@ -93,7 +95,7 @@ class _McpServerSpec(BaseModel):
 
     model_config = ConfigDict(strict=True)
 
-    command: str = Field(min_length=1)
+    command: str = Field(min_length=1, pattern=r"\S")
     args: list[str] = Field(default_factory=list)
     env: dict[str, str] = Field(default_factory=dict)
     cwd: str = ""

--- a/devops_bench/agents/config.py
+++ b/devops_bench/agents/config.py
@@ -18,10 +18,14 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from devops_bench.agents.capabilities import (
     AgentRules,
@@ -32,6 +36,76 @@ from devops_bench.agents.capabilities import (
 from devops_bench.core import ConfigError, get_env, get_int
 
 __all__ = ["AgentConfig"]
+
+
+# ``${VAR}`` reference in a declared MCP env value — the same form
+# :func:`~devops_bench.agents.shared.mcp_probe.expand_env` resolves for the probe
+# and every supported CLI resolves for the server it launches.
+_ENV_REF = re.compile(r"\$\{\w+\}")
+
+# Env keys whose value must be a reference, never a literal. A binding's ``env``
+# is written verbatim into the CLI's config file inside the agent's workspace,
+# and the harness collects that workspace wholesale into the run's artifacts, so
+# a pasted credential would be persisted with the results.
+_SECRET_KEY_HINTS: tuple[str, ...] = ("TOKEN", "KEY", "SECRET", "PASSWORD", "CREDENTIAL")
+
+
+def _reject_literal_secrets(name: str, env: dict[str, str]) -> None:
+    """Fail when a secret-named env value carries a literal instead of ``${VAR}``.
+
+    Args:
+        name: The server name, for the error message.
+        env: The server's declared ``env`` mapping.
+
+    Raises:
+        ConfigError: If a secret-named key holds a value with no ``${VAR}``
+            reference in it.
+    """
+    for key, value in env.items():
+        if not value or _ENV_REF.search(value):
+            continue
+        if any(hint in key.upper() for hint in _SECRET_KEY_HINTS):
+            raise ConfigError(
+                f"AGENT_MCP_CONFIG server {name!r} env {key!r} looks like a credential but "
+                f"holds a literal; use a '${{{key}}}' reference so the value stays out of "
+                "the run's artifacts"
+            )
+
+
+class _McpServerSpec(BaseModel):
+    """One entry of the standard ``mcpServers`` document.
+
+    Strict so a wrong JSON type fails the grant instead of being coerced: an
+    ``args`` of ``0`` silently becoming ``["0"]`` would launch the server with a
+    junk argument and report the resulting failure as unreachability.
+
+    Attributes:
+        command: The server binary. Required and non-empty — a binding with no
+            command is "no MCP", which is a grant that scores as an MCP arm.
+        args: Arguments appended to ``command``.
+        env: Declared child env; secret-named values must be ``${VAR}``
+            references, enforced by :func:`_reject_literal_secrets`.
+        cwd: Working directory the server is launched in; ``""`` for inherit.
+        tools: Tools to pre-approve, or ``None`` to inherit
+            ``AGENT_ALLOWED_TOOLS``. The distinction matters: an explicit ``[]``
+            grants none.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    command: str = Field(min_length=1)
+    args: list[str] = Field(default_factory=list)
+    env: dict[str, str] = Field(default_factory=dict)
+    cwd: str = ""
+    tools: list[str] | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _drop_nulls(cls, data: Any) -> Any:
+        """Treat an explicit ``null`` as absent so the field default applies."""
+        if isinstance(data, dict):
+            return {key: value for key, value in data.items() if value is not None}
+        return data
 
 
 def _parse_csv(raw: str | None) -> tuple[str, ...]:
@@ -99,8 +173,12 @@ def _parse_mcp_config(raw: str, default_tools: tuple[str, ...]) -> tuple[McpBind
     Returns:
         One binding per entry, in document order.
 
+    A secret-named ``env`` value must be a ``${VAR}`` reference, not a literal —
+    see :func:`_reject_literal_secrets`.
+
     Raises:
-        ConfigError: If the document is malformed or an entry has no ``command``.
+        ConfigError: If the document is malformed, an entry has no ``command``,
+            or a secret-named ``env`` value holds a literal.
     """
     servers = _load_mcp_config(raw).get("mcpServers")
     if servers is None:
@@ -117,35 +195,22 @@ def _parse_mcp_config(raw: str, default_tools: tuple[str, ...]) -> tuple[McpBind
     for name, entry in servers.items():
         if not isinstance(entry, dict):
             raise ConfigError(f"AGENT_MCP_CONFIG server {name!r} must be a JSON object")
-        command = entry.get("command")
-        if not isinstance(command, str) or not command:
-            raise ConfigError(f"AGENT_MCP_CONFIG server {name!r} needs a non-empty 'command'")
-        args = entry.get("args")
-        args = [] if args is None else args
-        if not isinstance(args, list) or not all(isinstance(a, str) for a in args):
-            raise ConfigError(f"AGENT_MCP_CONFIG server {name!r} 'args' must be a list of strings")
-        env = entry.get("env")
-        env = {} if env is None else env
-        if not isinstance(env, dict) or not all(
-            isinstance(k, str) and isinstance(v, str) for k, v in env.items()
-        ):
-            raise ConfigError(f"AGENT_MCP_CONFIG server {name!r} 'env' must be a string mapping")
-        tools = entry.get("tools")
-        if tools is not None and (
-            not isinstance(tools, list) or not all(isinstance(t, str) for t in tools)
-        ):
-            raise ConfigError(f"AGENT_MCP_CONFIG server {name!r} 'tools' must be a list of strings")
-        cwd = entry.get("cwd")
-        cwd = "" if cwd is None else cwd
-        if not isinstance(cwd, str):
-            raise ConfigError(f"AGENT_MCP_CONFIG server {name!r} 'cwd' must be a string")
+        try:
+            spec = _McpServerSpec.model_validate(entry)
+        except ValidationError as exc:
+            detail = "; ".join(
+                f"{'.'.join(str(part) for part in err['loc'])}: {err['msg']}"
+                for err in exc.errors()
+            )
+            raise ConfigError(f"AGENT_MCP_CONFIG server {name!r} is invalid: {detail}") from exc
+        _reject_literal_secrets(name, spec.env)
         bindings.append(
             McpBinding(
                 name=name,
-                command=(command, *args),
-                env=tuple(env.items()),
-                cwd=cwd,
-                tools=tuple(tools) if tools is not None else default_tools,
+                command=(spec.command, *spec.args),
+                env=tuple(spec.env.items()),
+                cwd=spec.cwd,
+                tools=tuple(spec.tools) if spec.tools is not None else default_tools,
             )
         )
     return tuple(bindings)

--- a/devops_bench/agents/shared/cli_capabilities.py
+++ b/devops_bench/agents/shared/cli_capabilities.py
@@ -158,7 +158,9 @@ def materialize_skills(skills_root: Path, paths: tuple[str, ...]) -> list[str]:
     copying ``SKILL.md`` alone leaves those instructions pointing at nothing.
 
     Symlinks are recreated rather than dereferenced, and any resolving outside
-    the bundle are dropped — see :func:`_ignore_escaping_links`.
+    the bundle are dropped — see :func:`_ignore_escaping_links`. A ``SKILL.md``
+    sitting directly in a discovery root is skipped with a warning: its bundle
+    would be the entire tree, nesting every sibling skill inside it.
 
     Args:
         skills_root: The destination skills directory to populate.
@@ -170,11 +172,24 @@ def materialize_skills(skills_root: Path, paths: tuple[str, ...]) -> list[str]:
     Returns:
         The names of the skills materialized, in discovery order.
     """
+    roots = {Path(os.path.expanduser(path)).resolve() for path in paths if path}
     written: list[str] = []
     for skill in iter_skills(paths):
+        bundle = Path(skill.path).parent
+        if bundle.resolve() in roots:
+            # A ``SKILL.md`` at the top of a discovery path makes its "bundle"
+            # the whole tree, so copying it would nest every sibling skill
+            # inside this one — and each sibling is materialized again in its
+            # own right. Skills live one directory down; say so and skip.
+            _log.warning(
+                "Skipping skill %r: its SKILL.md sits at the discovery root %s, so its "
+                "bundle would be every other skill in that tree",
+                skill.name,
+                bundle,
+            )
+            continue
         dest_dir = skills_root / skill.name
         dest_dir.parent.mkdir(parents=True, exist_ok=True)
-        bundle = Path(skill.path).parent
         shutil.copytree(
             bundle,
             dest_dir,

--- a/devops_bench/agents/shared/cli_capabilities.py
+++ b/devops_bench/agents/shared/cli_capabilities.py
@@ -25,7 +25,7 @@ import contextlib
 import os
 import shutil
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -116,7 +116,9 @@ def build_mcp_servers(mcp_servers: tuple[McpBinding, ...]) -> dict[str, dict]:
     return servers
 
 
-def _ignore_escaping_links(bundle: Path):
+def _ignore_escaping_links(
+    bundle: Path,
+) -> Callable[[str | os.PathLike[str], list[str]], set[str]]:
     """Return a :func:`shutil.copytree` ``ignore`` callback dropping escaping links.
 
     A skill bundle is data the harness copies into the agent's workspace, and
@@ -126,7 +128,7 @@ def _ignore_escaping_links(bundle: Path):
     """
     root = bundle.resolve()
 
-    def _ignore(dirpath: str, names: list[str]) -> set[str]:
+    def _ignore(dirpath: str | os.PathLike[str], names: list[str]) -> set[str]:
         skipped: set[str] = set()
         for name in names:
             entry = Path(dirpath) / name

--- a/devops_bench/agents/shared/cli_capabilities.py
+++ b/devops_bench/agents/shared/cli_capabilities.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import shutil
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
@@ -37,8 +38,6 @@ if TYPE_CHECKING:
 __all__ = ["agent_workdir", "build_mcp_servers", "materialize_skills"]
 
 _log = get_logger("agents.shared.cli_capabilities")
-
-_SKILL_FILE = "SKILL.md"
 
 
 @contextlib.contextmanager
@@ -77,12 +76,19 @@ def build_mcp_servers(mcp_servers: tuple[McpBinding, ...]) -> dict[str, dict]:
     it is resolved to its absolute path to prevent execution ambiguity in the
     agent's workspace. If it does not exist, a warning is logged.
 
+    A binding's ``env`` values are rendered **verbatim**, so a ``${VAR}``
+    reference reaches the config file unexpanded and the CLI resolves it from
+    the subprocess environment. Expanding here would write the credential into
+    the agent's workspace, which the harness copies wholesale into the run's
+    artifacts.
+
     Args:
         mcp_servers: Bindings granted for the run.
 
     Returns:
-        A ``{name: {"command": ..., "args": [...]}}`` mapping suitable for the
-        agent's MCP-servers config section. Empty when no binding carries a
+        A ``{name: {"command": ..., "args": [...], "env": {...}, "cwd": ...}}``
+        mapping suitable for the agent's MCP-servers config section, carrying
+        only the keys a binding populates. Empty when no binding carries a
         command.
     """
     servers: dict[str, dict] = {}
@@ -102,16 +108,55 @@ def build_mcp_servers(mcp_servers: tuple[McpBinding, ...]) -> dict[str, dict]:
         entry: dict = {"command": cmd}
         if len(binding.command) > 1:
             entry["args"] = list(binding.command[1:])
+        if binding.env:
+            entry["env"] = dict(binding.env)
+        if binding.cwd:
+            entry["cwd"] = binding.cwd
         servers[name] = entry
     return servers
 
 
+def _ignore_escaping_links(bundle: Path):
+    """Return a :func:`shutil.copytree` ``ignore`` callback dropping escaping links.
+
+    A skill bundle is data the harness copies into the agent's workspace, and
+    that workspace is collected wholesale into the run's artifacts. A symlink
+    resolving outside the bundle would pull host files along with it, so those
+    entries are skipped and named in the log.
+    """
+    root = bundle.resolve()
+
+    def _ignore(dirpath: str, names: list[str]) -> set[str]:
+        skipped: set[str] = set()
+        for name in names:
+            entry = Path(dirpath) / name
+            if not entry.is_symlink():
+                continue
+            try:
+                target = entry.resolve()
+            except OSError:
+                skipped.add(name)
+                continue
+            if not target.is_relative_to(root):
+                _log.warning("Skipping skill link %s: resolves outside the bundle", entry)
+                skipped.add(name)
+        return skipped
+
+    return _ignore
+
+
 def materialize_skills(skills_root: Path, paths: tuple[str, ...]) -> list[str]:
-    """Copy discovered ``SKILL.md`` files into a CLI's workspace skills tree.
+    """Copy discovered skill bundles into a CLI's workspace skills tree.
 
     For each ``SKILL.md`` found beneath ``paths`` (the same discovery the API
-    agent performs), the file is written to ``skills_root/<name>/SKILL.md`` using
-    the ``name`` from its frontmatter.
+    agent performs), its **containing directory** is copied to
+    ``skills_root/<name>/`` using the ``name`` from its frontmatter. The whole
+    directory rather than the one file, because a skill routinely instructs the
+    agent to read a sibling (``references/``, ``templates/``, ``scripts/``);
+    copying ``SKILL.md`` alone leaves those instructions pointing at nothing.
+
+    Symlinks are recreated rather than dereferenced, and any resolving outside
+    the bundle are dropped — see :func:`_ignore_escaping_links`.
 
     Args:
         skills_root: The destination skills directory to populate.
@@ -126,8 +171,20 @@ def materialize_skills(skills_root: Path, paths: tuple[str, ...]) -> list[str]:
     written: list[str] = []
     for skill in iter_skills(paths):
         dest_dir = skills_root / skill.name
-        dest_dir.mkdir(parents=True, exist_ok=True)
-        (dest_dir / _SKILL_FILE).write_text(skill.content, encoding="utf-8")
+        dest_dir.parent.mkdir(parents=True, exist_ok=True)
+        bundle = Path(skill.path).parent
+        shutil.copytree(
+            bundle,
+            dest_dir,
+            dirs_exist_ok=True,
+            # Recreate links instead of dereferencing them, and drop any that
+            # leave the bundle. Dereferencing would copy the *contents* of
+            # whatever a link points at into the workspace, so a bundle holding
+            # `creds -> ~/.ssh/id_rsa` would write that key into the run's
+            # collected artifacts; a dangling link would abort the run.
+            symlinks=True,
+            ignore=_ignore_escaping_links(bundle),
+        )
         written.append(skill.name)
         _log.info("Linked skill %s -> %s", skill.name, dest_dir)
     return written

--- a/devops_bench/agents/shared/cli_capabilities.py
+++ b/devops_bench/agents/shared/cli_capabilities.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from devops_bench.agents.shared.skills import iter_skills
-from devops_bench.core import get_logger
+from devops_bench.core import ConfigError, get_logger
 
 if TYPE_CHECKING:
     from devops_bench.agents.capabilities import McpBinding
@@ -90,12 +90,17 @@ def build_mcp_servers(mcp_servers: tuple[McpBinding, ...]) -> dict[str, dict]:
         mapping suitable for the agent's MCP-servers config section, carrying
         only the keys a binding populates. Empty when no binding carries a
         command.
+
+    Raises:
+        ConfigError: If two bindings resolve to the same name.
     """
     servers: dict[str, dict] = {}
     for index, binding in enumerate(mcp_servers):
         if not binding.command:
             continue
         name = binding.name or f"mcp{index}"
+        if name in servers:
+            raise ConfigError(f"two granted MCP servers resolve to the name {name!r}")
         cmd = binding.command[0]
         if os.sep in cmd:
             if os.path.exists(cmd):

--- a/devops_bench/agents/shared/mcp_probe.py
+++ b/devops_bench/agents/shared/mcp_probe.py
@@ -298,8 +298,9 @@ def _read_result(lines: queue.Queue[str | None], request_id: int, deadline: floa
             continue
         if "method" in message or ("result" not in message and "error" not in message):
             continue
-        if "error" in message:
-            raise McpUnreachableError(f"server returned an error: {message['error']}")
+        error = message.get("error")
+        if error is not None:
+            raise McpUnreachableError(f"server returned an error: {error}")
         result = message.get("result")
         return result if isinstance(result, dict) else {}
 
@@ -414,12 +415,15 @@ def _send(proc: subprocess.Popen, message: dict) -> None:
 
     Raises:
         McpUnreachableError: If the server's stdin is already closed — i.e. the
-            process died on launch.
+            process died on launch. ``OSError`` covers the whole family the pipe
+            can fail with (``BrokenPipeError`` when the reader is gone,
+            ``ConnectionResetError`` when it is torn down mid-write); ``ValueError``
+            is what a closed file object raises.
     """
     try:
         proc.stdin.write(json.dumps(message) + "\n")
         proc.stdin.flush()
-    except (BrokenPipeError, ValueError) as exc:
+    except (OSError, ValueError) as exc:
         raise McpUnreachableError(f"server exited before the handshake completed: {exc}") from exc
 
 

--- a/devops_bench/agents/shared/mcp_probe.py
+++ b/devops_bench/agents/shared/mcp_probe.py
@@ -1,0 +1,494 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pre-run reachability probe for granted MCP servers.
+
+A CLI agent that is handed an MCP server which never starts exits 0 with an
+empty error list: the model silently falls back to shell tools and the run is
+still recorded as an MCP arm. :func:`preflight_mcp` closes that hole by
+speaking the MCP stdio handshake directly — ``initialize`` /
+``notifications/initialized`` / ``tools/list`` as newline-delimited JSON-RPC —
+before the agent is invoked, so an unreachable server fails the run instead of
+scoring one.
+
+The handshake is implemented here rather than through the ``mcp`` SDK to keep
+the probe dependency-free; it is ~3 messages and the transport is line-based.
+"""
+
+from __future__ import annotations
+
+import collections
+import contextlib
+import json
+import os
+import queue
+import re
+import signal
+import subprocess
+import threading
+import time
+from collections.abc import Mapping
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING
+
+from devops_bench.core import DevOpsBenchError, get_logger
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from devops_bench.agents.capabilities import McpBinding
+
+__all__ = ["McpUnreachableError", "expand_env", "preflight_mcp", "probe_stdio_server"]
+
+_log = get_logger("agents.shared.mcp_probe")
+
+# Wall-clock budget per server. Servers are probed concurrently, so this is the
+# budget for the slowest one rather than a per-run sum. A cold ``uvx``/``npx``
+# package fetch can exceed it; warm the launcher cache during host setup instead
+# of paying a cold-fetch budget on every run of the matrix.
+PROBE_TIMEOUT_SEC = 30.0
+
+# Servers probed at once. Bounded so a large config cannot fork a process storm.
+_MAX_CONCURRENT_PROBES = 8
+
+# Grace given to a signalled server before escalating, and to a reader thread
+# before its stream is abandoned.
+_SIGNAL_GRACE_SEC = 2.0
+_READER_JOIN_SEC = 2.0
+
+# Caps on what a misbehaving server can accumulate in this process. Only the
+# stderr tail is ever reported, so older output is discarded as it arrives.
+_MAX_STDOUT_LINES = 1000
+_MAX_STDERR_CHUNKS = 64
+_STDERR_TAIL_CHARS = 500
+
+# Protocol revision this probe advertises. Servers negotiate down, so an older
+# server still answers; the reply's version is not enforced.
+_PROTOCOL_VERSION = "2025-06-18"
+
+_CLIENT_INFO = {"name": "devops-bench-preflight", "version": "1"}
+
+# ``${VAR}`` reference in an MCP server's declared env value. Braces are
+# required: a bare ``$VAR`` form would silently mangle any literal value that
+# happens to contain a dollar sign (``p$ssw0rd`` -> ``p``) and would leak the
+# fragment after the ``$`` into the "unset variable" error.
+_ENV_REF = re.compile(r"\$\{(\w+)\}")
+
+
+class McpUnreachableError(DevOpsBenchError):
+    """A granted MCP server did not complete the handshake."""
+
+
+def expand_env(
+    value: str,
+    *,
+    source: Mapping[str, str],
+    missing: list[str] | None = None,
+) -> str:
+    """Substitute ``${VAR}`` references from ``source``.
+
+    MCP configs carry secrets by reference, never by value, so the token stays
+    out of any file written into the agent's workspace (which is collected
+    wholesale into the run's artifacts). This resolves those references for the
+    probe's own child process only.
+
+    Args:
+        value: The raw declared value.
+        source: Mapping references are resolved against (the runner env).
+        missing: Optional list collecting names absent from ``source``, in
+            encounter order. Unresolved references expand to ``""``.
+
+    Returns:
+        ``value`` with every reference substituted.
+    """
+
+    def _sub(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name not in source:
+            if missing is not None and name not in missing:
+                missing.append(name)
+            return ""
+        return source[name]
+
+    return _ENV_REF.sub(_sub, value)
+
+
+def _child_env(binding: McpBinding, base_env: Mapping[str, str]) -> dict[str, str]:
+    """Build the child environment for ``binding``, resolving secret references.
+
+    Raises:
+        McpUnreachableError: If a declared reference is absent from ``base_env``.
+            Fail here rather than launch the server with an empty credential and
+            report the resulting auth error as "unreachable".
+    """
+    env = dict(base_env)
+    missing: list[str] = []
+    for key, raw in binding.env:
+        env[key] = expand_env(raw, source=base_env, missing=missing)
+    if missing:
+        raise McpUnreachableError(f"references unset environment variable(s): {', '.join(missing)}")
+    return env
+
+
+def _secret_values(binding: McpBinding, resolved: Mapping[str, str]) -> tuple[str, ...]:
+    """Return the values ``${VAR}`` expansion injected, for redaction.
+
+    Only values that came from a reference are returned: a literal declared in
+    the config is already visible to anyone reading the config, whereas an
+    expanded reference is a credential this process resolved and must not echo
+    back into a run artifact.
+    """
+    secrets = {
+        resolved[key] for key, raw in binding.env if _ENV_REF.search(raw) and resolved.get(key)
+    }
+    return tuple(sorted(secrets, key=len, reverse=True))
+
+
+def _redact(text: str, secrets: tuple[str, ...]) -> str:
+    """Replace every expanded secret in ``text`` with ``***``.
+
+    Probe failures embed the server's stderr tail, and a server that rejects a
+    credential routinely echoes it (``input_value='ghp_...'``). That text reaches
+    ``AgentResult.errors`` and is persisted to the run's ``results.json``, so it
+    is scrubbed before it can become an artifact.
+    """
+    for secret in secrets:
+        text = text.replace(secret, "***")
+    return text
+
+
+def _pump(stream, sink: queue.Queue) -> None:
+    """Forward each line of ``stream`` onto ``sink``, then a ``None`` sentinel.
+
+    Drops the oldest line when the queue is full: a server that chatters for its
+    whole timeout budget must not grow this process without bound.
+    """
+    try:
+        for line in stream:
+            try:
+                sink.put_nowait(line)
+            except queue.Full:
+                with contextlib.suppress(queue.Empty):  # pragma: no cover - racing consumer
+                    sink.get_nowait()
+                sink.put_nowait(line)
+    finally:
+        sink.put(None)
+
+
+def _drain_stderr(stream, sink: collections.deque) -> None:
+    """Collect ``stream``'s tail into ``sink`` line by line.
+
+    Line-at-a-time rather than one blocking ``read()`` so the tail is available
+    as soon as the process is signalled, instead of only at EOF — the timeout
+    path needs it and never reaches EOF on its own.
+    """
+    try:
+        for line in stream:
+            sink.append(line)
+    except (OSError, ValueError):  # pragma: no cover - stream torn down mid-read
+        pass
+
+
+def _read_result(lines: queue.Queue, request_id: int, deadline: float) -> dict:
+    """Read newline-delimited JSON-RPC until the reply to ``request_id`` arrives.
+
+    Non-JSON lines and unrelated messages (notifications, other ids) are skipped:
+    some servers log to stdout despite the spec reserving it for the protocol.
+    A match must be a *response* — carrying ``result`` or ``error`` and no
+    ``method`` — so a process that merely echoes stdin back (``cat``) cannot pass
+    the handshake by replaying the request's id.
+
+    Raises:
+        McpUnreachableError: On timeout, premature stream end, or an error reply.
+    """
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise McpUnreachableError(f"timed out waiting for response to request {request_id}")
+        try:
+            line = lines.get(timeout=remaining)
+        except queue.Empty:
+            raise McpUnreachableError(
+                f"timed out waiting for response to request {request_id}"
+            ) from None
+        if line is None:
+            raise McpUnreachableError("server closed its stdout before responding")
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(message, dict) or message.get("id") != request_id:
+            continue
+        if "method" in message or ("result" not in message and "error" not in message):
+            continue
+        if "error" in message:
+            raise McpUnreachableError(f"server returned an error: {message['error']}")
+        result = message.get("result")
+        return result if isinstance(result, dict) else {}
+
+
+def probe_stdio_server(
+    binding: McpBinding,
+    *,
+    base_env: Mapping[str, str] | None = None,
+    timeout: float = PROBE_TIMEOUT_SEC,
+    cwd: str | os.PathLike[str] | None = None,
+) -> tuple[str, ...]:
+    """Launch ``binding``'s server, handshake, and return its advertised tools.
+
+    Args:
+        binding: The stdio binding to probe; ``command`` must be non-empty.
+        base_env: Environment the server is launched with and whose values
+            resolve the binding's ``${VAR}`` references. Defaults to
+            ``os.environ``.
+        timeout: Wall-clock budget for launch plus handshake.
+        cwd: Directory to launch the server in when the binding does not pin one.
+            Pass the run's workspace so the probe launches the server exactly as
+            the CLI later will; a relative path in ``args`` resolves the same way
+            in both, instead of probing green and failing under the CLI.
+
+    Returns:
+        The tool names the server advertises, in the order it lists them.
+
+    Raises:
+        McpUnreachableError: If the server cannot be launched, does not complete
+            the handshake within ``timeout``, or answers with a JSON-RPC error,
+            or completes the handshake advertising no tools.
+    """
+    env = _child_env(binding, os.environ if base_env is None else base_env)
+    secrets = _secret_values(binding, env)
+    deadline = time.monotonic() + timeout
+    try:
+        proc = subprocess.Popen(  # noqa: S603 - argv list, never a shell string
+            list(binding.command),
+            cwd=binding.cwd or cwd or None,
+            env=env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            # Own process group, so _terminate can signal the whole tree. A
+            # launcher (uvx/npx/sh -c/docker) spawns the real server as a child
+            # that inherits these pipes; signalling only the launcher leaves the
+            # grandchild holding the write end, and the reader threads then never
+            # reach EOF.
+            start_new_session=True,
+        )
+    except OSError as exc:
+        raise McpUnreachableError(f"could not launch server: {exc}") from exc
+
+    lines: queue.Queue = queue.Queue(maxsize=_MAX_STDOUT_LINES)
+    stderr_tail: collections.deque = collections.deque(maxlen=_MAX_STDERR_CHUNKS)
+    readers = (
+        threading.Thread(target=_pump, args=(proc.stdout, lines), daemon=True),
+        threading.Thread(target=_drain_stderr, args=(proc.stderr, stderr_tail), daemon=True),
+    )
+    for reader in readers:
+        reader.start()
+
+    try:
+        try:
+            _send(
+                proc, {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": _init_params()}
+            )
+            _read_result(lines, 1, deadline)
+            _send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+            _send(proc, {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+            listing = _read_result(lines, 2, deadline)
+        except McpUnreachableError as exc:
+            # Signal first: on a timeout the server is still running and its
+            # stderr reader has not reached EOF, so the tail is empty until the
+            # process is stopped — and the timeout path is exactly the one whose
+            # cause the stderr explains.
+            _terminate(proc, readers)
+            stderr = _redact("".join(stderr_tail).strip(), secrets)
+            detail = f"{exc}; stderr: {stderr[-_STDERR_TAIL_CHARS:]}" if stderr else str(exc)
+            raise McpUnreachableError(detail) from exc
+    finally:
+        _terminate(proc, readers)
+
+    tools = listing.get("tools")
+    names = (
+        tuple(t["name"] for t in tools if isinstance(t, dict) and isinstance(t.get("name"), str))
+        if isinstance(tools, list)
+        else ()
+    )
+    if not names:
+        # A granted server exposing nothing is the tool-less arm this probe
+        # exists to catch: the model would fall back to shell tools and the run
+        # would still score as an MCP arm.
+        raise McpUnreachableError("server completed the handshake but advertised no tools")
+    return names
+
+
+def _init_params() -> dict:
+    """Return the ``initialize`` params this probe sends."""
+    return {
+        "protocolVersion": _PROTOCOL_VERSION,
+        "capabilities": {},
+        "clientInfo": dict(_CLIENT_INFO),
+    }
+
+
+def _send(proc: subprocess.Popen, message: dict) -> None:
+    """Write one newline-delimited JSON-RPC message to the server's stdin.
+
+    Raises:
+        McpUnreachableError: If the server's stdin is already closed — i.e. the
+            process died on launch.
+    """
+    try:
+        proc.stdin.write(json.dumps(message) + "\n")
+        proc.stdin.flush()
+    except (BrokenPipeError, ValueError) as exc:
+        raise McpUnreachableError(f"server exited before the handshake completed: {exc}") from exc
+
+
+def _signal_group(proc: subprocess.Popen, sig: int) -> None:
+    """Send ``sig`` to the server's whole process group, falling back to the child.
+
+    The group is what matters: launcher-style commands (``uvx``, ``npx -y``,
+    ``sh -c``, ``docker run``) exec or fork the real server, and signalling only
+    the direct child leaves that descendant alive holding the inherited pipes.
+    """
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), sig)
+    except (OSError, AttributeError):
+        with contextlib.suppress(OSError):
+            proc.send_signal(sig)
+
+
+def _terminate(proc: subprocess.Popen, readers: tuple[threading.Thread, ...] = ()) -> None:
+    """Stop the probed server and release its pipes, always within a bounded time.
+
+    Ordering is load-bearing. ``TextIOWrapper.close()`` must take the buffer lock
+    a blocked reader thread holds, and that reader only unblocks at EOF, which
+    needs *every* holder of the pipe's write end to exit. So the process group is
+    signalled first, then the readers are joined with a deadline, and any stream
+    whose reader is still alive is abandoned rather than closed — a leaked file
+    descriptor is recoverable, an unbounded hang on the per-run path is not.
+
+    Idempotent: called on both the success and failure paths of a single probe.
+    """
+    _signal_group(proc, signal.SIGTERM)
+    try:
+        proc.wait(timeout=_SIGNAL_GRACE_SEC)
+    except subprocess.TimeoutExpired:
+        _signal_group(proc, signal.SIGKILL)
+        try:
+            proc.wait(timeout=_SIGNAL_GRACE_SEC)
+        except subprocess.TimeoutExpired:  # pragma: no cover - unkillable child
+            _log.warning("MCP probe child %d survived SIGKILL", proc.pid)
+
+    stuck = False
+    for reader in readers:
+        reader.join(timeout=_READER_JOIN_SEC)
+        stuck = stuck or reader.is_alive()
+
+    streams = (proc.stdin,) if stuck else (proc.stdin, proc.stdout, proc.stderr)
+    if stuck:
+        _log.warning(
+            "MCP probe reader still blocked after the server was killed; "
+            "leaving its pipes open to avoid a hang"
+        )
+    for stream in streams:
+        try:
+            if stream is not None:
+                stream.close()
+        except OSError:
+            pass
+
+
+def preflight_mcp(
+    bindings: tuple[McpBinding, ...],
+    *,
+    base_env: Mapping[str, str] | None = None,
+    timeout: float = PROBE_TIMEOUT_SEC,
+    cwd: str | os.PathLike[str] | None = None,
+) -> dict[str, tuple[str, ...]]:
+    """Verify every launchable binding answers, or fail the run.
+
+    Bindings with an empty ``command`` are skipped: they denote a server the CLI
+    binary hosts itself, which has no process for this probe to speak to.
+
+    Servers are probed concurrently — they are independent, and probing in
+    sequence would make the worst case the sum of every server's timeout on a
+    path that runs before each of the matrix's runs.
+
+    Args:
+        bindings: The MCP bindings granted for the run.
+        base_env: Environment the servers are launched with (defaults to
+            ``os.environ``).
+        timeout: Per-server wall-clock budget.
+        cwd: Directory to launch servers in when a binding does not pin one;
+            pass the run's workspace so the probe matches the CLI's launch.
+
+    Returns:
+        A ``{server name: advertised tool names}`` mapping for every probed
+        binding.
+
+    Raises:
+        McpUnreachableError: If any probed server fails, naming the first
+            failure in binding order so the message is stable across runs.
+            Raised rather than reported so a granted-but-dead server can never
+            be scored as a working MCP arm.
+    """
+    probed = [
+        (binding.name or f"mcp{index}", binding)
+        for index, binding in enumerate(bindings)
+        if binding.command
+    ]
+    if not probed:
+        return {}
+
+    started = time.monotonic()
+    with ThreadPoolExecutor(max_workers=min(_MAX_CONCURRENT_PROBES, len(probed))) as pool:
+        outcomes = list(
+            pool.map(
+                lambda item: _probe_one(item[1], base_env=base_env, timeout=timeout, cwd=cwd),
+                probed,
+            )
+        )
+
+    discovered: dict[str, tuple[str, ...]] = {}
+    for (name, _binding), outcome in zip(probed, outcomes, strict=True):
+        if isinstance(outcome, McpUnreachableError):
+            raise McpUnreachableError(f"MCP server {name!r} is unreachable: {outcome}")
+        discovered[name] = outcome
+    _log.info(
+        "MCP preflight ok: %d server(s) in %.1fs (%s)",
+        len(discovered),
+        time.monotonic() - started,
+        ", ".join(f"{name}={len(tools)} tool(s)" for name, tools in discovered.items()),
+    )
+    return discovered
+
+
+def _probe_one(
+    binding: McpBinding,
+    *,
+    base_env: Mapping[str, str] | None,
+    timeout: float,
+    cwd: str | os.PathLike[str] | None,
+) -> tuple[str, ...] | McpUnreachableError:
+    """Probe one binding, returning its failure instead of raising.
+
+    Returning the error keeps the concurrent pool from surfacing whichever
+    server happened to fail first; the caller reports failures in binding order.
+    """
+    try:
+        return probe_stdio_server(binding, base_env=base_env, timeout=timeout, cwd=cwd)
+    except McpUnreachableError as exc:
+        return exc

--- a/devops_bench/agents/shared/mcp_probe.py
+++ b/devops_bench/agents/shared/mcp_probe.py
@@ -40,7 +40,7 @@ import threading
 import time
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING
+from typing import IO, TYPE_CHECKING
 
 from devops_bench.core import DevOpsBenchError, get_logger
 
@@ -166,7 +166,7 @@ def _redact(text: str, secrets: tuple[str, ...]) -> str:
     return text
 
 
-def _pump(stream, sink: queue.Queue) -> None:
+def _pump(stream: IO[str], sink: queue.Queue[str | None]) -> None:
     """Forward each line of ``stream`` onto ``sink``, then a ``None`` sentinel.
 
     Drops the oldest line when the queue is full: a server that chatters for its
@@ -184,7 +184,7 @@ def _pump(stream, sink: queue.Queue) -> None:
         sink.put(None)
 
 
-def _drain_stderr(stream, sink: collections.deque) -> None:
+def _drain_stderr(stream: IO[str], sink: collections.deque[str]) -> None:
     """Collect ``stream``'s tail into ``sink`` line by line.
 
     Line-at-a-time rather than one blocking ``read()`` so the tail is available
@@ -198,7 +198,7 @@ def _drain_stderr(stream, sink: collections.deque) -> None:
         pass
 
 
-def _read_result(lines: queue.Queue, request_id: int, deadline: float) -> dict:
+def _read_result(lines: queue.Queue[str | None], request_id: int, deadline: float) -> dict:
     """Read newline-delimited JSON-RPC until the reply to ``request_id`` arrives.
 
     Non-JSON lines and unrelated messages (notifications, other ids) are skipped:
@@ -287,8 +287,8 @@ def probe_stdio_server(
     except OSError as exc:
         raise McpUnreachableError(f"could not launch server: {exc}") from exc
 
-    lines: queue.Queue = queue.Queue(maxsize=_MAX_STDOUT_LINES)
-    stderr_tail: collections.deque = collections.deque(maxlen=_MAX_STDERR_CHUNKS)
+    lines: queue.Queue[str | None] = queue.Queue(maxsize=_MAX_STDOUT_LINES)
+    stderr_tail: collections.deque[str] = collections.deque(maxlen=_MAX_STDERR_CHUNKS)
     readers = (
         threading.Thread(target=_pump, args=(proc.stdout, lines), daemon=True),
         threading.Thread(target=_drain_stderr, args=(proc.stderr, stderr_tail), daemon=True),

--- a/devops_bench/agents/shared/mcp_probe.py
+++ b/devops_bench/agents/shared/mcp_probe.py
@@ -22,8 +22,11 @@ speaking the MCP stdio handshake directly — ``initialize`` /
 before the agent is invoked, so an unreachable server fails the run instead of
 scoring one.
 
-The handshake is implemented here rather than through the ``mcp`` SDK to keep
-the probe dependency-free; it is ~3 messages and the transport is line-based.
+The handshake is hand-rolled rather than driven through the ``mcp`` SDK (which
+the project already depends on) because the SDK's client is async and manages
+the child process for you, while this probe needs synchronous control of the
+launch: its own process group, a hard wall-clock deadline, and the child's
+stderr tail to report on failure. It is ~3 messages over a line-based transport.
 """
 
 from __future__ import annotations
@@ -47,7 +50,13 @@ from devops_bench.core import DevOpsBenchError, get_logger
 if TYPE_CHECKING:  # pragma: no cover - typing-only import
     from devops_bench.agents.capabilities import McpBinding
 
-__all__ = ["McpUnreachableError", "expand_env", "preflight_mcp", "probe_stdio_server"]
+__all__ = [
+    "McpUnreachableError",
+    "child_env",
+    "expand_env",
+    "preflight_mcp",
+    "probe_stdio_server",
+]
 
 _log = get_logger("agents.shared.mcp_probe")
 
@@ -122,14 +131,29 @@ def expand_env(
     return _ENV_REF.sub(_sub, value)
 
 
-def _child_env(binding: McpBinding, base_env: Mapping[str, str]) -> dict[str, str]:
+def child_env(binding: McpBinding, base_env: Mapping[str, str] | None = None) -> dict[str, str]:
     """Build the child environment for ``binding``, resolving secret references.
+
+    The runner env is the base rather than the declared vars alone: a stdio
+    server is a subprocess that still needs ``PATH``, ``HOME``, and the run's
+    isolation vars to start at all.
+
+    Args:
+        binding: The server whose declared ``env`` is resolved.
+        base_env: Mapping references resolve against; defaults to ``os.environ``.
+            The API agent routes through here precisely so it holds no
+            ``os.environ`` read of its own.
+
+    Returns:
+        The full environment the server subprocess should be launched with.
 
     Raises:
         McpUnreachableError: If a declared reference is absent from ``base_env``.
             Fail here rather than launch the server with an empty credential and
             report the resulting auth error as "unreachable".
     """
+    if base_env is None:
+        base_env = os.environ
     env = dict(base_env)
     missing: list[str] = []
     for key, raw in binding.env:
@@ -139,16 +163,32 @@ def _child_env(binding: McpBinding, base_env: Mapping[str, str]) -> dict[str, st
     return env
 
 
-def _secret_values(binding: McpBinding, resolved: Mapping[str, str]) -> tuple[str, ...]:
+def _secret_values(binding: McpBinding, source: Mapping[str, str]) -> tuple[str, ...]:
     """Return the values ``${VAR}`` expansion injected, for redaction.
 
     Only values that came from a reference are returned: a literal declared in
     the config is already visible to anyone reading the config, whereas an
     expanded reference is a credential this process resolved and must not echo
     back into a run artifact.
+
+    Each *substituted value* is collected, not the declared value it was spliced
+    into. A binding declaring ``AUTH="Bearer ${TOKEN}"`` must redact ``ghp_...``
+    on its own, because a server rejecting the credential echoes the bare token
+    far more often than the whole header.
+
+    Args:
+        binding: The binding whose declared ``env`` is scanned for references.
+        source: Mapping the references resolve against (the runner env).
+
+    Returns:
+        The distinct substituted values, longest first so a secret that contains
+        another is replaced before its substring.
     """
     secrets = {
-        resolved[key] for key, raw in binding.env if _ENV_REF.search(raw) and resolved.get(key)
+        source[name]
+        for _key, raw in binding.env
+        for name in _ENV_REF.findall(raw)
+        if source.get(name)
     }
     return tuple(sorted(secrets, key=len, reverse=True))
 
@@ -169,19 +209,47 @@ def _redact(text: str, secrets: tuple[str, ...]) -> str:
 def _pump(stream: IO[str], sink: queue.Queue[str | None]) -> None:
     """Forward each line of ``stream`` onto ``sink``, then a ``None`` sentinel.
 
-    Drops the oldest line when the queue is full: a server that chatters for its
-    whole timeout budget must not grow this process without bound.
+    Never blocks on a full queue: this thread outlives the probe's own deadline,
+    so a wait here would strand it after teardown. Instead the *oldest* queued
+    line is evicted to make room. That direction matters — the probe reads a
+    reply only after it has sent the request, so everything the server logged
+    beforehand is noise and the awaited reply is always the newest line. Dropping
+    the newest would discard the reply itself and report a merely chatty server
+    as unreachable.
+
+    Bounding the queue keeps a server that chatters for its whole timeout budget
+    from growing this process without bound.
     """
+    dropped = 0
     try:
         for line in stream:
-            try:
-                sink.put_nowait(line)
-            except queue.Full:
-                with contextlib.suppress(queue.Empty):  # pragma: no cover - racing consumer
-                    sink.get_nowait()
-                sink.put_nowait(line)
+            if _put_evicting_oldest(sink, line):
+                dropped += 1
     finally:
-        sink.put(None)
+        if dropped:
+            _log.warning(
+                "MCP probe discarded %d stdout line(s) past the %d-line cap",
+                dropped,
+                _MAX_STDOUT_LINES,
+            )
+        _put_evicting_oldest(sink, None)
+
+
+def _put_evicting_oldest(sink: queue.Queue[str | None], item: str | None) -> bool:
+    """Enqueue ``item`` without blocking, discarding the head if the queue is full.
+
+    Returns:
+        ``True`` if a queued item had to be discarded to make room.
+    """
+    try:
+        sink.put_nowait(item)
+        return False
+    except queue.Full:
+        with contextlib.suppress(queue.Empty):
+            sink.get_nowait()
+        with contextlib.suppress(queue.Full):
+            sink.put_nowait(item)
+        return True
 
 
 def _drain_stderr(stream: IO[str], sink: collections.deque[str]) -> None:
@@ -264,8 +332,9 @@ def probe_stdio_server(
             the handshake within ``timeout``, or answers with a JSON-RPC error,
             or completes the handshake advertising no tools.
     """
-    env = _child_env(binding, os.environ if base_env is None else base_env)
-    secrets = _secret_values(binding, env)
+    source = os.environ if base_env is None else base_env
+    env = child_env(binding, source)
+    secrets = _secret_values(binding, source)
     deadline = time.monotonic() + timeout
     try:
         proc = subprocess.Popen(  # noqa: S603 - argv list, never a shell string

--- a/tests/unit/agents/api/test_agents_api_agent.py
+++ b/tests/unit/agents/api/test_agents_api_agent.py
@@ -582,7 +582,7 @@ def test_execute_folds_assistant_tool_pairs_into_canonical_trajectory(
     mcp_advertised = [SimpleNamespace(name="do_thing", description="d", inputSchema=None)]
     mcp = _FakeMCPClient(tools=mcp_advertised)
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
-    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path, **_kw: mcp)
 
     result = ApiAgent(AgentConfig(capabilities=_mcp_caps("server"))).run("ping")
 
@@ -632,7 +632,7 @@ def test_execute_dispatch_error_lands_in_errors_and_continues(
     )
     mcp = _ExplodingMCP(tools=[SimpleNamespace(name="boom", description="d", inputSchema=None)])
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
-    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path, **_kw: mcp)
 
     result = ApiAgent(AgentConfig(capabilities=_mcp_caps("server"))).run("ping")
 
@@ -660,7 +660,7 @@ def test_execute_marks_mcp_iserror_result_as_error(monkeypatch: pytest.MonkeyPat
     fake = _FakeLLMClient([_Turn(text="trying", calls=fc), _Turn(text="giving up")])
     mcp = _IsErrorMCP(tools=[SimpleNamespace(name="get_pod", description="d", inputSchema=None)])
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
-    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path, **_kw: mcp)
 
     result = ApiAgent(AgentConfig(capabilities=_mcp_caps("server"))).run("ping")
 
@@ -776,7 +776,7 @@ def test_execute_lets_value_error_reach_base_safety_net(monkeypatch: pytest.Monk
     """
 
     class _BoomMCP:
-        def __init__(self, _path: str) -> None: ...
+        def __init__(self, _path: str, **_kw: Any) -> None: ...
 
         async def __aenter__(self) -> _BoomMCP:
             raise ValueError("bad provider argument")
@@ -842,24 +842,162 @@ def test_execute_honors_max_turns_zero(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result.output == ""
 
 
-def test_execute_warns_when_extra_mcp_servers_dropped(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+def _per_command_mcp(by_command: dict[str, _FakeMCPClient]):
+    """Build an ``MCPClient`` replacement handing each command its own client.
+
+    Multi-server behavior is only observable when the doubles have distinct
+    identities: a single shared client cannot show which server a call was
+    routed to.
+    """
+
+    def _factory(command: str, **_kw: Any) -> _FakeMCPClient:
+        assert command in by_command, f"unexpected server launch: {command!r}"
+        return by_command[command]
+
+    return _factory
+
+
+def test_execute_merges_tools_from_every_granted_server(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Only the first MCP binding is honored (documented aggregate behavior);
-    dropping servers 2..N must at least be visible in the logs."""
+    """Every launchable binding is opened and its tools advertised together.
+
+    Dropping servers 2..N would score the run as if the agent had the whole
+    grant while half its toolset was unreachable.
+    """
     fake = _FakeLLMClient([_Turn(text="ok")])
-    mcp = _FakeMCPClient(tools=[])
+    first = _FakeMCPClient(tools=[SimpleNamespace(name="alpha")])
+    second = _FakeMCPClient(tools=[SimpleNamespace(name="beta")])
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
-    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+    monkeypatch.setattr(
+        agent_mod,
+        "MCPClient",
+        _per_command_mcp({"server-a": first, "server-b": second}),
+    )
     caps = AllCapabilities(
         mcp_servers=(
             McpBinding(name="one", command=("server-a",)),
             McpBinding(name="two", command=("server-b",)),
         ),
     )
-    with caplog.at_level("WARNING", logger="devops_bench.agents.api.agent"):
-        ApiAgent(AgentConfig(capabilities=caps)).run("p")
-    assert any("only the first MCP binding" in r.message for r in caplog.records)
+    result = ApiAgent(AgentConfig(capabilities=caps)).run("p")
+    assert not result.has_errors()
+    assert first.entered and second.entered
+    assert first.exited and second.exited
+    # Advertised in grant order, both servers' tools present.
+    assert [getattr(t, "name", "") for t in fake.format_tools_calls[0]] == ["alpha", "beta"]
+
+
+def test_execute_routes_each_call_to_the_server_that_advertised_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool call reaches the session that listed the name, not the first one."""
+    fake = _FakeLLMClient(
+        [
+            _Turn(text="", calls=[{"name": "beta", "args": {}, "id": "c1"}]),
+            _Turn(text="done"),
+        ]
+    )
+    first = _FakeMCPClient(tools=[SimpleNamespace(name="alpha")])
+    second = _FakeMCPClient(tools=[SimpleNamespace(name="beta")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(
+        agent_mod,
+        "MCPClient",
+        _per_command_mcp({"server-a": first, "server-b": second}),
+    )
+    caps = AllCapabilities(
+        mcp_servers=(
+            McpBinding(name="one", command=("server-a",)),
+            McpBinding(name="two", command=("server-b",)),
+        ),
+    )
+    result = ApiAgent(AgentConfig(capabilities=caps)).run("p")
+    assert not result.has_errors()
+    assert first.calls == []
+    assert second.calls == [("beta", {})]
+
+
+def test_execute_fails_when_two_servers_advertise_the_same_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A duplicate tool name across servers fails the run.
+
+    Routing to whichever server was listed first would score the arm against a
+    toolset nobody chose, so ambiguity is fatal rather than resolved by order.
+    """
+    fake = _FakeLLMClient([_Turn(text="ok")])
+    first = _FakeMCPClient(tools=[SimpleNamespace(name="shared")])
+    second = _FakeMCPClient(tools=[SimpleNamespace(name="shared")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(
+        agent_mod,
+        "MCPClient",
+        _per_command_mcp({"server-a": first, "server-b": second}),
+    )
+    caps = AllCapabilities(
+        mcp_servers=(
+            McpBinding(name="one", command=("server-a",)),
+            McpBinding(name="two", command=("server-b",)),
+        ),
+    )
+    result = ApiAgent(AgentConfig(capabilities=caps)).run("p")
+    assert result.has_errors()
+    assert "MCP tool name conflict" in result.errors[0]
+    assert "'one' and 'two'" in result.errors[0]
+    assert "'shared'" in result.errors[0]
+    # Both sessions are torn down despite the failure.
+    assert first.exited and second.exited
+    # The model was never called — the run fails before any provider spend.
+    assert fake.calls == []
+
+
+def test_execute_tears_down_open_sessions_when_a_later_server_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Server N failing to start must not orphan the N-1 already running."""
+
+    class _FailingMCP(_FakeMCPClient):
+        async def __aenter__(self) -> _FakeMCPClient:
+            raise RuntimeError("connect refused")
+
+    fake = _FakeLLMClient([_Turn(text="ok")])
+    first = _FakeMCPClient(tools=[])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(
+        agent_mod,
+        "MCPClient",
+        _per_command_mcp({"server-a": first, "server-b": _FailingMCP()}),
+    )
+    caps = AllCapabilities(
+        mcp_servers=(
+            McpBinding(name="one", command=("server-a",)),
+            McpBinding(name="two", command=("server-b",)),
+        ),
+    )
+    result = ApiAgent(AgentConfig(capabilities=caps)).run("p")
+    assert result.has_errors()
+    assert first.exited
+
+
+def test_execute_allows_hosted_bindings_beside_launchable_ones(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A command-less binding denotes a server the CLI hosts itself, so this
+    agent has nothing to launch for it."""
+    fake = _FakeLLMClient([_Turn(text="ok")])
+    mcp = _FakeMCPClient(tools=[])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", _per_command_mcp({"server-b": mcp}))
+    caps = AllCapabilities(
+        mcp_servers=(
+            McpBinding(name="hosted", command=()),
+            McpBinding(name="spawned", command=("server-b",)),
+        ),
+    )
+    result = ApiAgent(AgentConfig(capabilities=caps)).run("p")
+    assert not result.has_errors()
+    assert result.output == "ok"
 
 
 # ---------------------------------------------------------------------------
@@ -1045,7 +1183,7 @@ def test_execute_runs_with_mcp_only_no_skills(monkeypatch: pytest.MonkeyPatch) -
     mcp_tools = [SimpleNamespace(name="do_thing", description="d", inputSchema=None)]
     mcp = _FakeMCPClient(tools=mcp_tools)
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
-    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path, **_kw: mcp)
 
     result = ApiAgent(AgentConfig(capabilities=_mcp_caps("server"))).run("p")
     assert result.errors == []
@@ -1067,7 +1205,7 @@ def test_execute_runs_with_both_mcp_and_skills(
         tools=[SimpleNamespace(name="do_thing", description="d", inputSchema=None)]
     )
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
-    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path, **_kw: mcp)
 
     caps = AllCapabilities(
         mcp_servers=(McpBinding(name="t", command=("server",)),),
@@ -1085,7 +1223,7 @@ def test_execute_runs_with_neither_mcp_nor_skills(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
     # If MCPClient is ever entered the test would import mcp; replace with a sentinel.
     monkeypatch.setattr(
-        agent_mod, "MCPClient", lambda _path: pytest.fail("MCPClient must not be used")
+        agent_mod, "MCPClient", lambda _path, **_kw: pytest.fail("MCPClient must not be used")
     )
     result = ApiAgent(AgentConfig()).run("p")
     assert result.output == "bare"
@@ -1130,7 +1268,7 @@ def test_execute_skips_mcp_when_binding_has_no_command(monkeypatch: pytest.Monke
     fake = _FakeLLMClient([_Turn(text="ok")])
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
     monkeypatch.setattr(
-        agent_mod, "MCPClient", lambda _path: pytest.fail("MCPClient must not be used")
+        agent_mod, "MCPClient", lambda _path, **_kw: pytest.fail("MCPClient must not be used")
     )
     caps = AllCapabilities(
         mcp_servers=(McpBinding(name="cli-shape", command=(), tools=("x",)),),
@@ -1155,7 +1293,7 @@ def test_execute_preserves_spaced_command_token_through_shlex_roundtrip(
     captured: dict = {}
 
     class _RecordingMCP(_FakeMCPClient):
-        def __init__(self, path: str) -> None:
+        def __init__(self, path: str, **_kw: Any) -> None:
             super().__init__(tools=[])
             captured["path"] = path
 
@@ -1173,3 +1311,66 @@ def test_execute_preserves_spaced_command_token_through_shlex_roundtrip(
     # path the agent handed it must recover the original tuple element-for-
     # element, including the spaced first token.
     assert tuple(shlex.split(captured["path"])) == original
+
+
+def _recording_mcp(captured: dict) -> type:
+    """Return an ``MCPClient`` stand-in recording the kwargs it was built with."""
+
+    class _Recorder(_FakeMCPClient):
+        def __init__(self, path: str, **kw: Any) -> None:
+            super().__init__(tools=[])
+            captured.update(path=path, **kw)
+
+    return _Recorder
+
+
+def test_execute_threads_declared_env_and_cwd_to_the_mcp_child(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A binding's declared ``env`` and ``cwd`` must reach the server process.
+
+    ``${VAR}`` references resolve against the runner env, and the resolved pair
+    is layered *over* that env rather than replacing it: the SDK swaps the child
+    environment outright for any mapping it is given, so a bare ``{"TOKEN": ...}``
+    would launch the server without ``PATH`` and it would not start.
+    """
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("REAL_TOKEN", "s3cret")
+    captured: dict = {}
+    fake = _FakeLLMClient([_Turn(text="done")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", _recording_mcp(captured))
+
+    caps = AllCapabilities(
+        mcp_servers=(
+            McpBinding(
+                name="gh",
+                command=("gh-mcp",),
+                env=(("GH_TOKEN", "${REAL_TOKEN}"), ("MODE", "read-only")),
+                cwd="/srv/work",
+            ),
+        ),
+    )
+    ApiAgent(AgentConfig(capabilities=caps)).run("p")
+
+    assert captured["cwd"] == "/srv/work"
+    assert captured["env"]["GH_TOKEN"] == "s3cret"
+    assert captured["env"]["MODE"] == "read-only"
+    assert captured["env"]["PATH"] == "/usr/bin"
+
+
+def test_execute_leaves_mcp_child_env_unset_when_binding_declares_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No declared env means ``env=None`` — the SDK's own minimal default, not
+    a copy of the runner env, so nothing incidental leaks into the server."""
+    captured: dict = {}
+    fake = _FakeLLMClient([_Turn(text="done")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", _recording_mcp(captured))
+
+    caps = AllCapabilities(mcp_servers=(McpBinding(name="plain", command=("srv",)),))
+    ApiAgent(AgentConfig(capabilities=caps)).run("p")
+
+    assert captured["env"] is None
+    assert captured["cwd"] is None

--- a/tests/unit/agents/api/test_agents_api_agent.py
+++ b/tests/unit/agents/api/test_agents_api_agent.py
@@ -952,6 +952,38 @@ def test_execute_fails_when_two_servers_advertise_the_same_tool(
     assert fake.calls == []
 
 
+def test_execute_fails_when_a_skill_and_a_server_share_a_tool_name(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A skill name colliding with a granted server's tool fails the run.
+
+    The model would be handed the same name twice, and the dispatcher's
+    skill-first rule would serve the skill while the server's tool never runs —
+    an MCP arm scored without the tool it granted.
+    """
+    skill_dir = tmp_path / "skills"
+    (skill_dir / "demo").mkdir(parents=True)
+    (skill_dir / "demo" / "SKILL.md").write_text('---\nname: "demo"\ndescription: x\n---\nbody\n')
+
+    fake = _FakeLLMClient([_Turn(text="ok")])
+    mcp = _FakeMCPClient(tools=[SimpleNamespace(name="skill_demo")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path, **_kw: mcp)
+
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="one", command=("server-a",)),),
+        skills=SkillBinding(paths=(str(skill_dir),)),
+    )
+    result = ApiAgent(AgentConfig(capabilities=caps)).run("p")
+
+    assert result.has_errors()
+    assert "MCP tool name conflict" in result.errors[0]
+    assert "skill_demo" in result.errors[0]
+    assert mcp.exited
+    # The model was never called — the run fails before any provider spend.
+    assert fake.calls == []
+
+
 def test_execute_tears_down_open_sessions_when_a_later_server_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/agents/conftest.py
+++ b/tests/unit/agents/conftest.py
@@ -1,0 +1,38 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared fixtures for the agent-harness unit tests."""
+
+from __future__ import annotations
+
+import pytest
+
+_PREFLIGHT_MODULES = (
+    "devops_bench.agents.cli.gemini_cli.agent",
+    "devops_bench.agents.cli.openclaw.agent",
+)
+
+
+@pytest.fixture(autouse=True)
+def stub_mcp_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralize the MCP reachability probe for every agent unit test.
+
+    The probe launches each bound server as a real subprocess, which these
+    tests deliberately do not provide (their bindings name fake binaries like
+    ``gke-mcp``). Tests that exercise the probe itself patch the symbol back to
+    a raising stub, or call
+    :mod:`devops_bench.agents.shared.mcp_probe` directly.
+    """
+    for module in _PREFLIGHT_MODULES:
+        monkeypatch.setattr(f"{module}.preflight_mcp", lambda *a, **kw: {})

--- a/tests/unit/agents/conftest.py
+++ b/tests/unit/agents/conftest.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import pytest
 
 _PREFLIGHT_MODULES = (
+    "devops_bench.agents.cli.antigravity.agent",
     "devops_bench.agents.cli.gemini_cli.agent",
     "devops_bench.agents.cli.openclaw.agent",
 )

--- a/tests/unit/agents/shared/test_cli_capabilities.py
+++ b/tests/unit/agents/shared/test_cli_capabilities.py
@@ -172,3 +172,109 @@ def test_agent_workdir_creates_and_cleans_up_temp_dir_when_no_path_supplied() ->
         assert workdir.name.startswith("agent-workdir-test-")
 
     assert not created.exists()
+
+
+def test_build_mcp_servers_renders_env_and_cwd() -> None:
+    """A binding's ``env``/``cwd`` reach the CLI's server entry, so a server
+    needing its own credential or working directory is launchable."""
+    binding = McpBinding(
+        name="github",
+        command=("npx", "server-github"),
+        env=(("GITHUB_TOKEN", "${GITHUB_TOKEN}"),),
+        cwd="/work",
+    )
+
+    assert build_mcp_servers((binding,)) == {
+        "github": {
+            "command": "npx",
+            "args": ["server-github"],
+            "env": {"GITHUB_TOKEN": "${GITHUB_TOKEN}"},
+            "cwd": "/work",
+        }
+    }
+
+
+def test_build_mcp_servers_keeps_secret_references_unexpanded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The rendered entry must carry the reference, never the resolved value:
+    this mapping is written into the agent's workspace, which the harness
+    collects wholesale into the run's artifacts."""
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_realsecret")
+    binding = McpBinding(
+        name="github", command=("npx",), env=(("GITHUB_TOKEN", "${GITHUB_TOKEN}"),)
+    )
+
+    rendered = build_mcp_servers((binding,))
+
+    assert rendered["github"]["env"] == {"GITHUB_TOKEN": "${GITHUB_TOKEN}"}
+
+
+def test_build_mcp_servers_omits_env_and_cwd_when_unset() -> None:
+    """A binding with neither adds no keys, leaving the CLI's defaults in place."""
+    assert build_mcp_servers((McpBinding(name="s", command=("srv",)),)) == {"s": {"command": "srv"}}
+
+
+def test_materialize_skills_copies_the_whole_bundle(tmp_path: Path) -> None:
+    """A skill's siblings come with it: ``SKILL.md`` routinely instructs the
+    agent to read ``references/``/``templates/``/``scripts/``, and copying the
+    one file leaves those instructions pointing at nothing."""
+    src = tmp_path / "src" / "design-doc"
+    (src / "templates").mkdir(parents=True)
+    (src / "SKILL.md").write_text(
+        "---\nname: design-doc\ndescription: d\n---\nread templates/full.md\n",
+        encoding="utf-8",
+    )
+    (src / "templates" / "full.md").write_text("TEMPLATE BODY", encoding="utf-8")
+    (src / "reference.md").write_text("REFERENCE BODY", encoding="utf-8")
+    dest = tmp_path / "dest"
+
+    written = materialize_skills(dest, (str(tmp_path / "src"),))
+
+    assert written == ["design-doc"]
+    assert (dest / "design-doc" / "templates" / "full.md").read_text() == "TEMPLATE BODY"
+    assert (dest / "design-doc" / "reference.md").read_text() == "REFERENCE BODY"
+    assert "read templates/full.md" in (dest / "design-doc" / "SKILL.md").read_text()
+
+
+def test_materialize_skills_recreates_links_without_copying_host_files(tmp_path: Path) -> None:
+    """Bundle copies must not dereference symlinks.
+
+    The workspace this writes into is collected wholesale into the run's
+    artifacts, so dereferencing a link would write the *contents* of whatever it
+    points at — a host credential, for instance — into those artifacts. An
+    in-bundle link is recreated as a link; one escaping the bundle is dropped.
+    """
+    outside = tmp_path / "outside" / "id_rsa"
+    outside.parent.mkdir(parents=True)
+    outside.write_text("HOST PRIVATE KEY", encoding="utf-8")
+    src = tmp_path / "src" / "linky"
+    src.mkdir(parents=True)
+    (src / "SKILL.md").write_text("---\nname: linky\ndescription: d\n---\nbody\n", encoding="utf-8")
+    (src / "real.md").write_text("IN BUNDLE", encoding="utf-8")
+    (src / "alias.md").symlink_to("real.md")
+    (src / "creds").symlink_to(outside)
+    dest = tmp_path / "dest"
+
+    written = materialize_skills(dest, (str(tmp_path / "src"),))
+
+    assert written == ["linky"]
+    assert (dest / "linky" / "alias.md").is_symlink()
+    assert (dest / "linky" / "alias.md").read_text() == "IN BUNDLE"
+    assert not (dest / "linky" / "creds").exists(follow_symlinks=False)
+    assert "HOST PRIVATE KEY" not in (dest / "linky" / "SKILL.md").read_text()
+
+
+def test_materialize_skills_survives_a_dangling_link(tmp_path: Path) -> None:
+    """A broken link inside a bundle used to abort the whole run with
+    ``shutil.Error``; it is dropped along with the escaping ones."""
+    src = tmp_path / "src" / "broken"
+    src.mkdir(parents=True)
+    (src / "SKILL.md").write_text(
+        "---\nname: broken\ndescription: d\n---\nbody\n", encoding="utf-8"
+    )
+    (src / "gone").symlink_to(tmp_path / "never-existed")
+
+    written = materialize_skills(tmp_path / "dest", (str(tmp_path / "src"),))
+
+    assert written == ["broken"]

--- a/tests/unit/agents/shared/test_cli_capabilities.py
+++ b/tests/unit/agents/shared/test_cli_capabilities.py
@@ -26,6 +26,7 @@ from devops_bench.agents.shared.cli_capabilities import (
     build_mcp_servers,
     materialize_skills,
 )
+from devops_bench.core import ConfigError
 
 
 def test_build_mcp_servers_maps_command_to_command_and_args() -> None:
@@ -52,6 +53,28 @@ def test_build_mcp_servers_names_unnamed_bindings_by_index() -> None:
     """A binding with no name falls back to a positional ``mcp<index>`` key."""
     servers = build_mcp_servers((McpBinding(name="", command=("srv",)),))
     assert servers == {"mcp0": {"command": "srv"}}
+
+
+def test_build_mcp_servers_rejects_bindings_that_resolve_to_one_name() -> None:
+    """A colliding name would drop a granted server from the launch map."""
+    with pytest.raises(ConfigError, match="resolve to the name 'gke'"):
+        build_mcp_servers(
+            (
+                McpBinding(name="gke", command=("a",)),
+                McpBinding(name="gke", command=("b",)),
+            )
+        )
+
+
+def test_build_mcp_servers_rejects_a_name_colliding_with_the_index_fallback() -> None:
+    """An explicit name can collide with an unnamed binding's ``mcp<index>`` key."""
+    with pytest.raises(ConfigError, match="resolve to the name 'mcp1'"):
+        build_mcp_servers(
+            (
+                McpBinding(name="mcp1", command=("a",)),
+                McpBinding(name="", command=("b",)),
+            )
+        )
 
 
 def test_materialize_skills_writes_named_skill_files(tmp_path: Path) -> None:

--- a/tests/unit/agents/shared/test_cli_capabilities.py
+++ b/tests/unit/agents/shared/test_cli_capabilities.py
@@ -278,3 +278,44 @@ def test_materialize_skills_survives_a_dangling_link(tmp_path: Path) -> None:
     written = materialize_skills(tmp_path / "dest", (str(tmp_path / "src"),))
 
     assert written == ["broken"]
+
+
+def test_materialize_skills_skips_a_skill_md_at_the_discovery_root(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A ``SKILL.md`` at the top of a granted path has the whole tree as its
+    bundle, so copying it would nest every sibling skill inside it — and each
+    sibling is materialized again in its own right. It is skipped and warned."""
+    src = tmp_path / "src"
+    (src / "rotate").mkdir(parents=True)
+    (src / "rotate" / "SKILL.md").write_text(
+        "---\nname: rotate\ndescription: d\n---\nbody\n", encoding="utf-8"
+    )
+    (src / "SKILL.md").write_text(
+        "---\nname: at-root\ndescription: d\n---\nbody\n", encoding="utf-8"
+    )
+    dest = tmp_path / "dest"
+
+    with caplog.at_level("WARNING", logger="devops_bench.agents.shared.cli_capabilities"):
+        written = materialize_skills(dest, (str(src),))
+
+    assert written == ["rotate"]
+    assert not (dest / "at-root").exists()
+    assert not (dest / "rotate" / "rotate").exists()
+    assert any("discovery root" in r.message for r in caplog.records)
+
+
+def test_materialize_skills_skips_a_root_skill_reached_through_a_symlinked_path(
+    tmp_path: Path,
+) -> None:
+    """The root comparison resolves both sides, so granting a path by way of a
+    symlink does not slip a root-level bundle past the guard."""
+    real = tmp_path / "real"
+    real.mkdir()
+    (real / "SKILL.md").write_text(
+        "---\nname: at-root\ndescription: d\n---\nbody\n", encoding="utf-8"
+    )
+    link = tmp_path / "link"
+    link.symlink_to(real)
+
+    assert materialize_skills(tmp_path / "dest", (str(link),)) == []

--- a/tests/unit/agents/shared/test_mcp_probe.py
+++ b/tests/unit/agents/shared/test_mcp_probe.py
@@ -1,0 +1,398 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.agents.shared.mcp_probe."""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from devops_bench.agents.capabilities import McpBinding
+from devops_bench.agents.shared.mcp_probe import (
+    McpUnreachableError,
+    expand_env,
+    preflight_mcp,
+    probe_stdio_server,
+)
+
+# A minimal stdio MCP server: answers ``initialize`` and ``tools/list`` with
+# newline-delimited JSON-RPC, exactly as the transport specifies.
+_FAKE_SERVER = """
+import json, os, sys
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    method = msg.get("method")
+    if method == "initialize":
+        print(json.dumps({"jsonrpc": "2.0", "id": msg["id"],
+                          "result": {"protocolVersion": "2025-06-18",
+                                     "capabilities": {},
+                                     "serverInfo": {"name": "fake", "version": "1"}}}),
+              flush=True)
+    elif method == "tools/list":
+        names = os.environ.get("FAKE_TOOLS", "alpha,beta").split(",")
+        print(json.dumps({"jsonrpc": "2.0", "id": msg["id"],
+                          "result": {"tools": [{"name": n} for n in names]}}), flush=True)
+    elif method == "notifications/initialized":
+        continue
+"""
+
+# Speaks the protocol but reports a working directory rather than tool names,
+# so a test can assert the ``cwd`` a binding requested was honored.
+_CWD_SERVER = _FAKE_SERVER.replace(
+    'os.environ.get("FAKE_TOOLS", "alpha,beta").split(",")', "[os.getcwd()]"
+)
+
+
+def _server(tmp_path: Path, source: str, name: str = "server.py") -> tuple[str, ...]:
+    """Write ``source`` as a script and return the argv that launches it."""
+    script = tmp_path / name
+    script.write_text(source, encoding="utf-8")
+    return (sys.executable, str(script))
+
+
+def test_probe_returns_advertised_tool_names(tmp_path: Path) -> None:
+    """A server completing the handshake yields the tools it lists."""
+    binding = McpBinding(name="fake", command=_server(tmp_path, _FAKE_SERVER))
+
+    assert probe_stdio_server(binding, timeout=30) == ("alpha", "beta")
+
+
+def test_probe_launches_server_with_declared_env(tmp_path: Path) -> None:
+    """A binding's ``env`` reaches the server process."""
+    binding = McpBinding(
+        name="fake",
+        command=_server(tmp_path, _FAKE_SERVER),
+        env=(("FAKE_TOOLS", "only_one"),),
+    )
+
+    assert probe_stdio_server(binding, timeout=30) == ("only_one",)
+
+
+def test_probe_resolves_secret_references_from_the_runner_env(tmp_path: Path) -> None:
+    """``${VAR}`` in a declared value is resolved from the launching environment."""
+    binding = McpBinding(
+        name="fake",
+        command=_server(tmp_path, _FAKE_SERVER),
+        env=(("FAKE_TOOLS", "${SECRET_TOOL}"),),
+    )
+
+    tools = probe_stdio_server(binding, base_env={**os.environ, "SECRET_TOOL": "sourced"})
+
+    assert tools == ("sourced",)
+
+
+def test_probe_fails_when_a_referenced_secret_is_unset(tmp_path: Path) -> None:
+    """An unset reference fails before launch rather than starting the server
+    with an empty credential and reporting the resulting auth error."""
+    binding = McpBinding(
+        name="fake",
+        command=_server(tmp_path, _FAKE_SERVER),
+        env=(("TOKEN", "${DEFINITELY_UNSET_VAR}"),),
+    )
+
+    with pytest.raises(McpUnreachableError, match="DEFINITELY_UNSET_VAR"):
+        probe_stdio_server(binding, base_env={})
+
+
+def test_probe_launches_server_in_declared_cwd(tmp_path: Path) -> None:
+    """A binding's ``cwd`` becomes the server process's working directory."""
+    workdir = tmp_path / "elsewhere"
+    workdir.mkdir()
+    binding = McpBinding(
+        name="fake",
+        command=_server(tmp_path, _CWD_SERVER),
+        cwd=str(workdir),
+    )
+
+    (reported,) = probe_stdio_server(binding, timeout=30)
+
+    assert Path(reported).resolve() == workdir.resolve()
+
+
+def test_probe_reports_a_missing_binary(tmp_path: Path) -> None:
+    """The dominant real failure — the server binary is not installed."""
+    binding = McpBinding(name="gone", command=("definitely-not-a-real-binary-xyz",))
+
+    with pytest.raises(McpUnreachableError, match="could not launch server"):
+        probe_stdio_server(binding, timeout=5)
+
+
+def test_probe_reports_a_server_that_exits_immediately(tmp_path: Path) -> None:
+    """A server that dies on startup (bad args, failed package fetch) is caught,
+    and its stderr is carried into the error so the cause is diagnosable."""
+    script = tmp_path / "dies.py"
+    script.write_text("import sys; sys.stderr.write('boom: bad config\\n')", encoding="utf-8")
+    binding = McpBinding(name="dies", command=(sys.executable, str(script)))
+
+    with pytest.raises(McpUnreachableError, match="boom: bad config"):
+        probe_stdio_server(binding, timeout=15)
+
+
+def test_probe_times_out_on_a_server_that_never_responds(tmp_path: Path) -> None:
+    """A server that starts but never answers must not hang the run."""
+    script = tmp_path / "mute.py"
+    script.write_text("import time; time.sleep(60)", encoding="utf-8")
+    binding = McpBinding(name="mute", command=(sys.executable, str(script)))
+
+    with pytest.raises(McpUnreachableError, match="timed out"):
+        probe_stdio_server(binding, timeout=1.5)
+
+
+def test_probe_rejects_a_process_that_only_echoes_its_input(tmp_path: Path) -> None:
+    """Echoing stdin replays the request id; a reply must carry ``result`` or
+    ``error`` and no ``method``, so an echo cannot pass as a handshake."""
+    script = tmp_path / "echo.py"
+    script.write_text(
+        "import sys\nfor line in sys.stdin: sys.stdout.write(line); sys.stdout.flush()",
+        encoding="utf-8",
+    )
+    binding = McpBinding(name="echo", command=(sys.executable, str(script)))
+
+    with pytest.raises(McpUnreachableError, match="timed out"):
+        probe_stdio_server(binding, timeout=1.5)
+
+
+def test_probe_skips_noise_on_stdout(tmp_path: Path) -> None:
+    """Servers that log to stdout despite the spec still pass: non-JSON lines
+    and unrelated notifications are skipped rather than failing the handshake."""
+    noisy = _FAKE_SERVER.replace(
+        'if method == "initialize":',
+        'print("starting up, not json", flush=True)\n'
+        '    print(json.dumps({"jsonrpc": "2.0", "method": "notifications/message"}), flush=True)\n'
+        '    if method == "initialize":',
+    )
+    binding = McpBinding(name="noisy", command=_server(tmp_path, noisy))
+
+    assert probe_stdio_server(binding, timeout=30) == ("alpha", "beta")
+
+
+def test_preflight_probes_every_binding(tmp_path: Path) -> None:
+    """Each launchable binding is probed and keyed by its name."""
+    command = _server(tmp_path, _FAKE_SERVER)
+    bindings = (
+        McpBinding(name="one", command=command, env=(("FAKE_TOOLS", "a"),)),
+        McpBinding(name="two", command=command, env=(("FAKE_TOOLS", "b,c"),)),
+    )
+
+    assert preflight_mcp(bindings, timeout=30) == {"one": ("a",), "two": ("b", "c")}
+
+
+def test_preflight_names_the_failing_server(tmp_path: Path) -> None:
+    """The error identifies which of several servers is unreachable."""
+    bindings = (
+        McpBinding(name="good", command=_server(tmp_path, _FAKE_SERVER)),
+        McpBinding(name="bad", command=("definitely-not-a-real-binary-xyz",)),
+    )
+
+    with pytest.raises(McpUnreachableError, match="'bad' is unreachable"):
+        preflight_mcp(bindings, timeout=10)
+
+
+def test_preflight_skips_bindings_the_cli_hosts_itself() -> None:
+    """An empty command denotes a server the CLI binary hosts; there is no
+    process to probe, so it is skipped rather than failed."""
+    assert preflight_mcp((McpBinding(name="builtin", tools=("x",)),)) == {}
+
+
+def test_expand_env_leaves_plain_values_untouched() -> None:
+    """A value with no reference passes through unchanged."""
+    assert expand_env("plain-value", source={}) == "plain-value"
+
+
+def test_expand_env_resolves_braced_references_and_leaves_bare_dollars_alone() -> None:
+    """Only ``${VAR}`` is a reference.
+
+    A bare ``$VAR`` form would treat the dollar in a literal credential as a
+    reference, mangling the value (``p$ssw0rd`` -> ``p``) and leaking the
+    fragment after it into the "unset variable" error.
+    """
+    source = {"A": "1", "B": "2"}
+
+    assert expand_env("${A}/${B}", source=source) == "1/2"
+    assert expand_env("p$ssw0rd", source=source) == "p$ssw0rd"
+    assert expand_env("Bearer ${A}", source=source) == "Bearer 1"
+
+
+_FORKING_SERVER = """
+import json, subprocess, sys
+subprocess.Popen([sys.executable, "-c", "import time; time.sleep(120)"])
+for line in sys.stdin:
+    msg = json.loads(line)
+    if msg.get("method") == "initialize":
+        print(json.dumps({"jsonrpc": "2.0", "id": msg["id"], "result": {
+            "protocolVersion": "2025-06-18", "capabilities": {},
+            "serverInfo": {"name": "f", "version": "1"}}}), flush=True)
+    elif msg.get("method") == "tools/list":
+        print(json.dumps({"jsonrpc": "2.0", "id": msg["id"],
+                          "result": {"tools": [{"name": "t"}]}}), flush=True)
+"""
+
+_SECRET_ECHO_SERVER = """
+import os, sys
+sys.stderr.write("FATAL: rejected input_value='%s'\\n" % os.environ.get("TOK"))
+sys.exit(1)
+"""
+
+_HANGS_AFTER_STDERR = """
+import sys, time
+sys.stderr.write("FATAL: token rejected\\n")
+sys.stderr.flush()
+time.sleep(60)
+"""
+
+_NO_TOOLS_SERVER = """
+import json, sys
+for line in sys.stdin:
+    msg = json.loads(line)
+    if msg.get("method") == "initialize":
+        print(json.dumps({"jsonrpc": "2.0", "id": msg["id"], "result": {
+            "protocolVersion": "2025-06-18", "capabilities": {},
+            "serverInfo": {"name": "n", "version": "1"}}}), flush=True)
+    elif msg.get("method") == "tools/list":
+        print(json.dumps({"jsonrpc": "2.0", "id": msg["id"], "result": {"tools": []}}), flush=True)
+"""
+
+_CWD_ECHO_SERVER = """
+import json, os, sys
+for line in sys.stdin:
+    msg = json.loads(line)
+    if msg.get("method") == "initialize":
+        print(json.dumps({"jsonrpc": "2.0", "id": msg["id"], "result": {
+            "protocolVersion": "2025-06-18", "capabilities": {},
+            "serverInfo": {"name": "c", "version": "1"}}}), flush=True)
+    elif msg.get("method") == "tools/list":
+        print(json.dumps({"jsonrpc": "2.0", "id": msg["id"],
+                          "result": {"tools": [{"name": os.getcwd()}]}}), flush=True)
+"""
+
+
+def _server(tmp_path: Path, source: str) -> tuple[str, ...]:
+    """Write ``source`` as a script and return the argv that runs it."""
+    script = tmp_path / "srv.py"
+    script.write_text(source, encoding="utf-8")
+    return (sys.executable, str(script))
+
+
+def test_probe_returns_promptly_when_the_server_forks_a_surviving_grandchild(
+    tmp_path: Path,
+) -> None:
+    """A launcher (uvx/npx/sh -c/docker) execs the real server as a child.
+
+    Signalling only the direct child leaves that grandchild holding the inherited
+    stdout pipe, so the reader thread never reaches EOF and closing the stream
+    blocks on its lock — the probe used to hang for the grandchild's whole life
+    (2 minutes here) instead of returning. Regression test for that hang, which
+    also fired on the success path.
+    """
+    binding = McpBinding(name="forker", command=_server(tmp_path, _FORKING_SERVER))
+
+    started = time.monotonic()
+    tools = probe_stdio_server(binding, base_env=dict(os.environ), timeout=10.0)
+
+    assert tools == ("t",)
+    assert time.monotonic() - started < 20.0, "probe must not wait out the grandchild"
+
+
+def test_probe_redacts_expanded_secrets_from_the_reported_stderr(tmp_path: Path) -> None:
+    """The probe holds the only expanded copy of a ``${VAR}`` credential.
+
+    Its failure message reaches ``AgentResult.errors`` and is persisted to the
+    run's results.json, and a server rejecting a credential routinely echoes it,
+    so the value must never survive into the message.
+    """
+    binding = McpBinding(
+        name="leaky",
+        command=_server(tmp_path, _SECRET_ECHO_SERVER),
+        env=(("TOK", "${REAL_SECRET}"),),
+    )
+
+    with pytest.raises(McpUnreachableError) as excinfo:
+        probe_stdio_server(binding, base_env={"REAL_SECRET": "ghp_supersecret123"}, timeout=10.0)
+
+    assert "ghp_supersecret123" not in str(excinfo.value)
+    assert "***" in str(excinfo.value)
+
+
+def test_probe_reports_stderr_when_the_server_starts_then_hangs(tmp_path: Path) -> None:
+    """Timeout is the case the stderr explains, so it must carry it.
+
+    The stderr reader only reaches EOF once the process stops, so composing the
+    message before terminating produced a bare "timed out" with no cause.
+    """
+    binding = McpBinding(name="hangs", command=_server(tmp_path, _HANGS_AFTER_STDERR))
+
+    with pytest.raises(McpUnreachableError, match="token rejected"):
+        probe_stdio_server(binding, base_env=dict(os.environ), timeout=2.0)
+
+
+def test_probe_fails_a_server_that_advertises_no_tools(tmp_path: Path) -> None:
+    """Handshaking with an empty tool list is the tool-less arm this probe exists
+    to catch: the model falls back to shell tools and the run still scores."""
+    binding = McpBinding(name="empty", command=_server(tmp_path, _NO_TOOLS_SERVER))
+
+    with pytest.raises(McpUnreachableError, match="advertised no tools"):
+        probe_stdio_server(binding, base_env=dict(os.environ), timeout=10.0)
+
+
+def test_probe_launches_the_server_in_the_supplied_cwd(tmp_path: Path) -> None:
+    """The probe must launch a server where the CLI later will, so a relative
+    path in the binding's args resolves the same way in both."""
+    run_dir = tmp_path / "workspace"
+    run_dir.mkdir()
+    binding = McpBinding(name="cwd", command=_server(tmp_path, _CWD_ECHO_SERVER))
+
+    tools = probe_stdio_server(binding, base_env=dict(os.environ), timeout=10.0, cwd=run_dir)
+
+    assert Path(tools[0]).resolve() == run_dir.resolve()
+
+
+def test_preflight_probes_servers_concurrently(tmp_path: Path) -> None:
+    """Servers are independent, so the budget is the slowest one, not the sum.
+
+    Sequential probing put N * timeout on a path that runs before every run in
+    the matrix.
+    """
+    slow = tmp_path / "slow.py"
+    slow.write_text("import time; time.sleep(30)", encoding="utf-8")
+    bindings = tuple(
+        McpBinding(name=f"s{i}", command=(sys.executable, str(slow))) for i in range(4)
+    )
+
+    started = time.monotonic()
+    with pytest.raises(McpUnreachableError):
+        preflight_mcp(bindings, base_env=dict(os.environ), timeout=2.0)
+
+    assert time.monotonic() - started < 6.0, "probes must overlap, not queue"
+
+
+def test_preflight_names_the_first_failure_in_binding_order(tmp_path: Path) -> None:
+    """Concurrency must not make the reported failure depend on a race."""
+    good = _server(tmp_path, _FORKING_SERVER)
+    bindings = (
+        McpBinding(name="alpha", command=("/nonexistent/a",)),
+        McpBinding(name="beta", command=("/nonexistent/b",)),
+        McpBinding(name="gamma", command=good),
+    )
+
+    with pytest.raises(McpUnreachableError, match="'alpha'"):
+        preflight_mcp(bindings, base_env=dict(os.environ), timeout=10.0)

--- a/tests/unit/agents/shared/test_mcp_probe.py
+++ b/tests/unit/agents/shared/test_mcp_probe.py
@@ -389,3 +389,22 @@ def test_preflight_names_the_first_failure_in_binding_order(tmp_path: Path) -> N
 
     with pytest.raises(McpUnreachableError, match="'alpha'"):
         preflight_mcp(bindings, base_env=dict(os.environ), timeout=10.0)
+
+
+def test_probe_survives_a_stdout_burst_larger_than_the_line_cap(tmp_path: Path) -> None:
+    """A server logging far more than ``_MAX_STDOUT_LINES`` before its reply must
+    still hand that reply to the probe.
+
+    The reader thread holds a bounded queue so a chatty server cannot exhaust
+    memory, but the cap is a backlog limit, not a total: the consumer drains
+    concurrently. If the reader ever blocked on a full queue instead of dropping,
+    the server would stall behind its own pipe and the probe would report a
+    healthy server as unreachable.
+    """
+    burst = _FAKE_SERVER.replace(
+        "for line in sys.stdin:",
+        'for _i in range(5000):\n    print("log line", _i, flush=True)\n\nfor line in sys.stdin:',
+    )
+    binding = McpBinding(name="chatty", command=_server(tmp_path, burst))
+
+    assert probe_stdio_server(binding, timeout=30) == ("alpha", "beta")

--- a/tests/unit/agents/shared/test_mcp_probe.py
+++ b/tests/unit/agents/shared/test_mcp_probe.py
@@ -286,13 +286,6 @@ for line in sys.stdin:
 """
 
 
-def _server(tmp_path: Path, source: str) -> tuple[str, ...]:
-    """Write ``source`` as a script and return the argv that runs it."""
-    script = tmp_path / "srv.py"
-    script.write_text(source, encoding="utf-8")
-    return (sys.executable, str(script))
-
-
 def test_probe_returns_promptly_when_the_server_forks_a_surviving_grandchild(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/agents/test_agents_cli_antigravity.py
+++ b/tests/unit/agents/test_agents_cli_antigravity.py
@@ -971,3 +971,40 @@ def test_agy_cli_agent_probes_with_the_run_env_and_workdir(
     assert seen["base_env"]["GEMINI_API_KEY"] == "secret-key"
     assert seen["base_env"]["PATH"] == os.environ["PATH"]
     assert seen["cwd_exists"]
+
+
+@mock.patch.object(pathlib.Path, "home")
+@mock.patch.object(devops_subprocess, "run")
+def test_agy_cli_agent_probes_every_granted_binding(mock_run, mock_home, tmp_path, monkeypatch):
+    """Every granted binding is handed to the probe verbatim. Passing a subset —
+    or a rebuilt binding that drops ``env``/``cwd`` — would gate on a server the
+    run does not launch, and the dead one it does launch would score as an MCP
+    arm."""
+    seen: dict = {}
+    mock_home.return_value = tmp_path
+    mock_run.return_value = SimpleNamespace(args=["agy"], returncode=0, stdout="ok", stderr="")
+
+    def record(bindings, **kw):
+        seen["bindings"] = bindings
+        seen["kwargs"] = kw
+
+    monkeypatch.setattr(agy_mod, "preflight_mcp", record)
+    bindings = (
+        capabilities.McpBinding(name="gke", command=("gke-mcp",)),
+        capabilities.McpBinding(
+            name="facts",
+            command=("uvx", "facts-server"),
+            env=(("FACTS_TOKEN", "${FACTS_TOKEN}"),),
+            cwd="/srv/facts",
+        ),
+    )
+    config = agents_config.AgentConfig(
+        target="/bin/agy",
+        model="gemini-3.5-flash",
+        capabilities=capabilities.AllCapabilities(mcp_servers=bindings),
+    )
+
+    agy_mod.AgyCliAgent(config)._execute("run task")
+
+    assert seen["bindings"] == bindings
+    assert set(seen["kwargs"]) == {"base_env", "cwd"}

--- a/tests/unit/agents/test_agents_cli_antigravity.py
+++ b/tests/unit/agents/test_agents_cli_antigravity.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import sqlite3
 from types import SimpleNamespace
@@ -26,6 +27,7 @@ from devops_bench.agents import capabilities
 from devops_bench.agents import config as agents_config
 from devops_bench.agents.cli.antigravity import agent as agy_mod
 from devops_bench.agents.cli.antigravity import parsing
+from devops_bench.agents.shared.mcp_probe import McpUnreachableError
 from devops_bench.core import subprocess as devops_subprocess
 from devops_bench.core.errors import SubprocessError
 
@@ -816,6 +818,36 @@ def test_agy_cli_agent_forwards_extra_flags(
 
 @mock.patch.object(pathlib.Path, "home")
 @mock.patch.object(devops_subprocess, "run")
+def test_agy_cli_agent_fails_the_run_when_a_granted_mcp_server_is_unreachable(
+    mock_run, mock_home, tmp_path, monkeypatch
+):
+    """A granted server that never starts leaves agy falling back to shell tools
+    while the run is still scored as an MCP arm — the same gate the other CLI
+    harnesses run, so the binary must never be launched."""
+
+    def boom(*_a, **_kw):
+        raise McpUnreachableError("MCP server 'gke' is unreachable: could not launch server")
+
+    mock_home.return_value = tmp_path
+    monkeypatch.setattr(agy_mod, "preflight_mcp", boom)
+    caps = capabilities.AllCapabilities(
+        mcp_servers=(capabilities.McpBinding(name="gke", command=("gke-mcp",)),)
+    )
+    config = agents_config.AgentConfig(
+        target="/bin/agy", model="gemini-3.5-flash", capabilities=caps
+    )
+
+    result = agy_mod.AgyCliAgent(config)._execute("run task")
+
+    assert result.errors == [
+        "MCP preflight failed: MCP server 'gke' is unreachable: could not launch server"
+    ]
+    # The gcloud project/location lookups still run; the agy binary must not.
+    assert all(call.args[0][0] == "gcloud" for call in mock_run.call_args_list)
+
+
+@mock.patch.object(pathlib.Path, "home")
+@mock.patch.object(devops_subprocess, "run")
 def test_agy_cli_agent_discovers_gemini_dir_conversations_fallback(
     mock_run: mock.MagicMock,
     mock_home: mock.MagicMock,
@@ -907,3 +939,35 @@ def test_agy_cli_agent_discovers_parent_conversations_when_nested_is_empty(
     )
     assert len(result.trajectory) == 2
     assert result.errors == []
+
+
+@mock.patch.object(pathlib.Path, "home")
+@mock.patch.object(devops_subprocess, "run")
+def test_agy_cli_agent_probes_with_the_run_env_and_workdir(
+    mock_run, mock_home, tmp_path, monkeypatch
+):
+    """The probe must launch the server the way agy will: with the harness env
+    overlay applied and in the workspace, or it validates a different process
+    than the one the run uses."""
+    seen: dict = {}
+    mock_home.return_value = tmp_path
+    mock_run.return_value = SimpleNamespace(args=["agy"], returncode=0, stdout="ok", stderr="")
+
+    def record(_bindings, **kw):
+        # The workspace is a temp dir torn down when ``_execute`` returns, so
+        # its existence has to be sampled here rather than asserted afterwards.
+        seen.update(kw, cwd_exists=pathlib.Path(kw["cwd"]).is_dir())
+
+    monkeypatch.setattr(agy_mod, "preflight_mcp", record)
+    caps = capabilities.AllCapabilities(
+        mcp_servers=(capabilities.McpBinding(name="gke", command=("gke-mcp",)),)
+    )
+    config = agents_config.AgentConfig(
+        target="/bin/agy", model="gemini-3.5-flash", api_key="secret-key", capabilities=caps
+    )
+
+    agy_mod.AgyCliAgent(config)._execute("run task")
+
+    assert seen["base_env"]["GEMINI_API_KEY"] == "secret-key"
+    assert seen["base_env"]["PATH"] == os.environ["PATH"]
+    assert seen["cwd_exists"]

--- a/tests/unit/agents/test_agents_cli_gemini.py
+++ b/tests/unit/agents/test_agents_cli_gemini.py
@@ -41,6 +41,7 @@ from devops_bench.agents.cli.gemini_cli.agent import (
     _build_env,
     _build_settings,
 )
+from devops_bench.agents.shared.mcp_probe import McpUnreachableError
 from devops_bench.core.errors import ConfigError, SubprocessError
 
 
@@ -738,3 +739,151 @@ def test_execute_forwards_extra_flags(monkeypatch: pytest.MonkeyPatch) -> None:
     GeminiCliAgent(cfg).run("p")
     assert "--flag1" in captured["argv"]
     assert "--opt=val" in captured["argv"]
+
+
+def test_execute_fails_the_run_when_a_granted_mcp_server_is_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dead MCP server is fatal and the prompt is never run.
+
+    Without this the CLI exits 0 with an empty error list: the model falls back
+    to shell tools and the run is still recorded as an MCP arm, so the arm
+    measures shell competence instead of tool use. The probe supplies the cause
+    the CLI's own listing never reports.
+    """
+    invoked: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        invoked.append(argv)
+        if argv[1:3] == ["mcp", "list"]:
+            return SimpleNamespace(
+                stdout="○ gke: gke-mcp (stdio) - Disconnected\n", stderr="", returncode=0
+            )
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    def fake_preflight(*_args, **_kwargs):
+        raise McpUnreachableError("MCP server 'gke' is unreachable: could not launch server")
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    monkeypatch.setattr(gemini_mod, "preflight_mcp", fake_preflight)
+    caps = AllCapabilities(mcp_servers=(McpBinding(name="gke", command=("gke-mcp",)),))
+
+    result = GeminiCliAgent(AgentConfig(target="gemini", capabilities=caps)).run("p")
+
+    assert result.errors == [
+        "MCP preflight failed: the CLI does not report these servers as connected: "
+        "gke (Disconnected); MCP server 'gke' is unreachable: could not launch server"
+    ]
+    assert [a[1:3] for a in invoked] == [["mcp", "list"]], "the prompt must never run"
+
+
+def test_execute_fails_the_run_when_the_cli_cannot_see_a_granted_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reachable is not usable: gemini gates MCP on folder trust and an untrusted
+    workspace disables every server with nothing on the run's stderr, so the
+    binary's own ``mcp list`` view is the gate."""
+    invoked: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        invoked.append(argv)
+        if argv[1:3] == ["mcp", "list"]:
+            return SimpleNamespace(
+                stdout="Configured MCP servers:\n\n\u25cb gke: gke-mcp  (stdio) - Disabled\n",
+                stderr="",
+                returncode=0,
+            )
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    caps = AllCapabilities(mcp_servers=(McpBinding(name="gke", command=("gke-mcp",)),))
+
+    result = GeminiCliAgent(AgentConfig(target="gemini", capabilities=caps)).run("p")
+
+    assert result.errors == [
+        "MCP preflight failed: the CLI does not report these servers as connected: gke (Disabled)"
+        "; every server answered a direct stdio probe, so this is a CLI-side gate (folder trust)"
+    ]
+    assert [a[1:3] for a in invoked] == [["mcp", "list"]], "the prompt must never run"
+
+
+def test_execute_proceeds_when_the_cli_reports_every_server_connected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connected server clears the gate and the prompt runs."""
+
+    def fake_run(argv, **kwargs):
+        if argv[1:3] == ["mcp", "list"]:
+            return SimpleNamespace(
+                stdout="\u2713 gke: gke-mcp  (stdio) - Connected\n", stderr="", returncode=0
+            )
+        return SimpleNamespace(stdout=SAMPLE_STREAM, stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    caps = AllCapabilities(mcp_servers=(McpBinding(name="gke", command=("gke-mcp",)),))
+
+    result = GeminiCliAgent(AgentConfig(target="gemini", capabilities=caps)).run("p")
+
+    assert result.errors == []
+    assert result.output == "Done."
+
+
+def test_execute_fails_when_a_granted_server_is_absent_from_the_listing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unparseable or changed listing format must fail loud, not pass by
+    default — the whole point of the gate is that silence is indistinguishable
+    from success."""
+
+    def fake_run(argv, **kwargs):
+        if argv[1:3] == ["mcp", "list"]:
+            return SimpleNamespace(stdout="no servers here", stderr="", returncode=0)
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    caps = AllCapabilities(mcp_servers=(McpBinding(name="gke", command=("gke-mcp",)),))
+
+    result = GeminiCliAgent(AgentConfig(target="gemini", capabilities=caps)).run("p")
+
+    assert "gke (<not listed>)" in result.errors[0]
+
+
+def test_execute_skips_the_cli_gate_when_no_mcp_is_granted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A no-MCP arm pays no extra CLI invocation."""
+    invoked: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        invoked.append(argv)
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+
+    result = GeminiCliAgent(AgentConfig(target="gemini")).run("p")
+
+    assert result.errors == []
+    assert all(a[1:3] != ["mcp", "list"] for a in invoked)
+
+
+def test_execute_reads_the_mcp_listing_from_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """gemini 0.56 prints the whole ``mcp list`` listing on stderr, so a gate that
+    only read stdout failed every run with "<not listed>"."""
+
+    def fake_run(argv, **kwargs):
+        if argv[1:3] == ["mcp", "list"]:
+            return SimpleNamespace(
+                stdout="",
+                stderr="Configured MCP servers:\n\n✓ gke: gke-mcp  (stdio) - Connected\n",
+                returncode=0,
+            )
+        return SimpleNamespace(stdout=SAMPLE_STREAM, stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    caps = AllCapabilities(mcp_servers=(McpBinding(name="gke", command=("gke-mcp",)),))
+
+    result = GeminiCliAgent(AgentConfig(target="gemini", capabilities=caps)).run("p")
+
+    assert result.errors == []

--- a/tests/unit/agents/test_agents_cli_gemini.py
+++ b/tests/unit/agents/test_agents_cli_gemini.py
@@ -848,6 +848,33 @@ def test_execute_fails_when_a_granted_server_is_absent_from_the_listing(
     assert "gke (<not listed>)" in result.errors[0]
 
 
+def test_execute_fails_when_the_mcp_listing_command_exits_non_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-zero ``gemini mcp list`` means the CLI never dialled the servers —
+    a malformed settings.json or an unknown flag. Parsing that output for status
+    rows would report the generic "<not listed>" instead of the cause the CLI
+    already printed."""
+
+    def fake_run(argv, **kwargs):
+        if argv[1:3] == ["mcp", "list"]:
+            return SimpleNamespace(
+                stdout="",
+                stderr="SyntaxError: Unexpected token } in JSON at position 42\n",
+                returncode=1,
+            )
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    caps = AllCapabilities(mcp_servers=(McpBinding(name="gke", command=("gke-mcp",)),))
+
+    result = GeminiCliAgent(AgentConfig(target="gemini", capabilities=caps)).run("p")
+
+    assert "'gemini mcp list' exited 1" in result.errors[0]
+    assert "Unexpected token }" in result.errors[0]
+    assert "<not listed>" not in result.errors[0]
+
+
 def test_execute_skips_the_cli_gate_when_no_mcp_is_granted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/agents/test_agents_cli_openclaw.py
+++ b/tests/unit/agents/test_agents_cli_openclaw.py
@@ -45,6 +45,7 @@ from devops_bench.agents.cli.openclaw.agent import (
     _oc_model_id,
 )
 from devops_bench.agents.cli.openclaw.parsing import _pick_session_key, _strip_ansi
+from devops_bench.agents.shared.mcp_probe import McpUnreachableError
 from devops_bench.core.errors import ConfigError, SubprocessError
 
 
@@ -909,3 +910,29 @@ def test_execute_cleans_up_temp_working_dir_after_run(
     OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"))).run("p")
     assert captured["cwd"] is not None
     assert not os.path.exists(captured["cwd"])
+
+
+def test_execute_fails_the_run_when_a_granted_mcp_server_is_unreachable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A dead MCP server is fatal and ``oc`` is never invoked — otherwise the
+    run scores as an MCP arm while the model only had shell tools."""
+    invoked: list[Any] = []
+
+    def fake_bash(command: str, **kwargs: Any) -> SimpleNamespace:
+        invoked.append(command)
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    def fake_preflight(*_args: Any, **_kwargs: Any) -> dict:
+        raise McpUnreachableError("MCP server 'gke' is unreachable: could not launch server")
+
+    _install_oc_run(monkeypatch, fake_bash)
+    monkeypatch.setattr(oc_mod, "preflight_mcp", fake_preflight)
+    caps = AllCapabilities(mcp_servers=(McpBinding(name="gke", command=("gke-mcp",)),))
+
+    result = OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"), capabilities=caps)).run("p")
+
+    assert invoked == [], "oc must not run once preflight has failed"
+    assert result.errors == [
+        "MCP preflight failed: MCP server 'gke' is unreachable: could not launch server"
+    ]

--- a/tests/unit/agents/test_agents_config.py
+++ b/tests/unit/agents/test_agents_config.py
@@ -243,6 +243,12 @@ def test_from_env_blank_mcp_config_falls_back_to_the_shorthand() -> None:
         ('{"mcpServers": {"a": {"command": "uvx", "env": {"K": 1}}}}', "string mapping"),
         ('{"mcpServers": {"a": {"command": "uvx", "tools": "x"}}}', "list of strings"),
         ('{"mcpServers": {"a": {"command": "uvx", "cwd": ["/tmp"]}}}', "'cwd' must be a string"),
+        # A falsy wrong type must raise rather than fall back to the default:
+        # dropping a declared env or argv leaves the server launching without
+        # its credential, and the probe then reports the wrong cause.
+        ('{"mcpServers": {"a": {"command": "uvx", "args": 0}}}', "list of strings"),
+        ('{"mcpServers": {"a": {"command": "uvx", "env": 0}}}', "string mapping"),
+        ('{"mcpServers": {"a": {"command": "uvx", "cwd": 0}}}', "'cwd' must be a string"),
         ('{"mcpServers": {}}', "is empty"),
         ("/nonexistent/bench-mcp.json", "unreadable"),
     ],

--- a/tests/unit/agents/test_agents_config.py
+++ b/tests/unit/agents/test_agents_config.py
@@ -240,6 +240,13 @@ def test_from_env_blank_mcp_config_falls_back_to_the_shorthand() -> None:
         ('{"mcpServers": {"a": "uvx"}}', "must be a JSON object"),
         ('{"mcpServers": {"a": {}}}', "command: Field required"),
         ('{"mcpServers": {"a": {"command": ""}}}', "command: String should have at least 1"),
+        # An all-whitespace command clears min_length but splits to no argv at
+        # all, which is the same "MCP arm with no MCP server" the empty case is
+        # rejected for.
+        (
+            '{"mcpServers": {"a": {"command": "   "}}}',
+            "command: String should match pattern",
+        ),
         (
             '{"mcpServers": {"a": {"command": "uvx", "args": "x"}}}',
             "args: Input should be a valid list",

--- a/tests/unit/agents/test_agents_config.py
+++ b/tests/unit/agents/test_agents_config.py
@@ -268,3 +268,13 @@ def test_from_env_mcp_config_file_must_hold_a_json_object(tmp_path: Path) -> Non
 
     with pytest.raises(ConfigError, match="must be a JSON object"):
         AgentConfig.from_env({"AGENT_MCP_CONFIG": str(config)})
+
+
+def test_from_env_undecodable_mcp_config_file_raises_config_error(tmp_path: Path) -> None:
+    """``from_env`` documents ``ConfigError`` as its only failure, so a file that
+    is not UTF-8 must not surface the raw ``UnicodeDecodeError``."""
+    config = tmp_path / "bench-mcp.json"
+    config.write_bytes(b'{"mcpServers": {"a": {"command": "\xff\xfe"}}}')
+
+    with pytest.raises(ConfigError, match="not valid UTF-8"):
+        AgentConfig.from_env({"AGENT_MCP_CONFIG": str(config)})

--- a/tests/unit/agents/test_agents_config.py
+++ b/tests/unit/agents/test_agents_config.py
@@ -238,17 +238,40 @@ def test_from_env_blank_mcp_config_falls_back_to_the_shorthand() -> None:
         ('{"servers": {}}', "no 'mcpServers' key"),
         ('{"mcpServers": []}', "must be a JSON object"),
         ('{"mcpServers": {"a": "uvx"}}', "must be a JSON object"),
-        ('{"mcpServers": {"a": {}}}', "non-empty 'command'"),
-        ('{"mcpServers": {"a": {"command": "uvx", "args": "x"}}}', "list of strings"),
-        ('{"mcpServers": {"a": {"command": "uvx", "env": {"K": 1}}}}', "string mapping"),
-        ('{"mcpServers": {"a": {"command": "uvx", "tools": "x"}}}', "list of strings"),
-        ('{"mcpServers": {"a": {"command": "uvx", "cwd": ["/tmp"]}}}', "'cwd' must be a string"),
-        # A falsy wrong type must raise rather than fall back to the default:
-        # dropping a declared env or argv leaves the server launching without
-        # its credential, and the probe then reports the wrong cause.
-        ('{"mcpServers": {"a": {"command": "uvx", "args": 0}}}', "list of strings"),
-        ('{"mcpServers": {"a": {"command": "uvx", "env": 0}}}', "string mapping"),
-        ('{"mcpServers": {"a": {"command": "uvx", "cwd": 0}}}', "'cwd' must be a string"),
+        ('{"mcpServers": {"a": {}}}', "command: Field required"),
+        ('{"mcpServers": {"a": {"command": ""}}}', "command: String should have at least 1"),
+        (
+            '{"mcpServers": {"a": {"command": "uvx", "args": "x"}}}',
+            "args: Input should be a valid list",
+        ),
+        (
+            '{"mcpServers": {"a": {"command": "uvx", "env": {"K": 1}}}}',
+            "env.K: Input should be a valid string",
+        ),
+        (
+            '{"mcpServers": {"a": {"command": "uvx", "tools": "x"}}}',
+            "tools: Input should be a valid list",
+        ),
+        (
+            '{"mcpServers": {"a": {"command": "uvx", "cwd": ["/tmp"]}}}',
+            "cwd: Input should be a valid string",
+        ),
+        # A falsy wrong type must raise rather than be coerced or fall back to
+        # the default: dropping a declared env or argv leaves the server
+        # launching without its credential, and the probe then reports the wrong
+        # cause. Strict mode is what makes ``0`` an error instead of ``"0"``.
+        (
+            '{"mcpServers": {"a": {"command": "uvx", "args": 0}}}',
+            "args: Input should be a valid list",
+        ),
+        (
+            '{"mcpServers": {"a": {"command": "uvx", "env": 0}}}',
+            "env: Input should be a valid dict",
+        ),
+        (
+            '{"mcpServers": {"a": {"command": "uvx", "cwd": 0}}}',
+            "cwd: Input should be a valid string",
+        ),
         ('{"mcpServers": {}}', "is empty"),
         ("/nonexistent/bench-mcp.json", "unreadable"),
     ],
@@ -268,6 +291,45 @@ def test_from_env_mcp_config_file_must_hold_a_json_object(tmp_path: Path) -> Non
 
     with pytest.raises(ConfigError, match="must be a JSON object"):
         AgentConfig.from_env({"AGENT_MCP_CONFIG": str(config)})
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["GITHUB_TOKEN", "API_KEY", "CLIENT_SECRET", "DB_PASSWORD", "GCP_CREDENTIALS"],
+)
+def test_from_env_rejects_a_literal_in_a_secret_named_mcp_env_value(key: str) -> None:
+    """A pasted credential must fail the config, not ride into the artifacts.
+
+    The declared env is written into the agent's workspace config and the
+    harness collects that workspace wholesale into the run's results, so a
+    literal secret is persisted. A ``${VAR}`` reference is resolved only for the
+    server's own process.
+    """
+    raw = json.dumps({"mcpServers": {"gh": {"command": "uvx", "env": {key: "ghp_literal"}}}})
+
+    with pytest.raises(ConfigError, match="looks like a credential"):
+        AgentConfig.from_env({"AGENT_MCP_CONFIG": raw})
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("GITHUB_TOKEN", "${GITHUB_TOKEN}"),
+        ("AUTH_HEADER_KEY", "Bearer ${GH_PAT}"),
+        # Not credential-shaped: rejecting every literal would break ordinary
+        # configuration, which is the common case.
+        ("NODE_ENV", "production"),
+        # An empty value carries nothing to leak.
+        ("API_KEY", ""),
+    ],
+)
+def test_from_env_accepts_references_and_non_secret_literals(key: str, value: str) -> None:
+    """The guard fires on secret-named keys holding a literal, and nothing else."""
+    raw = json.dumps({"mcpServers": {"gh": {"command": "uvx", "env": {key: value}}}})
+
+    cfg = AgentConfig.from_env({"AGENT_MCP_CONFIG": raw})
+
+    assert cfg.capabilities.mcp_servers[0].env == ((key, value),)
 
 
 def test_from_env_undecodable_mcp_config_file_raises_config_error(tmp_path: Path) -> None:

--- a/tests/unit/agents/test_agents_config.py
+++ b/tests/unit/agents/test_agents_config.py
@@ -14,6 +14,11 @@
 
 """Unit tests for devops_bench.agents.config."""
 
+import json
+from pathlib import Path
+
+import pytest
+
 from devops_bench.agents.capabilities import (
     AgentRules,
     AllCapabilities,
@@ -21,6 +26,7 @@ from devops_bench.agents.capabilities import (
     SkillBinding,
 )
 from devops_bench.agents.config import AgentConfig
+from devops_bench.core import ConfigError
 
 
 def test_default_construction_uses_safe_defaults() -> None:
@@ -149,3 +155,110 @@ def test_from_env_extra_flags_unset_or_empty() -> None:
     assert AgentConfig.from_env({}).extra_flags == ()
     assert AgentConfig.from_env({"AGENT_EXTRA_FLAGS": ""}).extra_flags == ()
     assert AgentConfig.from_env({"AGENT_EXTRA_FLAGS": "   "}).extra_flags == ()
+
+
+def test_from_env_parses_inline_mcp_config_document() -> None:
+    """``AGENT_MCP_CONFIG`` accepts the standard ``mcpServers`` document inline,
+    so a one-off run needs no config file."""
+    env = {
+        "AGENT_MCP_CONFIG": json.dumps(
+            {
+                "mcpServers": {
+                    "time": {"command": "uvx", "args": ["mcp-server-time"]},
+                    "github": {
+                        "command": "npx",
+                        "args": ["-y", "@modelcontextprotocol/server-github"],
+                        "env": {"GITHUB_TOKEN": "${GITHUB_TOKEN}"},
+                        "cwd": "/work",
+                        "tools": ["create_issue"],
+                    },
+                }
+            }
+        )
+    }
+    cfg = AgentConfig.from_env(env)
+
+    assert cfg.capabilities.mcp_servers == (
+        McpBinding(name="time", command=("uvx", "mcp-server-time")),
+        McpBinding(
+            name="github",
+            command=("npx", "-y", "@modelcontextprotocol/server-github"),
+            env=(("GITHUB_TOKEN", "${GITHUB_TOKEN}"),),
+            cwd="/work",
+            tools=("create_issue",),
+        ),
+    )
+
+
+def test_from_env_reads_mcp_config_from_a_path(tmp_path: Path) -> None:
+    """A value that is not inline JSON is a path — the form the matrix uses,
+    where a quoted JSON blob would not survive its ';'-joined, eval'd env."""
+    config = tmp_path / "bench-mcp.json"
+    config.write_text(json.dumps({"mcpServers": {"time": {"command": "uvx"}}}))
+
+    cfg = AgentConfig.from_env({"AGENT_MCP_CONFIG": str(config)})
+
+    assert cfg.capabilities.mcp_servers == (McpBinding(name="time", command=("uvx",)),)
+
+
+def test_from_env_mcp_config_servers_inherit_allowed_tools() -> None:
+    """A server declaring no ``tools`` inherits ``AGENT_ALLOWED_TOOLS``."""
+    env = {
+        "AGENT_MCP_CONFIG": '{"mcpServers": {"time": {"command": "uvx"}}}',
+        "AGENT_ALLOWED_TOOLS": "a,b",
+    }
+    cfg = AgentConfig.from_env(env)
+
+    assert cfg.capabilities.mcp_servers[0].tools == ("a", "b")
+
+
+def test_from_env_mcp_config_takes_precedence_over_the_shorthand() -> None:
+    """``AGENT_MCP_SERVER`` is the single-server shorthand; the document wins."""
+    env = {
+        "AGENT_MCP_CONFIG": '{"mcpServers": {"time": {"command": "uvx"}}}',
+        "AGENT_MCP_SERVER": "/bin/gke-mcp",
+    }
+    cfg = AgentConfig.from_env(env)
+
+    assert [b.name for b in cfg.capabilities.mcp_servers] == ["time"]
+
+
+def test_from_env_blank_mcp_config_falls_back_to_the_shorthand() -> None:
+    """An empty value is treated as unset, not as a malformed document."""
+    env = {"AGENT_MCP_CONFIG": "  ", "AGENT_MCP_SERVER": "/bin/gke-mcp"}
+    cfg = AgentConfig.from_env(env)
+
+    assert cfg.capabilities.mcp_servers == (McpBinding(name="default", command=("/bin/gke-mcp",)),)
+
+
+@pytest.mark.parametrize(
+    ("raw", "match"),
+    [
+        ("{not json", "not valid JSON"),
+        ('{"servers": {}}', "no 'mcpServers' key"),
+        ('{"mcpServers": []}', "must be a JSON object"),
+        ('{"mcpServers": {"a": "uvx"}}', "must be a JSON object"),
+        ('{"mcpServers": {"a": {}}}', "non-empty 'command'"),
+        ('{"mcpServers": {"a": {"command": "uvx", "args": "x"}}}', "list of strings"),
+        ('{"mcpServers": {"a": {"command": "uvx", "env": {"K": 1}}}}', "string mapping"),
+        ('{"mcpServers": {"a": {"command": "uvx", "tools": "x"}}}', "list of strings"),
+        ('{"mcpServers": {"a": {"command": "uvx", "cwd": ["/tmp"]}}}', "'cwd' must be a string"),
+        ('{"mcpServers": {}}', "is empty"),
+        ("/nonexistent/bench-mcp.json", "unreadable"),
+    ],
+)
+def test_from_env_malformed_mcp_config_fails_loud(raw: str, match: str) -> None:
+    """A broken capability grant raises rather than running an MCP arm with no
+    MCP server — the same validity concern the reachability probe addresses."""
+    with pytest.raises(ConfigError, match=match):
+        AgentConfig.from_env({"AGENT_MCP_CONFIG": raw})
+
+
+def test_from_env_mcp_config_file_must_hold_a_json_object(tmp_path: Path) -> None:
+    """Only the inline form is recognized by its leading ``{``; a file is read
+    first and then validated, so a non-object document fails there."""
+    config = tmp_path / "bench-mcp.json"
+    config.write_text("[]")
+
+    with pytest.raises(ConfigError, match="must be a JSON object"):
+        AgentConfig.from_env({"AGENT_MCP_CONFIG": str(config)})

--- a/tests/unit/evalharness/test_default_harness.py
+++ b/tests/unit/evalharness/test_default_harness.py
@@ -48,6 +48,7 @@ def isolated_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "BENCH_USE_MCP",
         "BENCH_AGENT_TYPE",
         "AGENT_MCP_SERVER",
+        "AGENT_MCP_CONFIG",
         "AGENT_ALLOWED_TOOLS",
         "AGENT_SKILLS_PATHS",
         "AGENT_RULES_TEXT",

--- a/tests/unit/evalharness/test_single_env_read.py
+++ b/tests/unit/evalharness/test_single_env_read.py
@@ -44,6 +44,7 @@ def isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "BENCH_AGENT_TYPE",
         "BENCH_NO_INFRA",
         "AGENT_MCP_SERVER",
+        "AGENT_MCP_CONFIG",
         "AGENT_ALLOWED_TOOLS",
         "AGENT_SKILLS_PATHS",
         "AGENT_RULES_TEXT",


### PR DESCRIPTION
Adds support for multiple MCP servers, fails a run when a granted server is unreachable, and copies whole skill bundles instead of just `SKILL.md`.

**Multiple MCP servers.** `AGENT_MCP_SERVER` holds one argv string with no env and no cwd, so only a server that reads everything from the ambient environment works. New `AGENT_MCP_CONFIG` takes the standard `mcpServers` document (the one Claude Code and Cursor read), inline or as a file path:

```json
{"mcpServers": {"github": {"command": "npx",
                           "args": ["-y", "@modelcontextprotocol/server-github"],
                           "env": {"GITHUB_TOKEN": "${GITHUB_TOKEN}"}}}}
```

`AGENT_MCP_SERVER` still works as the single-server shorthand. Secrets go in as `${VAR}` and the CLI expands them from the subprocess env — the workspace gets copied into `generated_files/`, so a rendered value would end up committed.

**Unreachable servers fail the run.** Right now a server that doesn't start is invisible: gemini falls back to `run_shell_command`, `errors` is empty, exit 0, and the record still counts as an MCP arm. Both CLI agents now check their granted servers before the model runs. gemini uses `gemini mcp list` (which also covers folder trust); openclaw has no equivalent, so it uses a small stdio probe.

**Skill bundles.** `materialize_skills` copied `SKILL.md` and dropped the `references/`, `templates/`, `scripts/` next to it, so a skill telling the agent to read `templates/report.md` pointed at nothing. It now copies the directory.

Tested against real `gemini` 0.56 and `openclaw` 2026.7.1 with two MCP servers: both models called through both servers, the untrusted-workspace and dead-server cases both failed with the reason named, and no secret reached the workspace config.

HTTP/SSE MCP servers are out of scope — the probe only speaks stdio and I had nothing remote to test against.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for multiple MCP servers with per-server tools, environment variables, working directories, and configuration files.
  - Added MCP preflight checks across supported CLI agents, including connection validation, tool discovery, secret redaction, and actionable errors.
  - Added support for forwarding custom agent command-line flags.
  - Added API support for routing tool calls across multiple MCP servers.

- **Bug Fixes**
  - Improved MCP configuration validation and error reporting.
  - Improved skill bundle copying while safely handling symbolic links.
  - Prevented agent runs when required MCP servers are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->