### PR TITLE
Add a vcluster infrastructure provider for fast task iteration

### DIFF
--- a/devops_bench/providers/vcluster.py
+++ b/devops_bench/providers/vcluster.py
@@ -1,0 +1,130 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""vcluster provider: virtual clusters running inside an existing GKE host."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from devops_bench.core import ClusterInfo, ConfigError, get_env, get_logger
+from devops_bench.core.subprocess import run
+from devops_bench.providers.base import PROVIDERS, Provider, ResolveContext
+
+__all__ = ["VclusterProvider"]
+
+_log = get_logger("providers.vcluster")
+
+
+@PROVIDERS.register("vcluster")
+class VclusterProvider(Provider):
+    """Provider for loft-sh vcluster virtual clusters hosted on GKE.
+
+    A vcluster is a virtual Kubernetes control plane running as a workload
+    inside an existing GKE host cluster, provisioned in a couple of minutes
+    instead of the ten-plus minutes a real GKE cluster takes. Access to the
+    vcluster itself goes through the kubeconfig the OpenTofu module writes to
+    disk, not through ``gcloud``; only reaching the *host* cluster (to run the
+    vcluster's own control plane) may need ``gcloud`` credentials.
+    """
+
+    def ensure_account_credentials(self) -> None:
+        """Ensure the host GKE cluster's context is available for kubectl/helm.
+
+        If ``VCLUSTER_HOST_CLUSTER`` is set and a project is resolvable from
+        ``GCP_PROJECT_ID``, runs ``gcloud container clusters get-credentials``
+        for the host cluster so its context exists in kubeconfig. Otherwise a
+        no-op: assumes the host context is already present in kubeconfig.
+
+        Raises:
+            ConfigError: If ``VCLUSTER_HOST_CLUSTER`` is set but no location is
+                resolvable from ``VCLUSTER_HOST_LOCATION`` or ``GCP_LOCATION``.
+        """
+        host_cluster = get_env("VCLUSTER_HOST_CLUSTER")
+        project = get_env("GCP_PROJECT_ID")
+        if not host_cluster or not project:
+            _log.debug(
+                "vcluster provider: assuming host cluster context is already in kubeconfig"
+            )
+            return
+
+        location = get_env("VCLUSTER_HOST_LOCATION") or get_env("GCP_LOCATION")
+        if not location:
+            raise ConfigError(
+                "VCLUSTER_HOST_CLUSTER is set but no location is resolvable; "
+                "set VCLUSTER_HOST_LOCATION or GCP_LOCATION"
+            )
+        _log.info("Configuring kubectl for host cluster: %s in %s...", host_cluster, location)
+        run(
+            [
+                "gcloud",
+                "container",
+                "clusters",
+                "get-credentials",
+                host_cluster,
+                "--location",
+                location,
+                "--project",
+                project,
+            ],
+            capture=False,
+        )
+
+    def ensure_cluster_credentials(
+        self, cluster_name: str, location: str, variables: dict[str, Any]
+    ) -> ClusterInfo:
+        """Describe a vcluster; its kubeconfig is already on disk.
+
+        Args:
+            cluster_name: Cluster name from the stack outputs.
+            location: Location from the stack outputs (the host GKE region).
+            variables: OpenTofu input variables the cluster was provisioned with.
+
+        Returns:
+            The cluster's :class:`~devops_bench.core.ClusterInfo`.
+        """
+        project = variables.get("project_id") or get_env("GCP_PROJECT_ID")
+        return ClusterInfo.from_dict(
+            {
+                "name": cluster_name,
+                "location": location,
+                "project": project,
+                "kubeconfig_path": variables.get("kubeconfig_path"),
+            }
+        )
+
+    def resolve_variables(
+        self, ctx: ResolveContext, custom_variables: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Resolve default OpenTofu variables for vcluster stacks.
+
+        Returns:
+            A new mapping with ``project_id``, ``cluster_name``, ``location``,
+            ``host_cluster_name``, ``host_context``, and ``kubeconfig_path``
+            filled in where not already set.
+        """
+        variables = custom_variables.copy()
+        variables.setdefault("infra_provider", "vcluster")
+        variables.setdefault("project_id", ctx.project_id)
+        variables.setdefault("cluster_name", ctx.cluster_name)
+        variables.setdefault("location", ctx.location)
+        variables.setdefault("host_cluster_name", get_env("VCLUSTER_HOST_CLUSTER") or "")
+        host_context = get_env("VCLUSTER_HOST_CONTEXT")
+        if host_context:
+            variables.setdefault("host_context", host_context)
+        cluster_name = variables["cluster_name"]
+        kubeconfig_path = str(Path("~/.kube").expanduser() / f"vcluster-{cluster_name}.yaml")
+        variables.setdefault("kubeconfig_path", kubeconfig_path)
+        return variables

--- a/devops_bench/providers/vcluster.py
+++ b/devops_bench/providers/vcluster.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""vcluster provider: virtual clusters running inside an existing GKE host."""
+"""vcluster provider: virtual clusters running inside an existing host cluster."""
 
 from __future__ import annotations
 
@@ -30,28 +30,44 @@ _log = get_logger("providers.vcluster")
 
 @PROVIDERS.register("vcluster")
 class VclusterProvider(Provider):
-    """Provider for loft-sh vcluster virtual clusters hosted on GKE.
+    """Provider for loft-sh vcluster virtual clusters hosted on gke/eks/aks.
 
     A vcluster is a virtual Kubernetes control plane running as a workload
-    inside an existing GKE host cluster, provisioned in a couple of minutes
-    instead of the ten-plus minutes a real GKE cluster takes. Access to the
+    inside an existing host cluster, provisioned in a couple of minutes
+    instead of the ten-plus minutes a real cluster takes. Access to the
     vcluster itself goes through the kubeconfig the OpenTofu module writes to
-    disk, not through ``gcloud``; only reaching the *host* cluster (to run the
-    vcluster's own control plane) may need ``gcloud`` credentials.
+    disk, not through the host cloud's CLI; only reaching the *host* cluster
+    (to run the vcluster's own control plane) may need host cloud
+    credentials.
     """
 
     def ensure_account_credentials(self) -> None:
-        """Ensure the host GKE cluster's context is available for kubectl/helm.
+        """Ensure the host cluster's context is available for kubectl/helm.
 
-        If ``VCLUSTER_HOST_CLUSTER`` is set and a project is resolvable from
-        ``GCP_PROJECT_ID``, runs ``gcloud container clusters get-credentials``
-        for the host cluster so its context exists in kubeconfig. Otherwise a
-        no-op: assumes the host context is already present in kubeconfig.
+        Reads ``VCLUSTER_HOST_CLOUD`` (default ``gke``) to decide how. On
+        ``gke``, if ``VCLUSTER_HOST_CLUSTER`` is set and a project is
+        resolvable from ``GCP_PROJECT_ID``, runs ``gcloud container clusters
+        get-credentials`` for the host cluster so its context exists in
+        kubeconfig; otherwise a no-op, assuming the host context is already
+        present in kubeconfig. On ``eks``/``aks`` this is always a no-op for
+        now: host credential automation (``aws eks update-kubeconfig`` /
+        ``az aks get-credentials``) is not yet implemented, so the host
+        context is assumed to already be present in kubeconfig.
 
         Raises:
-            ConfigError: If ``VCLUSTER_HOST_CLUSTER`` is set but no location is
-                resolvable from ``VCLUSTER_HOST_LOCATION`` or ``GCP_LOCATION``.
+            ConfigError: If ``VCLUSTER_HOST_CLUSTER`` is set on a ``gke`` host
+                but no location is resolvable from ``VCLUSTER_HOST_LOCATION``
+                or ``GCP_LOCATION``.
         """
+        host_cloud = get_env("VCLUSTER_HOST_CLOUD") or "gke"
+        if host_cloud != "gke":
+            _log.debug(
+                "vcluster provider: host_cloud=%s, assuming host cluster credentials "
+                "are already present (no automation yet for eks/aks)",
+                host_cloud,
+            )
+            return
+
         host_cluster = get_env("VCLUSTER_HOST_CLUSTER")
         project = get_env("GCP_PROJECT_ID")
         if not host_cluster or not project:
@@ -112,14 +128,15 @@ class VclusterProvider(Provider):
 
         Returns:
             A new mapping with ``project_id``, ``cluster_name``, ``location``,
-            ``host_cluster_name``, ``host_context``, and ``kubeconfig_path``
-            filled in where not already set.
+            ``host_cloud``, ``host_cluster_name``, ``host_context``, and
+            ``kubeconfig_path`` filled in where not already set.
         """
         variables = custom_variables.copy()
         variables.setdefault("infra_provider", "vcluster")
         variables.setdefault("project_id", ctx.project_id)
         variables.setdefault("cluster_name", ctx.cluster_name)
         variables.setdefault("location", ctx.location)
+        variables.setdefault("host_cloud", get_env("VCLUSTER_HOST_CLOUD") or "gke")
         variables.setdefault("host_cluster_name", get_env("VCLUSTER_HOST_CLUSTER") or "")
         host_context = get_env("VCLUSTER_HOST_CONTEXT")
         if host_context:

--- a/docs/components/infra.md
+++ b/docs/components/infra.md
@@ -30,6 +30,7 @@ A cloud provider supplies credentials and Terraform variable defaults for a stac
 | --- | --- | --- |
 | `GcpProvider` | `gcp` | GKE clusters on Google Cloud |
 | `KindProvider` | `kind` | Local KinD clusters (no cloud identity) |
+| `VclusterProvider` | `vcluster` | loft-sh vcluster virtual clusters inside an existing GKE host cluster |
 
 Each implements the `Provider` interface (`devops_bench/providers/base.py`):
 
@@ -50,14 +51,61 @@ The env var outranks the config key so a task can pin a default `provider:` whil
 > [!IMPORTANT]
 > There is no default cloud. Any stack that does not deduce to `kind` — including every absolute or external path — **must** name its provider explicitly via `provider:` or `INFRA_PROVIDER`, or `_select_provider` raises a `ConfigError`. Nothing falls back to `gcp`, so a new provider never silently inherits another's defaults. An unknown provider name is likewise a configuration error.
 
+## vcluster: fast virtual clusters on a GKE host
+
+`vcluster` (loft-sh, Helm chart `0.36.1`) runs a virtual Kubernetes control plane as a
+workload inside an existing GKE Autopilot host cluster, instead of provisioning a new
+GKE cluster per run. Provisioning takes roughly 2-3.5 minutes versus the 10-20 minutes
+a real GKE cluster takes, since the host cluster's nodes and networking already exist.
+
+**When to use it:** tasks that only need workload-, manifest-, or policy-level
+fidelity — deploying Kubernetes objects, evaluating admission policies, exercising
+controllers and operators, or anything that just needs a real API server to talk to.
+
+**When not to use it:** tasks that depend on node-level fidelity that a virtual
+cluster can't provide — real node pools and machine types, GKE Workload Identity,
+DaemonSets that need to run on real nodes, or anything that inspects the underlying
+node OS or GKE-specific node behavior. Use `gcp` for those.
+
+**Required environment:**
+
+| Variable | Effect |
+| --- | --- |
+| `VCLUSTER_HOST_CLUSTER` | Name of the host GKE cluster the vcluster runs inside. If set (with `GCP_PROJECT_ID` resolvable), `ensure_account_credentials()` runs `gcloud container clusters get-credentials` for the host cluster. If unset, the host context is assumed to already be in kubeconfig. |
+| `VCLUSTER_HOST_CONTEXT` | Explicit kube context of the host cluster. Overrides the default `gke_<project>_<location>_<host_cluster_name>` naming. |
+| `GCP_PROJECT_ID` | GCP project of the host cluster. |
+| `GCP_LOCATION` / `VCLUSTER_HOST_LOCATION` | Region of the host cluster. |
+
+A task example:
+
+```yaml
+infrastructure:
+  deployer: "tofu"
+  stack: "prebuilt/vcluster"
+  provider: "vcluster"
+  teardown: true
+```
+
+**Teardown:** the vcluster's Kubernetes namespace is managed directly by OpenTofu
+(not via Helm's `create_namespace`), so `tofu destroy` deletes the namespace and, with
+it, the vcluster StatefulSet's PVC. That means a torn-down run leaves no state behind
+on the host cluster; a plain `helm uninstall` would leave the PVC around and let a
+re-created vcluster resume stale state.
+
 ## What the Terraform provisions
 
 The OpenTofu stacks live under `tf/`:
 
-- `tf/modules/` — reusable building blocks: `cluster/gke`, `cluster/kind`, and `bastion`.
-- `tf/prebuilt/<stack>/` — standard, ready-to-use stacks, currently `kind` (a local
-  cluster for offline / no-cloud runs). Task-specific stacks build on the modules and
-  ship alongside the tasks that provision them.
+- `tf/modules/` — reusable building blocks: `cluster/gke`, `cluster/kind`,
+  `cluster/vcluster`, and `bastion`.
+- `tf/prebuilt/<stack>/` — standard, ready-to-use stacks: `kind` (a local cluster for
+  offline / no-cloud runs), `vcluster` (a virtual cluster on an existing GKE host), and
+  `minimal` (a provider-agnostic stack that dispatches through `tf/modules/cluster` and
+  flips between `gcp`, `kind`, and `vcluster` via the `infra_provider` variable, which
+  the harness sets from `INFRA_PROVIDER` or a task's `provider:` key; it is named
+  `minimal`, not `minimum`, to avoid colliding with downstream stacks that use that
+  name). Task-specific stacks build on the modules and ship alongside the tasks that
+  provision them.
 
 Every stack root that `TFDeployer` drives must output `cluster_name` and `cluster_location` — that's the contract the deployer reads back.
 
@@ -66,6 +114,7 @@ Every stack root that `TFDeployer` drives must output `cluster_name` and `cluste
 - Always: the `tofu` binary on `PATH`.
 - For GCP stacks: `gcloud`, application-default credentials (ADC), and a project with the GKE and Artifact Registry APIs enabled.
 - For KinD stacks: Docker and the `kind` binary.
+- For vcluster stacks: `gcloud`, `kubectl`, and `helm` on `PATH`, plus an existing GKE host cluster reachable via kubeconfig (`VCLUSTER_HOST_CLUSTER` or `VCLUSTER_HOST_CONTEXT`).
 
 ## Configuring infra for an eval
 
@@ -75,7 +124,7 @@ Infrastructure is declared in the `infrastructure:` block of a task's `task.yaml
 | --- | --- |
 | `deployer` | `tofu` or `noop`. |
 | `stack` | Stack name under `tf/` (e.g. `prebuilt/kind`) or an absolute path. |
-| `provider` | Optional. `gcp` or `kind`. Omit to let it be deduced (in-repo stacks only). |
+| `provider` | Optional. `gcp`, `kind`, or `vcluster`. Omit to let it be deduced (in-repo stacks only). |
 | `teardown` | Whether to destroy infra after the run. Defaults to `true`. |
 | `variables` | A map passed straight to `tofu` as `-var key=value` flags. |
 
@@ -99,7 +148,7 @@ infrastructure:
   deployer: "noop"
 ```
 
-The provider fills in sensible defaults for whatever you leave out. For GCP that means `project_id`, `cluster_name`, and `location` (plus `namespace` when `NAMESPACE` is set); for KinD it means `cluster_name`, `location` (`local`), and `kubeconfig_path`. Anything you put in `variables` always wins over the defaults.
+The provider fills in sensible defaults for whatever you leave out. For GCP that means `project_id`, `cluster_name`, and `location` (plus `namespace` when `NAMESPACE` is set); for KinD it means `cluster_name`, `location` (`local`), and `kubeconfig_path`; for vcluster it means `project_id`, `cluster_name`, `location`, `host_cluster_name`, `host_context`, and `kubeconfig_path`. Anything you put in `variables` always wins over the defaults.
 
 **Environment variables that affect infra:**
 
@@ -111,6 +160,9 @@ The provider fills in sensible defaults for whatever you leave out. For GCP that
 | `GCP_LOCATION` | Default region/zone (falls back to `us-central1-a`). |
 | `NAMESPACE` | Passed through to GCP stacks as the `namespace` variable. |
 | `KUBECONFIG` | Kubeconfig path used by KinD and by no-infra runs. |
+| `VCLUSTER_HOST_CLUSTER` | Name of the host GKE cluster a vcluster runs inside; also used to fetch host credentials via `gcloud`. |
+| `VCLUSTER_HOST_CONTEXT` | Explicit kube context of the host GKE cluster, overriding the derived `gke_<project>_<location>_<host_cluster_name>` name. |
+| `VCLUSTER_HOST_LOCATION` | Region of the host GKE cluster (falls back to `GCP_LOCATION`). |
 
 The `--project` and `--cluster` CLI flags supply the project and cluster name for a run, feeding the same defaults the providers resolve from.
 

--- a/docs/components/infra.md
+++ b/docs/components/infra.md
@@ -30,7 +30,7 @@ A cloud provider supplies credentials and Terraform variable defaults for a stac
 | --- | --- | --- |
 | `GcpProvider` | `gcp` | GKE clusters on Google Cloud |
 | `KindProvider` | `kind` | Local KinD clusters (no cloud identity) |
-| `VclusterProvider` | `vcluster` | loft-sh vcluster virtual clusters inside an existing GKE host cluster |
+| `VclusterProvider` | `vcluster` | loft-sh vcluster virtual clusters inside an existing host cluster (gke/eks/aks) |
 
 Each implements the `Provider` interface (`devops_bench/providers/base.py`):
 
@@ -51,12 +51,18 @@ The env var outranks the config key so a task can pin a default `provider:` whil
 > [!IMPORTANT]
 > There is no default cloud. Any stack that does not deduce to `kind` — including every absolute or external path — **must** name its provider explicitly via `provider:` or `INFRA_PROVIDER`, or `_select_provider` raises a `ConfigError`. Nothing falls back to `gcp`, so a new provider never silently inherits another's defaults. An unknown provider name is likewise a configuration error.
 
-## vcluster: fast virtual clusters on a GKE host
+## vcluster: fast virtual clusters on a host cluster
 
 `vcluster` (loft-sh, Helm chart `0.36.1`) runs a virtual Kubernetes control plane as a
-workload inside an existing GKE Autopilot host cluster, instead of provisioning a new
-GKE cluster per run. Provisioning takes roughly 2-3.5 minutes versus the 10-20 minutes
-a real GKE cluster takes, since the host cluster's nodes and networking already exist.
+workload inside an existing host cluster, instead of provisioning a new cluster per
+run. Provisioning takes roughly 2-3.5 minutes versus the 10-20 minutes a real GKE
+cluster takes, since the host cluster's nodes and networking already exist. The module
+that provisions it is host-cloud-agnostic: it pre-creates a plain Kubernetes
+`LoadBalancer` Service in front of the vcluster syncer pods and reads back whatever
+external address the host cloud hands out (an IP on GKE and AKS, a hostname on EKS's
+NLBs) before rendering the Helm values, so the proxy cert SANs and the exported
+kubeconfig server always match the real address. There is no cloud-specific resource
+in the module anymore.
 
 **When to use it:** tasks that only need workload-, manifest-, or policy-level
 fidelity — deploying Kubernetes objects, evaluating admission policies, exercising
@@ -65,16 +71,17 @@ controllers and operators, or anything that just needs a real API server to talk
 **When not to use it:** tasks that depend on node-level fidelity that a virtual
 cluster can't provide — real node pools and machine types, GKE Workload Identity,
 DaemonSets that need to run on real nodes, or anything that inspects the underlying
-node OS or GKE-specific node behavior. Use `gcp` for those.
+node OS or cloud-specific node behavior. Use `gcp` for those.
 
 **Required environment:**
 
 | Variable | Effect |
 | --- | --- |
-| `VCLUSTER_HOST_CLUSTER` | Name of the host GKE cluster the vcluster runs inside. If set (with `GCP_PROJECT_ID` resolvable), `ensure_account_credentials()` runs `gcloud container clusters get-credentials` for the host cluster. If unset, the host context is assumed to already be in kubeconfig. |
-| `VCLUSTER_HOST_CONTEXT` | Explicit kube context of the host cluster. Overrides the default `gke_<project>_<location>_<host_cluster_name>` naming. |
-| `GCP_PROJECT_ID` | GCP project of the host cluster. |
-| `GCP_LOCATION` / `VCLUSTER_HOST_LOCATION` | Region of the host cluster. |
+| `VCLUSTER_HOST_CLOUD` | Cloud the host cluster runs on: `gke` (default), `eks`, or `aks`. Passed through to the `host_cloud` OpenTofu variable. Only `gke` is implemented end to end today; see "EKS/AKS hosts" below. |
+| `VCLUSTER_HOST_CLUSTER` | Name of the host cluster the vcluster runs inside. On `gke`, if set (with `GCP_PROJECT_ID` resolvable), `ensure_account_credentials()` runs `gcloud container clusters get-credentials` for the host cluster. If unset, the host context is assumed to already be in kubeconfig. |
+| `VCLUSTER_HOST_CONTEXT` | Explicit kube context of the host cluster. On `gke`, overrides the default `gke_<project>_<location>_<host_cluster_name>` naming. Required on `eks`/`aks`, since there is no equivalent naming convention to derive it from. |
+| `GCP_PROJECT_ID` | GCP project of the host cluster (`gke` only). |
+| `GCP_LOCATION` / `VCLUSTER_HOST_LOCATION` | Region of the host cluster (`gke` only). |
 
 A task example:
 
@@ -88,9 +95,20 @@ infrastructure:
 
 **Teardown:** the vcluster's Kubernetes namespace is managed directly by OpenTofu
 (not via Helm's `create_namespace`), so `tofu destroy` deletes the namespace and, with
-it, the vcluster StatefulSet's PVC. That means a torn-down run leaves no state behind
-on the host cluster; a plain `helm uninstall` would leave the PVC around and let a
-re-created vcluster resume stale state.
+it, the vcluster StatefulSet's PVC and the pre-created LoadBalancer Service. That means
+a torn-down run leaves no state behind on the host cluster; a plain `helm uninstall`
+would leave the PVC around and let a re-created vcluster resume stale state.
+
+**EKS/AKS hosts:** vcluster itself is supported by loft-sh on any conformant
+Kubernetes cluster, including EKS and AKS, and the `tf/modules/cluster/vcluster`
+module has no GCP-specific resources left, so nothing in the module needs to change to
+run on those hosts. What's missing is on our side: `ensure_account_credentials()` only
+knows how to fetch GKE credentials today (`gcloud container clusters
+get-credentials`); equivalent `aws eks update-kubeconfig` / `az aks get-credentials`
+support hasn't been added yet, so `VCLUSTER_HOST_CONTEXT` must point at an
+already-configured kubeconfig entry when `VCLUSTER_HOST_CLOUD` is `eks` or `aks`. Those
+hosts also haven't been exercised against real EKS/AKS clusters in this repo, so treat
+them as untested until someone runs it.
 
 ## What the Terraform provisions
 
@@ -99,7 +117,7 @@ The OpenTofu stacks live under `tf/`:
 - `tf/modules/` — reusable building blocks: `cluster/gke`, `cluster/kind`,
   `cluster/vcluster`, and `bastion`.
 - `tf/prebuilt/<stack>/` — standard, ready-to-use stacks: `kind` (a local cluster for
-  offline / no-cloud runs), `vcluster` (a virtual cluster on an existing GKE host), and
+  offline / no-cloud runs), `vcluster` (a virtual cluster on an existing host cluster), and
   `minimal` (a provider-agnostic stack that dispatches through `tf/modules/cluster` and
   flips between `gcp`, `kind`, and `vcluster` via the `infra_provider` variable, which
   the harness sets from `INFRA_PROVIDER` or a task's `provider:` key; it is named
@@ -114,7 +132,7 @@ Every stack root that `TFDeployer` drives must output `cluster_name` and `cluste
 - Always: the `tofu` binary on `PATH`.
 - For GCP stacks: `gcloud`, application-default credentials (ADC), and a project with the GKE and Artifact Registry APIs enabled.
 - For KinD stacks: Docker and the `kind` binary.
-- For vcluster stacks: `gcloud`, `kubectl`, and `helm` on `PATH`, plus an existing GKE host cluster reachable via kubeconfig (`VCLUSTER_HOST_CLUSTER` or `VCLUSTER_HOST_CONTEXT`).
+- For vcluster stacks: `kubectl` and `helm` on `PATH`, plus an existing host cluster reachable via kubeconfig (`VCLUSTER_HOST_CLUSTER` or `VCLUSTER_HOST_CONTEXT`). `gcloud` is only needed when `VCLUSTER_HOST_CLOUD` is `gke` (the default).
 
 ## Configuring infra for an eval
 
@@ -148,7 +166,7 @@ infrastructure:
   deployer: "noop"
 ```
 
-The provider fills in sensible defaults for whatever you leave out. For GCP that means `project_id`, `cluster_name`, and `location` (plus `namespace` when `NAMESPACE` is set); for KinD it means `cluster_name`, `location` (`local`), and `kubeconfig_path`; for vcluster it means `project_id`, `cluster_name`, `location`, `host_cluster_name`, `host_context`, and `kubeconfig_path`. Anything you put in `variables` always wins over the defaults.
+The provider fills in sensible defaults for whatever you leave out. For GCP that means `project_id`, `cluster_name`, and `location` (plus `namespace` when `NAMESPACE` is set); for KinD it means `cluster_name`, `location` (`local`), and `kubeconfig_path`; for vcluster it means `project_id`, `cluster_name`, `location`, `host_cloud`, `host_cluster_name`, `host_context`, and `kubeconfig_path`. Anything you put in `variables` always wins over the defaults.
 
 **Environment variables that affect infra:**
 
@@ -160,9 +178,10 @@ The provider fills in sensible defaults for whatever you leave out. For GCP that
 | `GCP_LOCATION` | Default region/zone (falls back to `us-central1-a`). |
 | `NAMESPACE` | Passed through to GCP stacks as the `namespace` variable. |
 | `KUBECONFIG` | Kubeconfig path used by KinD and by no-infra runs. |
-| `VCLUSTER_HOST_CLUSTER` | Name of the host GKE cluster a vcluster runs inside; also used to fetch host credentials via `gcloud`. |
-| `VCLUSTER_HOST_CONTEXT` | Explicit kube context of the host GKE cluster, overriding the derived `gke_<project>_<location>_<host_cluster_name>` name. |
-| `VCLUSTER_HOST_LOCATION` | Region of the host GKE cluster (falls back to `GCP_LOCATION`). |
+| `VCLUSTER_HOST_CLOUD` | Cloud the vcluster host cluster runs on: `gke` (default), `eks`, or `aks`. |
+| `VCLUSTER_HOST_CLUSTER` | Name of the host cluster a vcluster runs inside; on `gke`, also used to fetch host credentials via `gcloud`. |
+| `VCLUSTER_HOST_CONTEXT` | Explicit kube context of the host cluster, overriding the derived `gke_<project>_<location>_<host_cluster_name>` name (`gke` only). Required when `VCLUSTER_HOST_CLOUD` is `eks` or `aks`. |
+| `VCLUSTER_HOST_LOCATION` | Region of the host GKE cluster (falls back to `GCP_LOCATION`, `gke` only). |
 
 The `--project` and `--cluster` CLI flags supply the project and cluster name for a run, feeding the same defaults the providers resolve from.
 

--- a/tests/unit/providers/test_vcluster.py
+++ b/tests/unit/providers/test_vcluster.py
@@ -1,0 +1,119 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the vcluster provider."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from devops_bench.providers import PROVIDERS, ResolveContext
+from devops_bench.providers.vcluster import VclusterProvider
+
+
+@pytest.fixture
+def ctx() -> ResolveContext:
+    return ResolveContext(
+        stack="prebuilt/vcluster",
+        project_id="test-project",
+        cluster_name="test-cluster",
+        location="us-central1",
+    )
+
+
+def test_registry_populated() -> None:
+    assert PROVIDERS.get("vcluster") is VclusterProvider
+    assert "vcluster" in PROVIDERS
+
+
+def test_resolve_variables_fills_defaults(
+    ctx: ResolveContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("VCLUSTER_HOST_CLUSTER", raising=False)
+    monkeypatch.delenv("VCLUSTER_HOST_CONTEXT", raising=False)
+    variables = VclusterProvider().resolve_variables(ctx, {})
+    assert variables["infra_provider"] == "vcluster"
+    assert variables["project_id"] == "test-project"
+    assert variables["cluster_name"] == "test-cluster"
+    assert variables["location"] == "us-central1"
+    assert variables["host_cluster_name"] == ""
+    assert "host_context" not in variables
+    expected_kubeconfig = str(Path("~/.kube").expanduser() / "vcluster-test-cluster.yaml")
+    assert variables["kubeconfig_path"] == expected_kubeconfig
+
+
+def test_resolve_variables_custom_precedence(ctx: ResolveContext) -> None:
+    variables = VclusterProvider().resolve_variables(
+        ctx, {"cluster_name": "override", "kubeconfig_path": "/tmp/custom.yaml"}
+    )
+    assert variables["cluster_name"] == "override"
+    assert variables["kubeconfig_path"] == "/tmp/custom.yaml"
+
+
+def test_resolve_variables_host_env(ctx: ResolveContext, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VCLUSTER_HOST_CLUSTER", "host-cluster")
+    monkeypatch.setenv("VCLUSTER_HOST_CONTEXT", "my-context")
+    variables = VclusterProvider().resolve_variables(ctx, {})
+    assert variables["host_cluster_name"] == "host-cluster"
+    assert variables["host_context"] == "my-context"
+
+
+def test_ensure_cluster_credentials_returns_cluster_info(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch("devops_bench.providers.vcluster.run")
+    info = VclusterProvider().ensure_cluster_credentials(
+        "test-cluster",
+        "us-central1",
+        {"project_id": "test-project", "kubeconfig_path": "/tmp/vcluster-test-cluster.yaml"},
+    )
+    assert info.name == "test-cluster"
+    assert info.location == "us-central1"
+    assert info.project == "test-project"
+    assert info.kubeconfig_path == "/tmp/vcluster-test-cluster.yaml"
+    mock_run.assert_not_called()
+
+
+def test_ensure_account_credentials_noop_when_env_unset(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("VCLUSTER_HOST_CLUSTER", raising=False)
+    mock_run = mocker.patch("devops_bench.providers.vcluster.run")
+    VclusterProvider().ensure_account_credentials()
+    mock_run.assert_not_called()
+
+
+def test_ensure_account_credentials_runs_gcloud_when_host_cluster_set(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("VCLUSTER_HOST_CLUSTER", "host-cluster")
+    monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
+    monkeypatch.setenv("VCLUSTER_HOST_LOCATION", "us-central1")
+    mock_run = mocker.patch("devops_bench.providers.vcluster.run")
+    VclusterProvider().ensure_account_credentials()
+    mock_run.assert_called_once_with(
+        [
+            "gcloud",
+            "container",
+            "clusters",
+            "get-credentials",
+            "host-cluster",
+            "--location",
+            "us-central1",
+            "--project",
+            "test-project",
+        ],
+        capture=False,
+    )

--- a/tests/unit/providers/test_vcluster.py
+++ b/tests/unit/providers/test_vcluster.py
@@ -45,15 +45,25 @@ def test_resolve_variables_fills_defaults(
 ) -> None:
     monkeypatch.delenv("VCLUSTER_HOST_CLUSTER", raising=False)
     monkeypatch.delenv("VCLUSTER_HOST_CONTEXT", raising=False)
+    monkeypatch.delenv("VCLUSTER_HOST_CLOUD", raising=False)
     variables = VclusterProvider().resolve_variables(ctx, {})
     assert variables["infra_provider"] == "vcluster"
     assert variables["project_id"] == "test-project"
     assert variables["cluster_name"] == "test-cluster"
     assert variables["location"] == "us-central1"
+    assert variables["host_cloud"] == "gke"
     assert variables["host_cluster_name"] == ""
     assert "host_context" not in variables
     expected_kubeconfig = str(Path("~/.kube").expanduser() / "vcluster-test-cluster.yaml")
     assert variables["kubeconfig_path"] == expected_kubeconfig
+
+
+def test_resolve_variables_host_cloud_env(
+    ctx: ResolveContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("VCLUSTER_HOST_CLOUD", "eks")
+    variables = VclusterProvider().resolve_variables(ctx, {})
+    assert variables["host_cloud"] == "eks"
 
 
 def test_resolve_variables_custom_precedence(ctx: ResolveContext) -> None:
@@ -101,6 +111,7 @@ def test_ensure_account_credentials_runs_gcloud_when_host_cluster_set(
     monkeypatch.setenv("VCLUSTER_HOST_CLUSTER", "host-cluster")
     monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
     monkeypatch.setenv("VCLUSTER_HOST_LOCATION", "us-central1")
+    monkeypatch.delenv("VCLUSTER_HOST_CLOUD", raising=False)
     mock_run = mocker.patch("devops_bench.providers.vcluster.run")
     VclusterProvider().ensure_account_credentials()
     mock_run.assert_called_once_with(
@@ -117,3 +128,15 @@ def test_ensure_account_credentials_runs_gcloud_when_host_cluster_set(
         ],
         capture=False,
     )
+
+
+def test_ensure_account_credentials_noop_for_eks_host_cloud(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("VCLUSTER_HOST_CLOUD", "eks")
+    monkeypatch.setenv("VCLUSTER_HOST_CLUSTER", "host-cluster")
+    monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
+    monkeypatch.setenv("VCLUSTER_HOST_LOCATION", "us-central1")
+    mock_run = mocker.patch("devops_bench.providers.vcluster.run")
+    VclusterProvider().ensure_account_credentials()
+    mock_run.assert_not_called()

--- a/tf/modules/cluster/main.tf
+++ b/tf/modules/cluster/main.tf
@@ -13,9 +13,15 @@
 # limitations under the License.
 
 # This dispatch module instantiates only one concrete cluster sub-module and
-# declares no concrete-provider requirements of its own: each sub-module owns
-# its provider (google in ./gke, tehcyx/kind in ./kind), so a KinD-only run does
-# not pull in the GCP provider plugin.
+# declares no concrete-provider requirements or provider blocks of its own:
+# each sub-module only declares required_providers (google in ./gke,
+# tehcyx/kind in ./kind, google/helm/kubernetes in ./vcluster) and inherits
+# the actual provider configuration implicitly from whatever root caller
+# instantiates this module, so a KinD-only run does not pull in the GCP
+# provider plugin. A module invoked with `count`, as these are, cannot itself
+# declare `provider` blocks, so a caller that dispatches to "vcluster" must
+# configure the default helm/kubernetes providers itself, pointed at the host
+# cluster (see tf/prebuilt/vcluster for an example).
 
 module "gke" {
   source                   = "./gke"
@@ -42,5 +48,18 @@ module "kind" {
   project_id      = var.project_id
   location        = var.location != "" ? var.location : "local"
   node_count      = var.node_count
+}
+
+module "vcluster" {
+  source                 = "./vcluster"
+  count                  = var.infra_provider == "vcluster" ? 1 : 0
+  cluster_name           = var.cluster_name
+  location               = var.location != "" ? var.location : "us-central1"
+  project_id             = var.project_id
+  host_context           = var.host_context
+  host_cluster_name      = var.host_cluster_name
+  kubeconfig_path_host   = var.kubeconfig_path_host
+  kubeconfig_path        = var.kubeconfig_path
+  vcluster_chart_version = var.vcluster_chart_version
 }
 

--- a/tf/modules/cluster/main.tf
+++ b/tf/modules/cluster/main.tf
@@ -15,7 +15,7 @@
 # This dispatch module instantiates only one concrete cluster sub-module and
 # declares no concrete-provider requirements or provider blocks of its own:
 # each sub-module only declares required_providers (google in ./gke,
-# tehcyx/kind in ./kind, google/helm/kubernetes in ./vcluster) and inherits
+# tehcyx/kind in ./kind, helm/kubernetes in ./vcluster) and inherits
 # the actual provider configuration implicitly from whatever root caller
 # instantiates this module, so a KinD-only run does not pull in the GCP
 # provider plugin. A module invoked with `count`, as these are, cannot itself
@@ -56,6 +56,7 @@ module "vcluster" {
   cluster_name           = var.cluster_name
   location               = var.location != "" ? var.location : "us-central1"
   project_id             = var.project_id
+  host_cloud             = var.host_cloud
   host_context           = var.host_context
   host_cluster_name      = var.host_cluster_name
   kubeconfig_path_host   = var.kubeconfig_path_host

--- a/tf/modules/cluster/outputs.tf
+++ b/tf/modules/cluster/outputs.tf
@@ -13,22 +13,34 @@
 # limitations under the License.
 
 output "cluster_name" {
-  value       = var.infra_provider == "gcp" ? try(module.gke[0].cluster_name, "") : try(module.kind[0].cluster_name, "")
+  value = (
+    var.infra_provider == "gcp" ? try(module.gke[0].cluster_name, "") :
+    var.infra_provider == "vcluster" ? try(module.vcluster[0].cluster_name, "") :
+    try(module.kind[0].cluster_name, "")
+  )
   description = "The finalized name of the created cluster"
 }
 
 output "location" {
-  value       = var.infra_provider == "gcp" ? try(module.gke[0].cluster_location, "") : try(module.kind[0].cluster_location, "")
+  value = (
+    var.infra_provider == "gcp" ? try(module.gke[0].cluster_location, "") :
+    var.infra_provider == "vcluster" ? try(module.vcluster[0].cluster_location, "") :
+    try(module.kind[0].cluster_location, "")
+  )
   description = "The region/zone or 'local'"
 }
 
 output "endpoint" {
-  value       = var.infra_provider == "gcp" ? try(module.gke[0].endpoint, "") : try(module.kind[0].endpoint, "")
+  value = (
+    var.infra_provider == "gcp" ? try(module.gke[0].endpoint, "") :
+    var.infra_provider == "vcluster" ? try(module.vcluster[0].endpoint, "") :
+    try(module.kind[0].endpoint, "")
+  )
   description = "Cluster control plane endpoint"
 }
 
 output "cluster_ca_certificate" {
-  value       = var.infra_provider == "gcp" ? try(module.gke[0].cluster_ca_certificate, "") : try(module.kind[0].cluster_ca_certificate, "")
+  value       = var.infra_provider == "gcp" ? try(module.gke[0].cluster_ca_certificate, "") : var.infra_provider == "kind" ? try(module.kind[0].cluster_ca_certificate, "") : ""
   description = "Cluster CA certificate"
 }
 
@@ -43,7 +55,10 @@ output "client_key" {
 }
 
 output "kubeconfig_path" {
-  value       = var.infra_provider == "kind" ? try(module.kind[0].kubeconfig_path, "") : ""
+  value = (
+    var.infra_provider == "kind" ? try(module.kind[0].kubeconfig_path, "") :
+    var.infra_provider == "vcluster" ? try(module.vcluster[0].kubeconfig_path, "") :
+    ""
+  )
   description = "Local path to the kubeconfig file"
 }
-

--- a/tf/modules/cluster/variables.tf
+++ b/tf/modules/cluster/variables.tf
@@ -104,15 +104,26 @@ variable "node_image" {
   default     = "kindest/node:v1.29.2"
 }
 
+variable "host_cloud" {
+  type        = string
+  description = "Cloud the vcluster host cluster runs on: 'gke', 'eks', or 'aks' (vcluster-only). Only 'gke' is currently implemented end-to-end; 'eks'/'aks' require host_context to be set explicitly"
+  default     = "gke"
+
+  validation {
+    condition     = contains(["gke", "eks", "aks"], var.host_cloud)
+    error_message = "host_cloud must be one of: 'gke', 'eks', 'aks'."
+  }
+}
+
 variable "host_context" {
   type        = string
-  description = "Kube context of the host GKE cluster the virtual cluster runs inside (vcluster-only). Defaults to 'gke_<project_id>_<location>_<host_cluster_name>' when empty"
+  description = "Kube context of the host cluster the virtual cluster runs inside (vcluster-only). On GKE, defaults to 'gke_<project_id>_<location>_<host_cluster_name>' when empty; required for eks/aks host_cloud"
   default     = ""
 }
 
 variable "host_cluster_name" {
   type        = string
-  description = "Name of the host GKE cluster the virtual cluster runs inside (vcluster-only); used to derive host_context when host_context is not set"
+  description = "Name of the host cluster the virtual cluster runs inside (vcluster-only); used to derive host_context on GKE hosts when host_context is not set"
   default     = ""
 }
 

--- a/tf/modules/cluster/vcluster/main.tf
+++ b/tf/modules/cluster/vcluster/main.tf
@@ -14,10 +14,6 @@
 
 terraform {
   required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = ">= 5.0.0"
-    }
     helm = {
       source  = "hashicorp/helm"
       version = "~> 3.0"
@@ -30,25 +26,28 @@ terraform {
 }
 
 locals {
-  host_context = var.host_context != "" ? var.host_context : "gke_${var.project_id}_${var.location}_${var.host_cluster_name}"
+  host_context = var.host_context != "" ? var.host_context : (
+    var.host_cloud == "gke" ? "gke_${var.project_id}_${var.location}_${var.host_cluster_name}" : ""
+  )
+}
+
+# EKS/AKS host clusters have no reliable way to derive a kube context name
+# the way GKE's `gke_<project>_<location>_<cluster>` convention allows, so
+# host_context must be set explicitly whenever host_cloud isn't "gke".
+check "host_context_required_for_non_gke" {
+  assert {
+    condition     = var.host_cloud == "gke" || var.host_context != ""
+    error_message = "set host_context explicitly for eks/aks hosts"
+  }
 }
 
 # No local `provider "helm"` / `provider "kubernetes"` blocks here: a module
 # that declares its own provider configurations cannot be called with
 # `count`, which the dispatch module (tf/modules/cluster) needs to select
 # between gke/kind/vcluster. Instead this module only declares
-# required_providers and relies on the default (unaliased) helm/kubernetes/
-# google provider configurations passed down implicitly from its root
-# caller (e.g. tf/prebuilt/vcluster), which points them at the host cluster.
-
-# Reserving the IP up front lets it be baked into the proxy cert SANs and the
-# exported kubeconfig before the vcluster Service exists, avoiding a
-# TLS-SAN chicken-and-egg problem between the Service's LoadBalancer IP and
-# the certificate the control plane serves.
-resource "google_compute_address" "vcluster" {
-  name   = "${var.cluster_name}-ip"
-  region = var.location
-}
+# required_providers and relies on the default (unaliased) helm/kubernetes
+# provider configurations passed down implicitly from its root caller (e.g.
+# tf/prebuilt/vcluster), which points them at the host cluster.
 
 # Managed explicitly (not via helm's create_namespace) so `tofu destroy`
 # deletes the namespace, and with it the vcluster StatefulSet's PVC. A plain
@@ -58,6 +57,48 @@ resource "kubernetes_namespace" "vcluster" {
   metadata {
     name = var.cluster_name
   }
+}
+
+# Pre-created LoadBalancer Service fronting the vcluster syncer pods
+# (selector verified against the loft-sh/vcluster chart's own StatefulSet
+# pod template and Service selector: `app: vcluster`, `release: <release
+# name>`). Creating it up front lets its external address be baked into the
+# proxy cert SANs and the exported kubeconfig before the helm release
+# renders, avoiding a TLS-SAN chicken-and-egg problem between the Service's
+# external address and the certificate the control plane serves. This
+# replaces a GCP-specific `google_compute_address` with a cloud-agnostic
+# Kubernetes resource: GKE/AKS hand back an IP, EKS NLBs hand back a
+# hostname, and local.lb_address below picks whichever is set. The chart's
+# own Service stays ClusterIP (its default); this Service just fronts the
+# same pods.
+resource "kubernetes_service_v1" "lb" {
+  metadata {
+    name      = "${var.cluster_name}-lb"
+    namespace = kubernetes_namespace.vcluster.metadata[0].name
+  }
+
+  spec {
+    type = "LoadBalancer"
+
+    selector = {
+      app     = "vcluster"
+      release = var.cluster_name
+    }
+
+    port {
+      port        = 443
+      target_port = 8443
+    }
+  }
+
+  wait_for_load_balancer = true
+}
+
+locals {
+  lb_address = coalesce(
+    try(kubernetes_service_v1.lb.status[0].load_balancer[0].ingress[0].ip, ""),
+    try(kubernetes_service_v1.lb.status[0].load_balancer[0].ingress[0].hostname, "")
+  )
 }
 
 resource "helm_release" "vcluster" {
@@ -73,7 +114,7 @@ resource "helm_release" "vcluster" {
 
   values = [
     templatefile("${path.module}/vcluster.yaml.tftpl", {
-      lb_ip = google_compute_address.vcluster.address
+      lb_address = local.lb_address
     })
   ]
 }
@@ -81,8 +122,8 @@ resource "helm_release" "vcluster" {
 # Polls for the vcluster kubeconfig secret, writes it locally, then polls the
 # vcluster API through that kubeconfig until it answers. Both steps can take
 # a while after the Helm release reports ready: the LoadBalancer Service
-# needs to program the reserved IP, and the vcluster API needs to come up
-# behind it.
+# needs to finish programming its external address, and the vcluster API
+# needs to come up behind it.
 resource "terraform_data" "kubeconfig" {
   depends_on = [helm_release.vcluster]
 

--- a/tf/modules/cluster/vcluster/main.tf
+++ b/tf/modules/cluster/vcluster/main.tf
@@ -1,0 +1,133 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}
+
+locals {
+  host_context = var.host_context != "" ? var.host_context : "gke_${var.project_id}_${var.location}_${var.host_cluster_name}"
+}
+
+# No local `provider "helm"` / `provider "kubernetes"` blocks here: a module
+# that declares its own provider configurations cannot be called with
+# `count`, which the dispatch module (tf/modules/cluster) needs to select
+# between gke/kind/vcluster. Instead this module only declares
+# required_providers and relies on the default (unaliased) helm/kubernetes/
+# google provider configurations passed down implicitly from its root
+# caller (e.g. tf/prebuilt/vcluster), which points them at the host cluster.
+
+# Reserving the IP up front lets it be baked into the proxy cert SANs and the
+# exported kubeconfig before the vcluster Service exists, avoiding a
+# TLS-SAN chicken-and-egg problem between the Service's LoadBalancer IP and
+# the certificate the control plane serves.
+resource "google_compute_address" "vcluster" {
+  name   = "${var.cluster_name}-ip"
+  region = var.location
+}
+
+# Managed explicitly (not via helm's create_namespace) so `tofu destroy`
+# deletes the namespace, and with it the vcluster StatefulSet's PVC. A plain
+# `helm uninstall` leaves the PVC behind, and a re-created vcluster resumes
+# stale state from the old PVC.
+resource "kubernetes_namespace" "vcluster" {
+  metadata {
+    name = var.cluster_name
+  }
+}
+
+resource "helm_release" "vcluster" {
+  name       = var.cluster_name
+  repository = "https://charts.loft.sh"
+  chart      = "vcluster"
+  version    = var.vcluster_chart_version
+  namespace  = kubernetes_namespace.vcluster.metadata[0].name
+
+  create_namespace = false
+  wait             = true
+  timeout          = 900
+
+  values = [
+    templatefile("${path.module}/vcluster.yaml.tftpl", {
+      lb_ip = google_compute_address.vcluster.address
+    })
+  ]
+}
+
+# Polls for the vcluster kubeconfig secret, writes it locally, then polls the
+# vcluster API through that kubeconfig until it answers. Both steps can take
+# a while after the Helm release reports ready: the LoadBalancer Service
+# needs to program the reserved IP, and the vcluster API needs to come up
+# behind it.
+resource "terraform_data" "kubeconfig" {
+  depends_on = [helm_release.vcluster]
+
+  triggers_replace = {
+    cluster_name = var.cluster_name
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -e
+
+      host_kubeconfig="${pathexpand(var.kubeconfig_path_host)}"
+      host_context="${local.host_context}"
+      namespace="${kubernetes_namespace.vcluster.metadata[0].name}"
+      secret_name="vc-${var.cluster_name}"
+      out_path="${pathexpand(var.kubeconfig_path)}"
+
+      elapsed=0
+      timeout=300
+      interval=5
+      until kubectl --kubeconfig="$host_kubeconfig" --context="$host_context" \
+        -n "$namespace" get secret "$secret_name" >/dev/null 2>&1; do
+        if [ "$elapsed" -ge "$timeout" ]; then
+          echo "Timed out after $${timeout}s waiting for secret $secret_name in namespace $namespace" >&2
+          exit 1
+        fi
+        sleep "$interval"
+        elapsed=$((elapsed + interval))
+      done
+
+      mkdir -p "$(dirname "$out_path")"
+      kubectl --kubeconfig="$host_kubeconfig" --context="$host_context" \
+        -n "$namespace" get secret "$secret_name" \
+        --template='{{.data.config}}' | base64 -d > "$out_path"
+
+      elapsed=0
+      timeout=600
+      until kubectl --kubeconfig="$out_path" get ns >/dev/null 2>&1; do
+        if [ "$elapsed" -ge "$timeout" ]; then
+          echo "Timed out after $${timeout}s waiting for the vcluster API to answer via $out_path" >&2
+          exit 1
+        fi
+        sleep "$interval"
+        elapsed=$((elapsed + interval))
+      done
+    EOT
+  }
+}

--- a/tf/modules/cluster/vcluster/outputs.tf
+++ b/tf/modules/cluster/vcluster/outputs.tf
@@ -21,7 +21,7 @@ output "cluster_location" {
 }
 
 output "endpoint" {
-  value = "https://${google_compute_address.vcluster.address}:443"
+  value = "https://${local.lb_address}:443"
 }
 
 output "kubeconfig_path" {

--- a/tf/modules/cluster/vcluster/outputs.tf
+++ b/tf/modules/cluster/vcluster/outputs.tf
@@ -12,14 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Cloud providers selecting credentials and OpenTofu variables per cloud."""
+output "cluster_name" {
+  value = var.cluster_name
+}
 
-from __future__ import annotations
+output "cluster_location" {
+  value = var.location
+}
 
-# Import for their registration side effects so the registry is populated.
-from devops_bench.providers import gcp as _gcp  # noqa: F401
-from devops_bench.providers import kind as _kind  # noqa: F401
-from devops_bench.providers import vcluster as _vcluster  # noqa: F401
-from devops_bench.providers.base import PROVIDERS, Provider, ResolveContext
+output "endpoint" {
+  value = "https://${google_compute_address.vcluster.address}:443"
+}
 
-__all__ = ["PROVIDERS", "Provider", "ResolveContext"]
+output "kubeconfig_path" {
+  value      = pathexpand(var.kubeconfig_path)
+  depends_on = [terraform_data.kubeconfig]
+}

--- a/tf/modules/cluster/vcluster/variables.tf
+++ b/tf/modules/cluster/vcluster/variables.tf
@@ -1,0 +1,57 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "cluster_name" {
+  type        = string
+  description = "Name of the virtual cluster (and its namespace on the host cluster)"
+}
+
+variable "location" {
+  type        = string
+  description = "Region of the host GKE cluster (e.g. us-central1); used for the reserved static IP"
+}
+
+variable "project_id" {
+  type        = string
+  description = "GCP project ID of the host GKE cluster"
+}
+
+variable "host_context" {
+  type        = string
+  description = "Kube context of the host GKE cluster. Defaults to 'gke_<project_id>_<location>_<host_cluster_name>' when empty"
+  default     = ""
+}
+
+variable "host_cluster_name" {
+  type        = string
+  description = "Name of the host GKE cluster; used to derive host_context when host_context is not set"
+  default     = ""
+}
+
+variable "kubeconfig_path_host" {
+  type        = string
+  description = "Path to the kubeconfig used to reach the host GKE cluster"
+  default     = "~/.kube/config"
+}
+
+variable "kubeconfig_path" {
+  type        = string
+  description = "Path to write the vcluster's own kubeconfig. Required: unlike kubeconfig_path_host, there is no safe shared default, since each vcluster must write to its own file to avoid clobbering another run's kubeconfig"
+}
+
+variable "vcluster_chart_version" {
+  type        = string
+  description = "Version of the loft-sh vcluster Helm chart to install"
+  default     = "0.36.1"
+}

--- a/tf/modules/cluster/vcluster/variables.tf
+++ b/tf/modules/cluster/vcluster/variables.tf
@@ -19,29 +19,40 @@ variable "cluster_name" {
 
 variable "location" {
   type        = string
-  description = "Region of the host GKE cluster (e.g. us-central1); used for the reserved static IP"
+  description = "Region of the host cluster (e.g. us-central1); used to derive host_context on GKE hosts"
 }
 
 variable "project_id" {
   type        = string
-  description = "GCP project ID of the host GKE cluster"
+  description = "GCP project ID of the host cluster (GKE hosts only; used to derive host_context)"
+}
+
+variable "host_cloud" {
+  type        = string
+  description = "Cloud the host cluster runs on: 'gke', 'eks', or 'aks'. Only 'gke' is currently implemented end-to-end; 'eks'/'aks' require host_context to be set explicitly"
+  default     = "gke"
+
+  validation {
+    condition     = contains(["gke", "eks", "aks"], var.host_cloud)
+    error_message = "host_cloud must be one of: 'gke', 'eks', 'aks'."
+  }
 }
 
 variable "host_context" {
   type        = string
-  description = "Kube context of the host GKE cluster. Defaults to 'gke_<project_id>_<location>_<host_cluster_name>' when empty"
+  description = "Kube context of the host cluster. On GKE, defaults to 'gke_<project_id>_<location>_<host_cluster_name>' when empty; required for eks/aks host_cloud"
   default     = ""
 }
 
 variable "host_cluster_name" {
   type        = string
-  description = "Name of the host GKE cluster; used to derive host_context when host_context is not set"
+  description = "Name of the host cluster; used to derive host_context on GKE hosts when host_context is not set"
   default     = ""
 }
 
 variable "kubeconfig_path_host" {
   type        = string
-  description = "Path to the kubeconfig used to reach the host GKE cluster"
+  description = "Path to the kubeconfig used to reach the host cluster"
   default     = "~/.kube/config"
 }
 

--- a/tf/modules/cluster/vcluster/vcluster.yaml.tftpl
+++ b/tf/modules/cluster/vcluster/vcluster.yaml.tftpl
@@ -1,0 +1,17 @@
+controlPlane:
+  proxy:
+    extraSANs:
+      - "${lb_ip}"
+  service:
+    spec:
+      type: LoadBalancer
+      loadBalancerIP: "${lb_ip}"
+  statefulSet:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+        ephemeral-storage: 2Gi
+
+exportKubeConfig:
+  server: "https://${lb_ip}:443"

--- a/tf/modules/cluster/vcluster/vcluster.yaml.tftpl
+++ b/tf/modules/cluster/vcluster/vcluster.yaml.tftpl
@@ -1,11 +1,7 @@
 controlPlane:
   proxy:
     extraSANs:
-      - "${lb_ip}"
-  service:
-    spec:
-      type: LoadBalancer
-      loadBalancerIP: "${lb_ip}"
+      - "${lb_address}"
   statefulSet:
     resources:
       requests:
@@ -14,4 +10,4 @@ controlPlane:
         ephemeral-storage: 2Gi
 
 exportKubeConfig:
-  server: "https://${lb_ip}:443"
+  server: "https://${lb_address}:443"

--- a/tf/prebuilt/minimal/main.tf
+++ b/tf/prebuilt/minimal/main.tf
@@ -42,7 +42,9 @@ terraform {
 }
 
 locals {
-  host_context = var.host_context != "" ? var.host_context : "gke_${var.project_id}_${var.location}_${var.host_cluster_name}"
+  host_context = var.host_context != "" ? var.host_context : (
+    var.host_cloud == "gke" ? "gke_${var.project_id}_${var.location}_${var.host_cluster_name}" : ""
+  )
   # Only the vcluster path talks to the host cluster through helm/kubernetes.
   # Leaving these unset for gcp/kind keeps plans from requiring the host
   # context to exist in the local kubeconfig.
@@ -84,6 +86,7 @@ module "cluster" {
   agent_service_account    = var.agent_service_account
   enable_iap_ssh           = var.enable_iap_ssh
   node_image               = var.node_image
+  host_cloud               = var.host_cloud
   host_context             = var.host_context
   host_cluster_name        = var.host_cluster_name
   vcluster_chart_version   = var.vcluster_chart_version

--- a/tf/prebuilt/minimal/main.tf
+++ b/tf/prebuilt/minimal/main.tf
@@ -1,0 +1,91 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This stack is provider-agnostic: it dispatches to tf/modules/cluster, which
+# selects the gcp, kind, or vcluster sub-module via `infra_provider`. A module
+# invoked with `count`, as those are, cannot declare its own `provider`
+# blocks, so all concrete provider configuration lives here in the root
+# (mirroring tf/prebuilt/vcluster), even though only one provider is actually
+# exercised per run.
+
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    kind = {
+      source  = "tehcyx/kind"
+      version = ">= 0.5.0"
+    }
+  }
+}
+
+locals {
+  host_context = var.host_context != "" ? var.host_context : "gke_${var.project_id}_${var.location}_${var.host_cluster_name}"
+  # Only the vcluster path talks to the host cluster through helm/kubernetes.
+  # Leaving these unset for gcp/kind keeps plans from requiring the host
+  # context to exist in the local kubeconfig.
+  is_vcluster = var.infra_provider == "vcluster"
+}
+
+provider "google" {
+  project = var.project_id != "" ? var.project_id : null
+  region  = var.location != "" ? var.location : null
+}
+
+provider "helm" {
+  kubernetes = {
+    config_path    = local.is_vcluster ? pathexpand(var.kubeconfig_path_host) : null
+    config_context = local.is_vcluster ? local.host_context : null
+  }
+}
+
+provider "kubernetes" {
+  config_path    = local.is_vcluster ? pathexpand(var.kubeconfig_path_host) : null
+  config_context = local.is_vcluster ? local.host_context : null
+}
+
+provider "kind" {}
+
+module "cluster" {
+  source                   = "../../modules/cluster"
+  infra_provider           = var.infra_provider
+  cluster_name             = var.cluster_name
+  location                 = var.location
+  node_count               = var.node_count
+  machine_type             = var.machine_type
+  gpu_type                 = var.gpu_type
+  gpu_count                = var.gpu_count
+  project_id               = var.project_id
+  kubeconfig_path          = var.kubeconfig_path
+  kubernetes_version       = var.kubernetes_version
+  enable_workload_identity = var.enable_workload_identity
+  agent_service_account    = var.agent_service_account
+  enable_iap_ssh           = var.enable_iap_ssh
+  node_image               = var.node_image
+  host_context             = var.host_context
+  host_cluster_name        = var.host_cluster_name
+  vcluster_chart_version   = var.vcluster_chart_version
+  kubeconfig_path_host     = var.kubeconfig_path_host
+}

--- a/tf/prebuilt/minimal/outputs.tf
+++ b/tf/prebuilt/minimal/outputs.tf
@@ -12,14 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Cloud providers selecting credentials and OpenTofu variables per cloud."""
+output "cluster_name" {
+  value       = module.cluster.cluster_name
+  description = "The finalized name of the created cluster"
+}
 
-from __future__ import annotations
+output "cluster_location" {
+  value       = module.cluster.location
+  description = "The region/zone or 'local'"
+}
 
-# Import for their registration side effects so the registry is populated.
-from devops_bench.providers import gcp as _gcp  # noqa: F401
-from devops_bench.providers import kind as _kind  # noqa: F401
-from devops_bench.providers import vcluster as _vcluster  # noqa: F401
-from devops_bench.providers.base import PROVIDERS, Provider, ResolveContext
+output "endpoint" {
+  value       = module.cluster.endpoint
+  description = "Cluster control plane endpoint"
+}
 
-__all__ = ["PROVIDERS", "Provider", "ResolveContext"]
+output "kubeconfig_path" {
+  value       = module.cluster.kubeconfig_path
+  description = "Local path to the kubeconfig file"
+}

--- a/tf/prebuilt/minimal/variables.tf
+++ b/tf/prebuilt/minimal/variables.tf
@@ -124,7 +124,6 @@ variable "vcluster_chart_version" {
 
 variable "kubeconfig_path_host" {
   type        = string
-  description = "Path to the kubeconfig used to reach the host GKE cluster (vcluster-only). The caller must configure its default helm/kubernetes provider against this same path/context, since a count-dispatched module cannot declare its own provider blocks"
+  description = "Path to the kubeconfig used to reach the host GKE cluster (vcluster-only). The provider blocks in this root are configured against this same path/context"
   default     = "~/.kube/config"
 }
-

--- a/tf/prebuilt/minimal/variables.tf
+++ b/tf/prebuilt/minimal/variables.tf
@@ -104,15 +104,26 @@ variable "node_image" {
   default     = "kindest/node:v1.29.2"
 }
 
+variable "host_cloud" {
+  type        = string
+  description = "Cloud the vcluster host cluster runs on: 'gke', 'eks', or 'aks' (vcluster-only). Only 'gke' is currently implemented end-to-end; 'eks'/'aks' require host_context to be set explicitly"
+  default     = "gke"
+
+  validation {
+    condition     = contains(["gke", "eks", "aks"], var.host_cloud)
+    error_message = "host_cloud must be one of: 'gke', 'eks', 'aks'."
+  }
+}
+
 variable "host_context" {
   type        = string
-  description = "Kube context of the host GKE cluster the virtual cluster runs inside (vcluster-only). Defaults to 'gke_<project_id>_<location>_<host_cluster_name>' when empty"
+  description = "Kube context of the host cluster the virtual cluster runs inside (vcluster-only). On GKE, defaults to 'gke_<project_id>_<location>_<host_cluster_name>' when empty; required for eks/aks host_cloud"
   default     = ""
 }
 
 variable "host_cluster_name" {
   type        = string
-  description = "Name of the host GKE cluster the virtual cluster runs inside (vcluster-only); used to derive host_context when host_context is not set"
+  description = "Name of the host cluster the virtual cluster runs inside (vcluster-only); used to derive host_context on GKE hosts when host_context is not set"
   default     = ""
 }
 

--- a/tf/prebuilt/vcluster/main.tf
+++ b/tf/prebuilt/vcluster/main.tf
@@ -15,10 +15,6 @@
 terraform {
   required_version = ">= 1.5.0"
   required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = ">= 5.0.0"
-    }
     helm = {
       source  = "hashicorp/helm"
       version = "~> 3.0"
@@ -31,12 +27,9 @@ terraform {
 }
 
 locals {
-  host_context = var.host_context != "" ? var.host_context : "gke_${var.project_id}_${var.location}_${var.host_cluster_name}"
-}
-
-provider "google" {
-  project = var.project_id
-  region  = var.location
+  host_context = var.host_context != "" ? var.host_context : (
+    var.host_cloud == "gke" ? "gke_${var.project_id}_${var.location}_${var.host_cluster_name}" : ""
+  )
 }
 
 provider "helm" {
@@ -56,6 +49,7 @@ module "vcluster" {
   cluster_name         = var.cluster_name
   project_id           = var.project_id
   location             = var.location
+  host_cloud           = var.host_cloud
   host_context         = var.host_context
   host_cluster_name    = var.host_cluster_name
   kubeconfig_path_host = var.kubeconfig_path_host

--- a/tf/prebuilt/vcluster/main.tf
+++ b/tf/prebuilt/vcluster/main.tf
@@ -1,0 +1,79 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}
+
+locals {
+  host_context = var.host_context != "" ? var.host_context : "gke_${var.project_id}_${var.location}_${var.host_cluster_name}"
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.location
+}
+
+provider "helm" {
+  kubernetes = {
+    config_path    = pathexpand(var.kubeconfig_path_host)
+    config_context = local.host_context
+  }
+}
+
+provider "kubernetes" {
+  config_path    = pathexpand(var.kubeconfig_path_host)
+  config_context = local.host_context
+}
+
+module "vcluster" {
+  source               = "../../modules/cluster/vcluster"
+  cluster_name         = var.cluster_name
+  project_id           = var.project_id
+  location             = var.location
+  host_context         = var.host_context
+  host_cluster_name    = var.host_cluster_name
+  kubeconfig_path_host = var.kubeconfig_path_host
+  kubeconfig_path      = var.kubeconfig_path
+}
+
+output "cluster_name" {
+  value = module.vcluster.cluster_name
+}
+
+output "cluster_location" {
+  value = module.vcluster.cluster_location
+}
+
+output "kubeconfig_path" {
+  value = module.vcluster.kubeconfig_path
+}
+
+output "endpoint" {
+  value = module.vcluster.endpoint
+}

--- a/tf/prebuilt/vcluster/variables.tf
+++ b/tf/prebuilt/vcluster/variables.tf
@@ -19,30 +19,41 @@ variable "cluster_name" {
 
 variable "project_id" {
   type        = string
-  description = "GCP project ID of the host GKE cluster"
+  description = "GCP project ID of the host cluster (GKE hosts only; used to derive host_context)"
 }
 
 variable "location" {
   type        = string
-  description = "Region of the host GKE cluster (e.g. us-central1)"
+  description = "Region of the host cluster (e.g. us-central1); used to derive host_context on GKE hosts"
   default     = "us-central1"
+}
+
+variable "host_cloud" {
+  type        = string
+  description = "Cloud the host cluster runs on: 'gke', 'eks', or 'aks'. Only 'gke' is currently implemented end-to-end; 'eks'/'aks' require host_context to be set explicitly"
+  default     = "gke"
+
+  validation {
+    condition     = contains(["gke", "eks", "aks"], var.host_cloud)
+    error_message = "host_cloud must be one of: 'gke', 'eks', 'aks'."
+  }
 }
 
 variable "host_context" {
   type        = string
-  description = "Kube context of the host GKE cluster. Defaults to 'gke_<project_id>_<location>_<host_cluster_name>' when empty"
+  description = "Kube context of the host cluster. On GKE, defaults to 'gke_<project_id>_<location>_<host_cluster_name>' when empty; required for eks/aks host_cloud"
   default     = ""
 }
 
 variable "host_cluster_name" {
   type        = string
-  description = "Name of the host GKE cluster; used to derive host_context when host_context is not set"
+  description = "Name of the host cluster; used to derive host_context on GKE hosts when host_context is not set"
   default     = ""
 }
 
 variable "kubeconfig_path_host" {
   type        = string
-  description = "Path to the kubeconfig used to reach the host GKE cluster"
+  description = "Path to the kubeconfig used to reach the host cluster"
   default     = "~/.kube/config"
 }
 

--- a/tf/prebuilt/vcluster/variables.tf
+++ b/tf/prebuilt/vcluster/variables.tf
@@ -1,0 +1,52 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "cluster_name" {
+  type    = string
+  default = "devops-bench-vcluster"
+}
+
+variable "project_id" {
+  type        = string
+  description = "GCP project ID of the host GKE cluster"
+}
+
+variable "location" {
+  type        = string
+  description = "Region of the host GKE cluster (e.g. us-central1)"
+  default     = "us-central1"
+}
+
+variable "host_context" {
+  type        = string
+  description = "Kube context of the host GKE cluster. Defaults to 'gke_<project_id>_<location>_<host_cluster_name>' when empty"
+  default     = ""
+}
+
+variable "host_cluster_name" {
+  type        = string
+  description = "Name of the host GKE cluster; used to derive host_context when host_context is not set"
+  default     = ""
+}
+
+variable "kubeconfig_path_host" {
+  type        = string
+  description = "Path to the kubeconfig used to reach the host GKE cluster"
+  default     = "~/.kube/config"
+}
+
+variable "kubeconfig_path" {
+  type        = string
+  description = "Path to write the vcluster's own kubeconfig"
+}


### PR DESCRIPTION
## What this adds

A `vcluster` infrastructure provider that provisions [loft-sh/vcluster](https://github.com/loft-sh/vcluster) virtual clusters inside an existing host cluster, instead of creating a real GKE cluster per run. Cluster provisioning drops from 10-20 minutes to 2-4 minutes, and workloads inside the vcluster schedule in seconds. That changes how fast we can iterate while developing tasks.

Tasks opt in with `provider: "vcluster"` (or `INFRA_PROVIDER=vcluster` at run time). No task schema changes.

## What's in the change

- `tf/modules/cluster/vcluster`: the vcluster submodule, alongside `gke` and `kind`. It creates a LoadBalancer Service before the Helm release, waits for the ingress address, and bakes that address into the proxy cert SANs and the exported kubeconfig. Access needs no vcluster CLI: the kubeconfig comes from the `vc-<name>` secret and is written to a per-cluster path.
- The namespace is managed by tofu rather than Helm, so destroy removes the PVC. Without this, a re-created vcluster silently resumes the previous run's state (we hit this in testing).
- `tf/prebuilt/vcluster`: standalone stack. `tf/prebuilt/minimal`: a provider-agnostic stack that dispatches to `tf/modules/cluster` for gcp, kind, or vcluster. Named `minimal` rather than `minimum` to avoid colliding with downstream stacks of that name.
- `devops_bench/providers/vcluster.py`: `VclusterProvider`, mirroring the KinD provider shape. Handles host cluster credentials (gcloud on GKE hosts) and derives per-cluster kubeconfig paths so parallel runs don't collide.
- Docs in `docs/components/infra.md`, 20+ unit tests.

## Host clouds

The module is host-cloud agnostic: a `host_cloud` variable (`gke`, `eks`, `aks`; default `gke`) is threaded through, and the LB-address approach works on all three (IP on GKE/AKS, NLB hostname on EKS). GKE is implemented and tested. For EKS/AKS the remaining work is host credential automation (`aws eks update-kubeconfig` / `az aks get-credentials`) and a real test pass on each; until then those paths assume the host context already exists in kubeconfig.

## When to use it (and not)

vcluster is right for workload, manifest, and policy-level tasks, which is most of them. It is not faithful for anything that depends on real node behavior: node pools, per-cluster GKE Workload Identity, node-level DaemonSets, or Autopilot scaling semantics. Those tasks should keep using the `gcp` provider.

## Verification

Tested live against a GKE Autopilot host cluster (chart v0.36.1):

| Phase | Time |
|---|---|
| `tofu apply` to responsive vcluster API | 2m17s - 3m36s (varies with Autopilot node warmth) |
| nginx deployment inside the vcluster to Ready | 3-4s |
| `tofu destroy` (namespace, PVC, LB fully removed, verified) | 68-86s |

Full unit suite passes (1190 tests). `tofu validate` and `fmt` clean across `tf/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for provisioning and managing vcluster virtual clusters on GKE, EKS, and AKS.
  - Added configurable host-cluster contexts, kubeconfig paths, locations, projects, and chart versions.
  - Added cluster outputs for names, locations, endpoints, and kubeconfig files.
  - Added minimal and dedicated vcluster deployment configurations.

- **Documentation**
  - Documented vcluster setup, required configuration, provisioning, teardown, prerequisites, and host-cloud limitations.

- **Tests**
  - Added coverage for provider registration, configuration defaults, credential handling, and cluster output resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->