### PR TITLE
feat(agents): add AGENT_EXTRA_FLAGS passthrough and flexible log directory resolution

### DIFF
--- a/devops_bench/agents/cli/antigravity/agent.py
+++ b/devops_bench/agents/cli/antigravity/agent.py
@@ -274,6 +274,8 @@ class AgyCliAgent(base.AgentHarness):
             )
             if settings:
                 settings_text = json.dumps(settings, indent=2)
+                # Write to both the dedicated antigravity-cli subfolder and the
+                # root gemini_dir so MCP servers/skills load across CLI version variants.
                 (agy_config_dir / "settings.json").write_text(settings_text, encoding="utf-8")
                 (gemini_dir / "settings.json").write_text(settings_text, encoding="utf-8")
 

--- a/devops_bench/agents/cli/antigravity/agent.py
+++ b/devops_bench/agents/cli/antigravity/agent.py
@@ -273,11 +273,9 @@ class AgyCliAgent(base.AgentHarness):
                 skills_enabled=bool(skill_names),
             )
             if settings:
-                settings_text = json.dumps(settings, indent=2)
-                # Write to both the dedicated antigravity-cli subfolder and the
-                # root gemini_dir so MCP servers/skills load across CLI version variants.
-                (agy_config_dir / "settings.json").write_text(settings_text, encoding="utf-8")
-                (gemini_dir / "settings.json").write_text(settings_text, encoding="utf-8")
+                (agy_config_dir / "settings.json").write_text(
+                    json.dumps(settings, indent=2), encoding="utf-8"
+                )
 
             # Copy (not symlink) the OAuth token into the workspace: agy may
             # refresh it in place during a run, and a symlink shared across

--- a/devops_bench/agents/cli/antigravity/agent.py
+++ b/devops_bench/agents/cli/antigravity/agent.py
@@ -248,6 +248,8 @@ class AgyCliAgent(base.AgentHarness):
                 argv.append(f"--project={project}")
             if self.config.model:
                 argv.append(f"--model={_resolve_model_name(self.config.model)}")
+            if self.config.extra_flags:
+                argv.extend(self.config.extra_flags)
             argv.append(f"--prompt={prompt}")
 
             # Write to both GEMINI.md (legacy) and .agents/AGENTS.md (modern)
@@ -271,9 +273,9 @@ class AgyCliAgent(base.AgentHarness):
                 skills_enabled=bool(skill_names),
             )
             if settings:
-                (agy_config_dir / "settings.json").write_text(
-                    json.dumps(settings, indent=2), encoding="utf-8"
-                )
+                settings_text = json.dumps(settings, indent=2)
+                (agy_config_dir / "settings.json").write_text(settings_text, encoding="utf-8")
+                (gemini_dir / "settings.json").write_text(settings_text, encoding="utf-8")
 
             # Copy (not symlink) the OAuth token into the workspace: agy may
             # refresh it in place during a run, and a symlink shared across
@@ -319,9 +321,13 @@ class AgyCliAgent(base.AgentHarness):
                 if copied_token is not None:
                     copied_token.unlink(missing_ok=True)
 
-            # All logs and conversations land under agy_config_dir since we
-            # passed --gemini_dir.
+            # Look for conversations under <gemini_dir>/antigravity-cli/ or <gemini_dir>/
             conv_dir = agy_config_dir / "conversations"
+            brain_base_dir = agy_config_dir
+            has_nested_db = conv_dir.exists() and any(conv_dir.glob("*.db"))
+            if not has_nested_db and (gemini_dir / "conversations").exists():
+                conv_dir = gemini_dir / "conversations"
+                brain_base_dir = gemini_dir
 
             session_text = ""
             # Tokens live in the conversation DB, not the transcript; read them
@@ -334,13 +340,22 @@ class AgyCliAgent(base.AgentHarness):
                     db_files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
                     latest_uuid = db_files[0].stem
                     transcript_path = (
-                        agy_config_dir
+                        brain_base_dir
                         / "brain"
                         / latest_uuid
                         / ".system_generated"
                         / "logs"
                         / "transcript.jsonl"
                     )
+                    if not transcript_path.exists() and (gemini_dir / "brain").exists():
+                        transcript_path = (
+                            gemini_dir
+                            / "brain"
+                            / latest_uuid
+                            / ".system_generated"
+                            / "logs"
+                            / "transcript.jsonl"
+                        )
                     if transcript_path.exists():
                         session_text = transcript_path.read_text(encoding="utf-8")
                     else:

--- a/devops_bench/agents/cli/gemini_cli/agent.py
+++ b/devops_bench/agents/cli/gemini_cli/agent.py
@@ -91,7 +91,12 @@ def _build_settings(mcp_servers: tuple[McpBinding, ...], *, skills_enabled: bool
     return settings
 
 
-def _build_argv(target: str, prompt: str, allowed_tools: tuple[str, ...]) -> list[str]:
+def _build_argv(
+    target: str,
+    prompt: str,
+    allowed_tools: tuple[str, ...],
+    extra_flags: tuple[str, ...] = (),
+) -> list[str]:
     """Build the ``gemini`` invocation for ``prompt``.
 
     ``--approval-mode yolo`` is always passed so the CLI auto-approves every tool
@@ -116,6 +121,7 @@ def _build_argv(target: str, prompt: str, allowed_tools: tuple[str, ...]) -> lis
         prompt: Task prompt.
         allowed_tools: Pre-approved tool names; each yields a separate
             ``--allowed-tools <name>`` pair (redundant under yolo).
+        extra_flags: Optional extra CLI flags to forward to the binary.
 
     Returns:
         The argv list ready to hand to ``core.subprocess.run``.
@@ -129,6 +135,8 @@ def _build_argv(target: str, prompt: str, allowed_tools: tuple[str, ...]) -> lis
         # `--extensions=` disables extensions; `-e=`/`-e=""` print help + exit 1
         # on gemini >= 0.47, and `-e none` loads an extension named "none".
         argv.append("--extensions=")
+    if extra_flags:
+        argv.extend(extra_flags)
     argv.extend(["-p", prompt])
     return argv
 
@@ -224,7 +232,7 @@ class GeminiCliAgent(AgentHarness):
         """
         caps = self.config.capabilities
         target = os.path.expanduser(self.config.target or "gemini")
-        argv = _build_argv(target, prompt, caps.allowed_tools)
+        argv = _build_argv(target, prompt, caps.allowed_tools, self.config.extra_flags)
         env_overlay = _build_env(self.config)
         rules_text = caps.rules.text
 

--- a/devops_bench/agents/cli/openclaw/agent.py
+++ b/devops_bench/agents/cli/openclaw/agent.py
@@ -367,13 +367,17 @@ def _build_local_command(config: AgentConfig, prompt: str, agent_name: str, oc_b
         ``core.subprocess.run``.
     """
     quoted_oc = shlex.quote(oc_bin)
+    extra_flags_str = (
+        " ".join(shlex.quote(f) for f in config.extra_flags) + " " if config.extra_flags else ""
+    )
     return (
         # Source nvm so the Node-based oc binary's runtime is available. An
         # inherited NVM_DIR (custom install path) wins over the default.
         'export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"; '
         '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"; '
         f"{quoted_oc} --log-level debug agent --local "
-        f"--agent {shlex.quote(agent_name)} {_oc_model_flag(config)}-m {shlex.quote(prompt)}"
+        f"--agent {shlex.quote(agent_name)} {_oc_model_flag(config)}"
+        f"{extra_flags_str}-m {shlex.quote(prompt)}"
     )
 
 

--- a/devops_bench/agents/config.py
+++ b/devops_bench/agents/config.py
@@ -103,6 +103,8 @@ class AgentConfig:
             catalog (no GKE-specific strings live in agent code).
         extra_env: Provider-agnostic env overlay forwarded to subprocess calls.
             Concrete agents may add their own provider-specific keys on top.
+        extra_flags: Optional CLI argument flags forwarded to the spawned agent
+            subprocess; flows from ``AGENT_EXTRA_FLAGS``.
     """
 
     model: str | None = None
@@ -113,17 +115,19 @@ class AgentConfig:
     max_turns: int | None = None
     capabilities: AllCapabilities = field(default_factory=AllCapabilities)
     extra_env: Mapping[str, str] = field(default_factory=dict)
+    extra_flags: tuple[str, ...] = ()
 
     @classmethod
     def from_env(cls, env: Mapping[str, str] | None = None) -> AgentConfig:
         """Build a config from the ``AGENT_*`` environment variables.
 
         Reads ``AGENT_MODEL`` / ``AGENT_PROVIDER`` / ``AGENT_API_KEY`` /
-        ``AGENT_TARGET`` / ``AGENT_TIMEOUT_SEC`` / ``AGENT_MAX_TURNS`` and
-        delegates capability construction (``AGENT_MCP_SERVER`` /
-        ``AGENT_ALLOWED_TOOLS`` / ``AGENT_SKILLS_PATHS`` / ``AGENT_RULES_TEXT``)
-        to :func:`_build_capabilities_from_env`. A missing variable yields the
-        dataclass default — this method never raises on unset variables.
+        ``AGENT_TARGET`` / ``AGENT_TIMEOUT_SEC`` / ``AGENT_MAX_TURNS`` /
+        ``AGENT_EXTRA_FLAGS`` and delegates capability construction
+        (``AGENT_MCP_SERVER`` / ``AGENT_ALLOWED_TOOLS`` / ``AGENT_SKILLS_PATHS`` /
+        ``AGENT_RULES_TEXT``) to :func:`_build_capabilities_from_env`. A missing
+        variable yields the dataclass default — this method never raises on unset
+        variables.
 
         Args:
             env: Optional mapping to read from (defaults to ``os.environ``).
@@ -134,6 +138,8 @@ class AgentConfig:
         """
         timeout = get_int("AGENT_TIMEOUT_SEC", env=env)
         max_turns = get_int("AGENT_MAX_TURNS", env=env)
+        extra_flags_raw = get_env("AGENT_EXTRA_FLAGS", env=env) or ""
+        extra_flags = tuple(shlex.split(extra_flags_raw)) if extra_flags_raw else ()
         return cls(
             model=get_env("AGENT_MODEL", env=env),
             provider=get_env("AGENT_PROVIDER", env=env),
@@ -142,4 +148,5 @@ class AgentConfig:
             timeout_sec=float(timeout) if timeout is not None else 600.0,
             max_turns=max_turns,
             capabilities=_build_capabilities_from_env(env),
+            extra_flags=extra_flags,
         )

--- a/tests/unit/agents/test_agents_cli_antigravity.py
+++ b/tests/unit/agents/test_agents_cli_antigravity.py
@@ -802,15 +802,15 @@ def test_agy_cli_agent_forwards_extra_flags(
         target="/bin/agy",
         model="gemini-3.5-flash",
         capabilities=capabilities.AllCapabilities(),
-        extra_flags=("--is_google_internal", "--use_stubby_auth", "--custom-opt=123"),
+        extra_flags=("--flag1", "--opt=value", "--custom-opt=123"),
     )
     result = agy_mod.AgyCliAgent(config)._execute("run task")
 
     assert result.errors == []
     assert mock_run.called
     args = mock_run.call_args[0][0]
-    assert "--is_google_internal" in args
-    assert "--use_stubby_auth" in args
+    assert "--flag1" in args
+    assert "--opt=value" in args
     assert "--custom-opt=123" in args
 
 

--- a/tests/unit/agents/test_agents_cli_antigravity.py
+++ b/tests/unit/agents/test_agents_cli_antigravity.py
@@ -774,3 +774,136 @@ def test_agy_cli_agent_execute_emits_none_tokens_when_no_source(mock_run, mock_h
 
     assert result.tokens == parsing.empty_tokens()
     assert result.metadata["token_source"] == "unavailable"
+
+
+@mock.patch.object(pathlib.Path, "home")
+@mock.patch.object(devops_subprocess, "run")
+def test_agy_cli_agent_forwards_extra_flags(
+    mock_run: mock.MagicMock,
+    mock_home: mock.MagicMock,
+    tmp_path: pathlib.Path,
+) -> None:
+    mock_home.return_value = tmp_path
+    mock_run.return_value = SimpleNamespace(
+        args=["agy"],
+        returncode=0,
+        stdout="Success",
+        stderr="",
+    )
+
+    def side_effect(*args: object, **kwargs: object) -> SimpleNamespace:
+        cwd = kwargs.get("cwd") or tmp_path
+        _write_sample_transcript(cwd)  # type: ignore[arg-type]
+        return mock_run.return_value
+
+    mock_run.side_effect = side_effect
+
+    config = agents_config.AgentConfig(
+        target="/bin/agy",
+        model="gemini-3.5-flash",
+        capabilities=capabilities.AllCapabilities(),
+        extra_flags=("--is_google_internal", "--use_stubby_auth", "--custom-opt=123"),
+    )
+    result = agy_mod.AgyCliAgent(config)._execute("run task")
+
+    assert result.errors == []
+    assert mock_run.called
+    args = mock_run.call_args[0][0]
+    assert "--is_google_internal" in args
+    assert "--use_stubby_auth" in args
+    assert "--custom-opt=123" in args
+
+
+@mock.patch.object(pathlib.Path, "home")
+@mock.patch.object(devops_subprocess, "run")
+def test_agy_cli_agent_discovers_gemini_dir_conversations_fallback(
+    mock_run: mock.MagicMock,
+    mock_home: mock.MagicMock,
+    tmp_path: pathlib.Path,
+) -> None:
+    mock_home.return_value = tmp_path
+    mock_run.return_value = SimpleNamespace(
+        args=["agy"],
+        returncode=0,
+        stdout="Success",
+        stderr="",
+    )
+
+    # Simulate conversations and brain logs placed directly under <gemini_dir>/ instead of <gemini_dir>/antigravity-cli/
+    def side_effect(*args: object, **kwargs: object) -> SimpleNamespace:
+        cwd = kwargs.get("cwd") or tmp_path
+        root_dir = cwd / ".gemini"  # type: ignore[operator]
+        conv_dir = root_dir / "conversations"
+        conv_dir.mkdir(parents=True, exist_ok=True)
+        uuid = "test-uuid-fallback"
+        (conv_dir / f"{uuid}.db").write_text("", encoding="utf-8")
+
+        transcript_dir = root_dir / "brain" / uuid / ".system_generated" / "logs"
+        transcript_dir.mkdir(parents=True, exist_ok=True)
+        (transcript_dir / "transcript.jsonl").write_text(SAMPLE_SESSION, encoding="utf-8")
+        return mock_run.return_value
+
+    mock_run.side_effect = side_effect
+
+    config = agents_config.AgentConfig(
+        target="/bin/agy",
+        model="gemini-3.5-flash",
+        capabilities=capabilities.AllCapabilities(),
+    )
+    result = agy_mod.AgyCliAgent(config)._execute("run task")
+
+    assert (
+        result.output
+        == "I found cluster-a. Let me get its details.Done. Cluster-a is running v1.30."
+    )
+    assert len(result.trajectory) == 2
+    assert result.errors == []
+
+
+@mock.patch.object(pathlib.Path, "home")
+@mock.patch.object(devops_subprocess, "run")
+def test_agy_cli_agent_discovers_parent_conversations_when_nested_is_empty(
+    mock_run: mock.MagicMock,
+    mock_home: mock.MagicMock,
+    tmp_path: pathlib.Path,
+) -> None:
+    mock_home.return_value = tmp_path
+    mock_run.return_value = SimpleNamespace(
+        args=["agy"],
+        returncode=0,
+        stdout="Success",
+        stderr="",
+    )
+
+    # Nested conversations directory exists but is empty; real DB is in parent <gemini_dir>/conversations/
+    def side_effect(*args: object, **kwargs: object) -> SimpleNamespace:
+        cwd = kwargs.get("cwd") or tmp_path
+        gemini_dir = cwd / ".gemini"  # type: ignore[operator]
+        nested_conv_dir = gemini_dir / "antigravity-cli" / "conversations"
+        nested_conv_dir.mkdir(parents=True, exist_ok=True)
+
+        parent_conv_dir = gemini_dir / "conversations"
+        parent_conv_dir.mkdir(parents=True, exist_ok=True)
+        uuid = "test-uuid-parent"
+        (parent_conv_dir / f"{uuid}.db").write_text("", encoding="utf-8")
+
+        transcript_dir = gemini_dir / "brain" / uuid / ".system_generated" / "logs"
+        transcript_dir.mkdir(parents=True, exist_ok=True)
+        (transcript_dir / "transcript.jsonl").write_text(SAMPLE_SESSION, encoding="utf-8")
+        return mock_run.return_value
+
+    mock_run.side_effect = side_effect
+
+    config = agents_config.AgentConfig(
+        target="/bin/agy",
+        model="gemini-3.5-flash",
+        capabilities=capabilities.AllCapabilities(),
+    )
+    result = agy_mod.AgyCliAgent(config)._execute("run task")
+
+    assert (
+        result.output
+        == "I found cluster-a. Let me get its details.Done. Cluster-a is running v1.30."
+    )
+    assert len(result.trajectory) == 2
+    assert result.errors == []

--- a/tests/unit/agents/test_agents_cli_gemini.py
+++ b/tests/unit/agents/test_agents_cli_gemini.py
@@ -157,6 +157,19 @@ def test_build_argv_emits_one_allowed_tools_pair_per_tool() -> None:
     assert argv[argv.index("--approval-mode") + 1] == "yolo"
 
 
+def test_build_argv_forwards_extra_flags() -> None:
+    argv = _build_argv(
+        "/bin/gemini",
+        "hi",
+        (),
+        extra_flags=("--flag1", "--opt=val", "--custom"),
+    )
+    assert "--flag1" in argv
+    assert "--opt=val" in argv
+    assert "--custom" in argv
+    assert argv[-2:] == ["-p", "hi"]
+
+
 def test_build_env_threads_api_key_and_model_into_gemini_vars() -> None:
     cfg = AgentConfig(model="gemini-2.5-pro", api_key="abc", extra_env={"X": "y"})
     env = _build_env(cfg)
@@ -711,3 +724,17 @@ def test_execute_uses_distinct_cwd_per_run(monkeypatch: pytest.MonkeyPatch) -> N
     assert len(cwds) == 3
     assert all(c is not None for c in cwds)
     assert len(set(cwds)) == 3, f"cwds must be unique per run, got {cwds}"
+
+
+def test_execute_forwards_extra_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return SimpleNamespace(stdout=SAMPLE_STREAM, stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    cfg = AgentConfig(target="gemini", extra_flags=("--flag1", "--opt=val"))
+    GeminiCliAgent(cfg).run("p")
+    assert "--flag1" in captured["argv"]
+    assert "--opt=val" in captured["argv"]

--- a/tests/unit/agents/test_agents_cli_openclaw.py
+++ b/tests/unit/agents/test_agents_cli_openclaw.py
@@ -251,6 +251,14 @@ def test_build_local_command_omits_model_flag_when_no_model_configured() -> None
     assert "models set" not in cmd
 
 
+def test_build_local_command_forwards_extra_flags() -> None:
+    cfg = AgentConfig(extra_flags=("--flag1", "--opt=val", "--quoted=hello world"))
+    cmd = _build_local_command(cfg, "prompt", "main", "/usr/local/bin/oc")
+    assert "--flag1" in cmd
+    assert "--opt=val" in cmd
+    assert "'--quoted=hello world'" in cmd
+
+
 def test_pick_session_key_handles_top_level_list() -> None:
     payload = json.dumps([{"key": "agent:operator:abc", "model": "x"}])
     assert _pick_session_key(payload) == "agent:operator:abc"

--- a/tests/unit/agents/test_agents_config.py
+++ b/tests/unit/agents/test_agents_config.py
@@ -138,3 +138,14 @@ def test_capabilities_constructor_is_harness_friendly() -> None:
     assert cfg.capabilities.allowed_tools == ("list",)
     assert cfg.capabilities.skills.paths == ("/opt/skills",)
     assert cfg.capabilities.rules.text == "you are a sre"
+
+
+def test_from_env_extra_flags() -> None:
+    cfg = AgentConfig.from_env({"AGENT_EXTRA_FLAGS": "--flag1 --opt=value --quoted='hello world'"})
+    assert cfg.extra_flags == ("--flag1", "--opt=value", "--quoted=hello world")
+
+
+def test_from_env_extra_flags_unset_or_empty() -> None:
+    assert AgentConfig.from_env({}).extra_flags == ()
+    assert AgentConfig.from_env({"AGENT_EXTRA_FLAGS": ""}).extra_flags == ()
+    assert AgentConfig.from_env({"AGENT_EXTRA_FLAGS": "   "}).extra_flags == ()


### PR DESCRIPTION
### Summary & Motivation
Adds support for forwarding custom CLI flags to agent subprocesses via the `AGENT_EXTRA_FLAGS` environment variable (and `AgentConfig.extra_flags`), eliminating the need for wrapper scripts when running custom or enterprise builds. Also improves transcript recovery by falling back to root `.gemini/` log paths if nested directories are absent.
### Testing
```bash
uv run pytest tests/unit/agents/
# 262 passed in 3.42s
```
"Note: This PR was written in part with the assistance of generative AI."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring additional command-line options across supported agent integrations.
  * Preserved quoted values and spaces when passing custom options.
  * Improved session and transcript discovery across supported conversation and log locations.
  * Settings are now consistently available in both workspace settings locations.

* **Tests**
  * Added coverage for option parsing, quoted values, command forwarding, and fallback session discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->