### PR TITLE
Guard the minimum stack's Artifact Registry sweep to the gcp provider

### DIFF
--- a/tf/prebuilt/minimum/main.tf
+++ b/tf/prebuilt/minimum/main.tf
@@ -46,7 +46,14 @@ provider "google" {
 # listing the project's repos and delete it at its own location. The name match
 # is an exact suffix on the run-unique cluster, so a sibling run's repo is never
 # touched.
+#
+# GCP-only: the sweep shells out to `gcloud`, and on KinD there is no Artifact
+# Registry to sweep. Without the guard a local KinD run still makes a cloud call,
+# against whichever project the developer's `gcloud` is pointed at. Same
+# count-guard idiom as modules/cluster/main.tf.
 resource "null_resource" "ar_cleanup" {
+  count = var.infra_provider == "gcp" ? 1 : 0
+
   triggers = {
     project = var.project_id
     repo    = "hello-app-${var.cluster_name}"


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes-sigs/devops-bench/pull/64#discussion_r3834003057 — #64 merged before the comment was addressed.

## The problem

`null_resource.ar_cleanup` in `tf/prebuilt/minimum/main.tf` registers a destroy-time provisioner that shells out to `gcloud`, unconditionally. The stack is dual-provider — `module.cluster` picks GKE or KinD off `var.infra_provider` — so a KinD run creates the resource too, and teardown makes a cloud call even though there is no Artifact Registry repo to sweep.

On KinD `var.project_id` is `""`, so the call is `gcloud artifacts repositories list --project=''`. It doesn't delete anything, and `2>/dev/null` plus the pipe into `while` keeps it from failing the destroy — but it is still a cloud round-trip on a purely local run, made against whatever project the developer's `gcloud` is configured with, and it needs `gcloud` on `PATH` to be a clean no-op at all.

## The fix

```hcl
resource "null_resource" "ar_cleanup" {
  count = var.infra_provider == "gcp" ? 1 : 0
  ...
}
```

Same count-guard idiom `modules/cluster/main.tf:22,38` already uses to select a cluster backend. A destroy-time provisioner can't read variables directly (only `self`/`count`/`each`), so gating the resource is the way to express this rather than adding a shell-level `if` inside the command.

With `count = 0` on KinD the resource is never created, so no destroy provisioner is ever registered and teardown does no cloud I/O.

## Notes

- Nothing else in `tf/` references `null_resource.ar_cleanup`, so the index that `count` introduces breaks no reference.
- The GCP path is byte-for-byte unchanged: the sweep, the location discovery, and the exact-suffix name match on the run-unique cluster all behave exactly as they do on `main` today.
- `tofu fmt -check` and `tofu init` pass. I could not run `tofu validate` locally — the `hashicorp/google` plugin fails its go-plugin handshake on my machine, which is an environment problem unrelated to this change — so I'm relying on CI for that.

/cc @janetkuo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented Artifact Registry cleanup from running on KinD clusters, avoiding unnecessary cloud commands when no Artifact Registry is available.
  - Limited Artifact Registry cleanup to GCP-based environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->