### PR TITLE
Add the operational skills and references

### DIFF
--- a/.agents/references/monitoring-and-recovery.md
+++ b/.agents/references/monitoring-and-recovery.md
@@ -29,7 +29,7 @@ Spend the cheapest tier that can do each job:
 | **Supervisor** | your main model | every ~3–5 min while active; longer when idle | Read the monitor digest, dispatch analyzers, decide retries, re-spawn dead watchers, keep the session alive. |
 
 Run the monitor/analyzer as **sub-agents that can shell out on the runner host**
-(local shell, or ssh/gcloud to the bastion in remote mode) when your harness has
+(local shell, or ssh/cloud tunnel CLI to the bastion in remote mode) when your harness has
 sub-agents; if it doesn't, do those checks inline yourself — the loop still works
 on one model. Give each watcher the connection env and the `RESUME_STAMP`, and
 have it **return a compact digest, not raw logs**, to keep the supervisor's

--- a/.agents/references/monitoring-and-recovery.md
+++ b/.agents/references/monitoring-and-recovery.md
@@ -1,0 +1,101 @@
+# Monitoring & recovery
+
+How to babysit a detached eval run so it survives quiet stretches, dead watchers,
+and local drops — without busy-polling or declaring victory early. The eval skills
+link here for the monitoring loop.
+
+This reference is **agent-agnostic**: it describes capabilities (a cheap watcher,
+a stronger reader, background runs, timers, durable state, heartbeats). For the
+per-agent mapping of those capabilities to concrete tools see
+[`harness-capabilities.md`](./harness-capabilities.md), and degrade gracefully
+when one is absent.
+
+The **runner host is the source of truth** — every combo's state lives in
+`~/matrix-runs/<stamp>/<rid>/` (`status`, `run.log`) plus the runner's own log at
+`~/matrix-runs/<stamp>.out`. The watchers below are disposable readers of that
+state: losing one loses nothing, because a fresh one re-reads the same
+`RESUME_STAMP`.
+
+---
+
+## Tiered monitoring
+
+Spend the cheapest tier that can do each job:
+
+| Role | Tier | Cadence | Job |
+|---|---|---|---|
+| **Monitor** | cheap model | each tick | Shell to the runner host, read each combo's `status` + `run.log` tail, return a one-line-per-combo digest + an overall `running / done / flaked / .done` count. No analysis, no log dumps. |
+| **Analyzer** | mid model | once per finished combo (batch if several finish together) | Pull + read that combo's `results.json` + `run.log`; return scores + pass/fail checks + a root-cause digest if it failed. Never analyze a combo twice. |
+| **Supervisor** | your main model | every ~3–5 min while active; longer when idle | Read the monitor digest, dispatch analyzers, decide retries, re-spawn dead watchers, keep the session alive. |
+
+Run the monitor/analyzer as **sub-agents that can shell out on the runner host**
+(local shell, or ssh/gcloud to the bastion in remote mode) when your harness has
+sub-agents; if it doesn't, do those checks inline yourself — the loop still works
+on one model. Give each watcher the connection env and the `RESUME_STAMP`, and
+have it **return a compact digest, not raw logs**, to keep the supervisor's
+context clean.
+
+---
+
+## Supervision loop
+
+1. Launch detached and capture `RESUME_STAMP`; record the stamp + combo list in a
+   **durable state file** so a context reset can resume.
+2. Start the **monitor** — as a background/detached watcher if available, else a
+   short foreground check each tick.
+3. Each supervisor tick:
+   - Read the monitor digest; emit a one-line status (heartbeat).
+   - Newly finished combos (`exit=0`) → dispatch an **analyzer**.
+   - **Flaked** combos → the retry procedure in the eval skill (cap 2 per combo);
+     classify infra-flake vs real failure against
+     [`../../docs/appendix/known_issues.md`](../../docs/appendix/known_issues.md).
+   - `.done` present **and** every combo analyzed → summarize and finish.
+   - Otherwise **schedule the next wakeup** (~3–5 min while active; 20–30 min if
+     genuinely idle) and end the turn. No scheduler? `sleep` between checks. Poll
+     every ~3–5 min for infra-bearing tasks — **don't busy-poll.**
+
+The wrapper's own poller already tolerates one failure mode for you: the `.done`
+marker is written only after every combo finishes, so if the detached runner
+itself dies (reboot, OOM, manual kill) the marker never lands — the wrapper
+stops anyway once **every combo has a `status` file**, since that means the work
+finished either way.
+
+---
+
+## Keepalive / heartbeat
+
+Never declare the run "done" until **every** combo is terminal **and** summarized.
+A long detached matrix has quiet stretches; some harnesses watch the session and
+may classify it finished or time it out during those gaps. So:
+
+- **Never** emit a completion / "done" / "failed" signal mid-run.
+- Each tick, emit a short `still working: N running / M done / K flaked` line so
+  the session stays classified as active.
+- Re-engage via a timer rather than blocking, so you don't go silent.
+
+Harnesses with no such classifier can ignore the mechanics, but periodic progress
+is still good practice.
+
+---
+
+## Recovery
+
+- **Watcher died** (terminal error / empty result) → re-spawn a fresh one pointed
+  at the same `RESUME_STAMP`; no state is lost. Cap re-spawns (~3 per role per
+  tick); if a role keeps dying, fall back to doing that check yourself and note
+  the degradation.
+- **Local poller died** → the detached run continues on the runner host;
+  re-attach with `RESUME_STAMP=<stamp>` and the same command.
+- **Whole runner died** (no `.done`, no live process) → re-attach to confirm,
+  then relaunch only the unfinished combos.
+- **Transient ssh `exit 255`** (remote mode) → a relay blip; retry. The detached
+  run is unaffected — the wrapper's ssh transport uses keepalives and its result
+  pull already retries.
+
+---
+
+## Cost discipline
+
+Poll with the cheap monitor (frequent), analyze with the mid tier (per-finish
+only), spend the main model rarely (supervise/decide). Prefer one batched
+analyzer when several combos finish together.

--- a/.agents/references/monitoring-and-recovery.md
+++ b/.agents/references/monitoring-and-recovery.md
@@ -45,11 +45,16 @@ context clean.
    short foreground check each tick.
 3. Each supervisor tick:
    - Read the monitor digest; emit a one-line status (heartbeat).
-   - Newly finished combos (`exit=0`) → dispatch an **analyzer**.
+   - Every newly **terminal** combo → dispatch an **analyzer**. A combo that
+     stays failed past the retry cap is terminal too — close it out with a
+     root-cause digest (or record it as a non-graded failure); never leave a
+     failed combo unanalyzed.
    - **Flaked** combos → the retry procedure in the eval skill (cap 2 per combo);
      classify infra-flake vs real failure against
      [`../../docs/appendix/known_issues.md`](../../docs/appendix/known_issues.md).
-   - `.done` present **and** every combo analyzed → summarize and finish.
+   - `.done` present — or every expected combo has a `status` file, which the
+     wrapper itself treats as finished (see below) — **and** every combo
+     analyzed or recorded → summarize and finish.
    - Otherwise **schedule the next wakeup** (~3–5 min while active; 20–30 min if
      genuinely idle) and end the turn. No scheduler? `sleep` between checks. Poll
      every ~3–5 min for infra-bearing tasks — **don't busy-poll.**

--- a/.agents/references/running-evals.md
+++ b/.agents/references/running-evals.md
@@ -33,9 +33,8 @@ transports:
 - **Plain `ssh`/`scp`** — any VM you can reach directly. Set
   `BASTION_SSH_HOST` (and optionally `BASTION_SSH_USER`).
 - **Cloud tunnel CLI** — when `BASTION_SSH_HOST` is unset, the wrapper falls
-  back to the provider tunnel matching a VM provisioned by the repo's
-  `tf/modules/bastion` (that module targets GCP, so the tunnel is
-  `gcloud compute ssh --tunnel-through-iap`):
+  back to the tunneling CLI of the provider that the repo's
+  `tf/modules/bastion` module targets, matching the VM it provisions:
 
   ```bash
   export BASTION_VM=<your-vm> BASTION_ZONE=us-central1-a BASTION_PROJECT=<proj>
@@ -46,8 +45,8 @@ transports:
 > assume the defaults** (`bench-bastion` / `us-central1-a` / the CLI's active
 > project). The bastion is provisioned from `tf/modules/bastion`, which exports
 > an `iap_ssh_command` output — `tofu output iap_ssh_command` in the root
-> module where you instantiated it prints the exact
-> `gcloud compute ssh <name> --zone <zone> --project <project>` form. Set
+> module where you instantiated it prints the exact connect command with the
+> real name, zone, and project. Set
 > `BASTION_VM` / `BASTION_ZONE` / `BASTION_PROJECT` from that, and verify the
 > host is up before blaming credentials for a connection failure. Use
 > `REMOTE_DIR=devops-bench-<label>` to avoid clobbering another session's
@@ -61,19 +60,16 @@ Pick one mode:
 
 - **Cloud IAM / instance-role credentials** — the runner host's ambient
   credentials; no key handling, and the only mode that stays portable across
-  the isolated per-run state dirs parallel runs create. The wrapper currently
-  implements this mode for Vertex via application-default credentials (ADC):
-  set `BENCH_VERTEX=1` and **no API keys**. The runner unsets
-  every API key `~/secrets.env` exported (`AGENT_API_KEY`, `GEMINI_API_KEY`,
-  `GOOGLE_API_KEY`, `JUDGE_API_KEY`, `GOOGLE_GENAI_API_KEY`) so agents and
-  judges fall back to the runner host's ADC (on the bastion, the VM service
-  account), then points everything at Vertex: `GOOGLE_GENAI_USE_VERTEXAI=true`,
-  `GOOGLE_CLOUD_PROJECT` / `GCP_PROJECT_ID`, and location **`global`** via
-  `GOOGLE_CLOUD_LOCATION` / `GCP_VERTEX_LOCATION`. It also exports the portable
-  OpenClaw ADC marker `GOOGLE_CLOUD_API_KEY=gcp-vertex-credentials` (see the
-  router in [known_issues.md](../../docs/appendix/known_issues.md)). For the
-  legacy oc arm additionally set `AGENT_PROVIDER=google-vertex` so the model id
-  becomes `google-vertex/<model>`.
+  the isolated per-run state dirs parallel runs create. Set `BENCH_VERTEX=1`
+  and **no API keys**: the runner unsets every API key `~/secrets.env`
+  exported so agents and judges fall back to the runner host's ambient
+  credentials (on the bastion, the VM's service account), then exports the
+  provider env the model backend needs — project, location (**`global`**), and
+  the portable ADC marker (see the router in
+  [known_issues.md](../../docs/appendix/known_issues.md)); the exact variable
+  names live in the wrapper. For the legacy oc arm additionally set
+  `AGENT_PROVIDER=google-vertex` so the model id becomes
+  `google-vertex/<model>`.
 - **API keys** — the runner sources `~/secrets.env` on the runner host when
   present (`set -a`, so plain assignments export). Put the keys your providers
   need there — `AGENT_API_KEY` for the agent contract, `GEMINI_API_KEY` /
@@ -85,10 +81,10 @@ Pick one mode:
 `JUDGE_MODEL=gemini-3.1-pro`. On Vertex, keep the location `global` and use a
 `-preview` model id — set `JUDGE_MODEL=gemini-3.1-pro-preview` — because
 `gemini-3.x` previews 404 on regional endpoints (see the `404 Publisher model`
-row in [known_issues.md](../../docs/appendix/known_issues.md)). Note the two
-location variables are read by different layers: `GCP_VERTEX_LOCATION` by the
-models layer (`devops_bench/models/gemini.py`, `models/claude.py`),
-`GOOGLE_CLOUD_LOCATION` by the antigravity agent.
+row in [known_issues.md](../../docs/appendix/known_issues.md)). Note the
+wrapper exports the location under two variables read by different layers:
+`GCP_VERTEX_LOCATION` by the models layer (`devops_bench/models/gemini.py`,
+`models/claude.py`), `GOOGLE_CLOUD_LOCATION` by the antigravity agent.
 
 ---
 
@@ -133,8 +129,8 @@ once with `scripts/bastion/configure-oc.sh`.
 without provisioning (and without requiring `PROJECT_ID`), so a typo in
 `MATRIX_MODELS` costs nothing instead of clusters.
 
-Example (Vertex, refactored arm; prefix `BENCH_REMOTE=1` + the `BASTION_*` env
-for remote):
+Example (ambient credentials, refactored arm; prefix `BENCH_REMOTE=1` + the
+`BASTION_*` env for remote):
 
 ```bash
 PROJECT_ID=<proj> BENCH_VERTEX=1 \
@@ -163,12 +159,12 @@ run is isolated by `RunEnv` (`devops_bench/core/run_env.py`):
   basename in one matrix — they would collide on run id, cluster name, and
   output dir.
 - **Per-run state** — `/tmp/devops-bench-runs/<RUN_ID>/` (override the root with
-  `BENCH_RUN_STATE_ROOT`): kubeconfig, gcloud config, tofu data dir.
+  `BENCH_RUN_STATE_ROOT`): kubeconfig, cloud CLI config, tofu data dir.
 - **Cluster name** — `<token>-<CLUSTER_NAME>`, where the token is `c` + 7 hex
   chars derived from the run id. Deterministic: **the same combo always maps to
   the same cluster name**, which is why two runs of the *same* combo must never
-  overlap. The GKE node SA is `gke-nodes-<slug:9>-<md5(cluster_name):6>`
-  (`tf/modules/cluster/gke/main.tf`).
+  overlap. The cluster module's node SA is
+  `gke-nodes-<slug:9>-<md5(cluster_name):6>` (`tf/modules/cluster/gke/main.tf`).
 
 ---
 
@@ -186,7 +182,7 @@ run is isolated by `RunEnv` (`devops_bench/core/run_env.py`):
 | `BENCH_VERTEX` | Run agents + judges on the runner host's ambient cloud credentials instead of API keys (currently implemented for Vertex/ADC). |
 | `BENCH_REMOTE` | Run on the bastion over ssh; unset runs every combo locally. |
 | `SKIP_SYNC` | Skip the working-tree sync to the bastion (after one real sync). |
-| `BASTION_VM` / `BASTION_ZONE` / `BASTION_PROJECT` | Bastion identity for the cloud tunnel transport (GCP IAP; defaults: `bench-bastion` / `us-central1-a` / the CLI's active project). |
+| `BASTION_VM` / `BASTION_ZONE` / `BASTION_PROJECT` | Bastion identity for the cloud tunnel transport (defaults: `bench-bastion` / `us-central1-a` / the CLI's active project). |
 | `BASTION_SSH_HOST` / `BASTION_SSH_USER` | Plain-ssh transport for any directly reachable VM (bypasses the cloud tunnel). |
 | `REMOTE_DIR` | Checkout dir on the VM (default `devops-bench`). Set a per-run value to avoid clobbering another session's checkout. |
 | `RESULTS_DIR` | Where pulled results land in remote mode (default `results/matrix`). |

--- a/.agents/references/running-evals.md
+++ b/.agents/references/running-evals.md
@@ -1,0 +1,203 @@
+# Running evals — shared run mechanics
+
+The single home for the run mechanics that `run-eval` and `run-parallel-evals`
+reuse: where to run, how to authenticate, how to come up clean, how to launch
+detached, the matrix knobs, and where results land. The skills link here instead
+of repeating it.
+
+This reference is **agent-agnostic** — it describes capabilities, not specific
+tools. For the per-agent mapping (sub-agents, background runs, timers, durable
+state, worktrees, asking the operator) see
+[`harness-capabilities.md`](./harness-capabilities.md). For the failure router
+see [`../../docs/appendix/known_issues.md`](../../docs/appendix/known_issues.md);
+for how scores are computed and read, see
+[`../../docs/components/metrics.md`](../../docs/components/metrics.md) — this
+file does not duplicate either.
+
+---
+
+## Choosing where to run
+
+The matrix runs on the **runner host** — the machine where you invoke the
+wrapper. **Local is the default** (`nohup` on this host, no ssh/sync, outputs in
+`~/matrix-runs/<stamp>`). Set **`BENCH_REMOTE=1`** to sync the working tree to
+the **bastion** (a GCP VM, `tf/modules/bastion`) and run there over ssh, pulling
+results back. The snippets below show the bare command; in remote mode they run
+under the wrapper's ssh transport, so the same paths (`~/secrets.env`,
+`~/matrix-runs/<stamp>`) live on the VM.
+
+**Bastion connection env (remote mode only).** By default the wrapper connects
+with `gcloud compute ssh --tunnel-through-iap`:
+
+```bash
+export BASTION_VM=<your-vm> BASTION_ZONE=us-central1-a BASTION_PROJECT=<proj>
+```
+
+Set `BASTION_SSH_HOST` (and optionally `BASTION_SSH_USER`) instead to use a
+plain `ssh`/`scp` transport, bypassing the IAP tunnel.
+
+> [!IMPORTANT]
+> **Get the bastion's identity from Terraform — don't assume the defaults**
+> (`bench-bastion` / `us-central1-a` / gcloud's active project). The bastion is
+> provisioned from `tf/modules/bastion`, which exports an `iap_ssh_command`
+> output — `tofu output iap_ssh_command` in the root module where you
+> instantiated it prints the exact
+> `gcloud compute ssh <name> --zone <zone> --project <project>` form. Set
+> `BASTION_VM` / `BASTION_ZONE` / `BASTION_PROJECT` from that, and verify the
+> host is up before blaming credentials for a connection failure. Use
+> `REMOTE_DIR=devops-bench-<label>` to avoid clobbering another session's
+> checkout on the VM.
+
+---
+
+## Authentication
+
+Pick one mode (recommend **Vertex/ADC** — no key handling, and the only mode
+that stays portable across the isolated per-run state dirs parallel runs
+create):
+
+- **Vertex / ADC** — set `BENCH_VERTEX=1` and **no API keys**. The runner unsets
+  every API key `~/secrets.env` exported (`AGENT_API_KEY`, `GEMINI_API_KEY`,
+  `GOOGLE_API_KEY`, `JUDGE_API_KEY`, `GOOGLE_GENAI_API_KEY`) so agents and
+  judges fall back to the runner host's ADC (on the bastion, the VM service
+  account), then points everything at Vertex: `GOOGLE_GENAI_USE_VERTEXAI=true`,
+  `GOOGLE_CLOUD_PROJECT` / `GCP_PROJECT_ID`, and location **`global`** via
+  `GOOGLE_CLOUD_LOCATION` / `GCP_VERTEX_LOCATION`. It also exports the portable
+  OpenClaw ADC marker `GOOGLE_CLOUD_API_KEY=gcp-vertex-credentials` (see the
+  router in [known_issues.md](../../docs/appendix/known_issues.md)). For the
+  legacy oc arm additionally set `AGENT_PROVIDER=google-vertex` so the model id
+  becomes `google-vertex/<model>`.
+- **API keys** — the runner sources `~/secrets.env` on the runner host when
+  present (`set -a`, so plain assignments export). Put the keys your providers
+  need there — `AGENT_API_KEY` for the agent contract, `GEMINI_API_KEY` /
+  `GOOGLE_API_KEY` for the google model provider (which also serves the judge).
+  Check names only — **never print key values**; ask the operator for a missing
+  key rather than guessing.
+
+**Judge.** The wrapper defaults `JUDGE_PROVIDER=google` and
+`JUDGE_MODEL=gemini-3.1-pro`. On Vertex, keep the location `global` and use a
+`-preview` model id — set `JUDGE_MODEL=gemini-3.1-pro-preview` — because
+`gemini-3.x` previews 404 on regional endpoints (see the `404 Publisher model`
+row in [known_issues.md](../../docs/appendix/known_issues.md)). Note the two
+location variables are read by different layers: `GCP_VERTEX_LOCATION` by the
+models layer (`devops_bench/models/gemini.py`, `models/claude.py`),
+`GOOGLE_CLOUD_LOCATION` by the antigravity agent.
+
+---
+
+## Clean-environment pre-flight
+
+Stale per-run state and orphaned cloud resources are the most common cause of a
+"fresh" run failing instantly. Before **every** launch or retry, work the
+**"Before any retry" checklist** in
+[`known_issues.md`](../../docs/appendix/known_issues.md) — don't re-derive it
+here, and keep it **scoped to the run you are retrying**: runs execute
+concurrently on a shared host, so unscoped wipes (`rm -rf
+/tmp/devops-bench-runs/*`, deleting every kind cluster, a bare `pkill`) take out
+sibling runs.
+
+For orphaned **cloud** resources (clusters, `gke-nodes-*` service accounts,
+leaked secrets), use the
+[`cleanup-orphaned-resources`](../skills/cleanup-orphaned-resources/SKILL.md)
+skill rather than re-listing them inline.
+
+---
+
+## Launching (detached)
+
+`scripts/bastion/run_matrix.sh` (refactored arm: Task × Model × AgentConfig)
+runs the matrix **detached under `nohup`** (staged as
+`~/.matrix-runner-<stamp>.sh`, log at `~/matrix-runs/<stamp>.out`), polls for
+the `~/matrix-runs/<stamp>/.done` marker, and pulls results in remote mode. It
+prints a `STAMP` (`<YYYYmmdd_HHMMSS>-<pid>`) on launch — record
+`RESUME_STAMP=<stamp>` in durable state; it is your handle for monitoring,
+retry, and re-attach. If your poller dies the detached run keeps going —
+re-attach with `RESUME_STAMP=<stamp>` and the same command.
+
+`run_matrix_legacy.sh` (legacy arm: Task × Model, oc-only) shares the same
+wrapper mechanics, but drives the legacy evaluator entrypoint
+(`pkg/evaluator/evaluate.py`), which is **not part of this repository** — it
+only works if you place a legacy evaluator checkout at `pkg/` yourself
+(`sync-to-bastion.sh` ships that path when present and silently skips it
+otherwise). Its MCP/skills capabilities come from the global oc config, set
+once with `scripts/bastion/configure-oc.sh`.
+
+**Always `DRY_RUN=1` first** — it prints the expanded matrix + per-combo env
+without provisioning (and without requiring `PROJECT_ID`), so a typo in
+`MATRIX_MODELS` costs nothing instead of clusters.
+
+Example (Vertex, refactored arm; prefix `BENCH_REMOTE=1` + the `BASTION_*` env
+for remote):
+
+```bash
+PROJECT_ID=<proj> BENCH_VERTEX=1 \
+JUDGE_MODEL=gemini-3.1-pro-preview \
+MAX_PARALLEL=3 MATRIX_TASKS="tasks/common/opa-remediation/task.yaml" \
+MATRIX_MODELS="gemini-3.1-pro-preview gemini-3.5-flash" \
+MATRIX_AGENT_CONFIGS="gcli+mcp+skills oc+mcp+skills" \
+RESULTS_DIR="results/<label>" \
+  scripts/bastion/run_matrix.sh
+```
+
+To run **both arms in parallel** (when you have the legacy evaluator on hand):
+sync once, then start each wrapper with `SKIP_SYNC=1` — the stamps carry the
+wrapper's PID, so parallel launches can't collide on state.
+
+---
+
+## Run identity
+
+Under `--parallel` (the matrix always sets it via `BENCH_PARALLEL=true`), each
+run is isolated by `RunEnv` (`devops_bench/core/run_env.py`):
+
+- **Run id** — `RUN_ID` env if set (the matrix sets it to the combo's `rid`),
+  else `<YYYYmmdd-HHMMSS>-<pid>`.
+- **Per-run state** — `/tmp/devops-bench-runs/<RUN_ID>/` (override the root with
+  `BENCH_RUN_STATE_ROOT`): kubeconfig, gcloud config, tofu data dir.
+- **Cluster name** — `<token>-<CLUSTER_NAME>`, where the token is `c` + 7 hex
+  chars derived from the run id. Deterministic: **the same combo always maps to
+  the same cluster name**, which is why two runs of the *same* combo must never
+  overlap. The GKE node SA is `gke-nodes-<slug:9>-<md5(cluster_name):6>`
+  (`tf/modules/cluster/gke/main.tf`).
+
+---
+
+## Matrix knobs
+
+| Variable | Meaning |
+|---|---|
+| `MATRIX_TASKS` | Space-separated `task.yaml` paths, or `ALL` to enumerate every task. Default `tasks/common/opa-remediation/task.yaml`. |
+| `MATRIX_MODELS` | Space-separated model ids. Default `gemini-3.1-pro`. |
+| `MATRIX_AGENT_CONFIGS` | Refactored arm only. Each `oc\|gcli` `[+mcp][+skills]` (e.g. `gcli+mcp+skills`). Default `oc+mcp+skills`. |
+| `MAX_PARALLEL` | Max combos running at once (default `3`). Each combo is its own cluster — mind quota. |
+| `PROJECT_ID` | Cloud project for the run. **Required** unless `DRY_RUN=1`. |
+| `CLUSTER_NAME` | Base cluster name (default `eval`); per-run names are derived from it (see *Run identity*). |
+| `AGENT_TIMEOUT_SEC` | Per-agent timeout (default `1200` in the matrix; the harness's own default of 600s is too low for infra-bearing tasks). |
+| `BENCH_VERTEX` | Run agents + judges on Vertex via the runner host's ADC (no API keys). |
+| `BENCH_REMOTE` | Run on the bastion over ssh; unset runs every combo locally. |
+| `SKIP_SYNC` | Skip the working-tree sync to the bastion (after one real sync). |
+| `BASTION_VM` / `BASTION_ZONE` / `BASTION_PROJECT` | Bastion identity for the IAP transport (defaults: `bench-bastion` / `us-central1-a` / gcloud's active project). |
+| `BASTION_SSH_HOST` / `BASTION_SSH_USER` | Direct-ssh transport, bypassing the IAP tunnel. |
+| `REMOTE_DIR` | Checkout dir on the VM (default `devops-bench`). Set a per-run value to avoid clobbering another session's checkout. |
+| `RESULTS_DIR` | Where pulled results land in remote mode (default `results/matrix`). |
+| `MCP_SERVER_BIN` | MCP server binary for `+mcp` combos (default `/usr/local/bin/gke-mcp`, where the bastion startup script installs it). |
+| `SKILLS_PATHS` | Skills source for `+skills` combos (default `$HOME/mcp-skills/skills`, cloned by `vm-setup.sh`). |
+| `DRY_RUN` | Print the expanded matrix + per-combo env without provisioning. |
+| `RESUME_STAMP` | Skip launching; re-poll + pull an existing run by its stamp. |
+| `MATRIX_POLL_TIMEOUT_SEC` | Give up polling after this long (default `86400`); the detached run itself is unaffected. |
+
+---
+
+## Where results land
+
+Per combo on the runner host: `~/matrix-runs/<stamp>/<rid>/` with `status`
+(`exit=<rc>` once finished), `run.log`, and a `run_<ts>_<rid>/` subdirectory
+holding `results.json` (the judged per-criterion scores), `rows.json`, and
+`manifest.json`. In remote mode the whole stamped dir is pulled back to
+`RESULTS_DIR/<stamp>/`. A bare CLI run (`python -m devops_bench <task>`)
+instead writes a single timestamped `run_<ts>_…/` directory under
+`RESULTS_ROOT` (default `results/`) — suffixed with the run id when one is set,
+else with sub-second precision.
+
+For how scoring works and how to read it, see
+[`../../docs/components/metrics.md`](../../docs/components/metrics.md).

--- a/.agents/references/running-evals.md
+++ b/.agents/references/running-evals.md
@@ -184,7 +184,7 @@ run is isolated by `RunEnv` (`devops_bench/core/run_env.py`):
 | `REMOTE_DIR` | Checkout dir on the VM (default `devops-bench`). Set a per-run value to avoid clobbering another session's checkout. |
 | `RESULTS_DIR` | Where pulled results land in remote mode (default `results/matrix`). |
 | `MCP_SERVER_BIN` | MCP server binary for `+mcp` combos (default `/usr/local/bin/gke-mcp`, where the bastion startup script installs it). |
-| `SKILLS_PATHS` | Skills source for `+skills` combos (default `$HOME/mcp-skills/skills`, cloned by `vm-setup.sh`). |
+| `SKILLS_PATHS` | Skills source for `+skills` combos (default `$HOME/mcp-skills/skills`, cloned by `vm-setup.sh`). Currently empty on a fresh bastion: upstream gke-mcp removed its `skills/` directory, so the clone yields no skills ([#117](https://github.com/kubernetes-sigs/devops-bench/issues/117)). |
 | `DRY_RUN` | Print the expanded matrix + per-combo env without provisioning. |
 | `RESUME_STAMP` | Skip launching; re-poll + pull an existing run by its stamp. |
 | `MATRIX_POLL_TIMEOUT_SEC` | Give up polling after this long (default `86400`); the detached run itself is unaffected. |

--- a/.agents/references/running-evals.md
+++ b/.agents/references/running-evals.md
@@ -151,7 +151,10 @@ Under `--parallel` (the matrix always sets it via `BENCH_PARALLEL=true`), each
 run is isolated by `RunEnv` (`devops_bench/core/run_env.py`):
 
 - **Run id** — `RUN_ID` env if set (the matrix sets it to the combo's `rid`),
-  else `<YYYYmmdd-HHMMSS>-<pid>`.
+  else `<YYYYmmdd-HHMMSS>-<pid>`. The matrix derives `rid` from the task's
+  **directory basename**, so never select two tasks whose directories share a
+  basename in one matrix — they would collide on run id, cluster name, and
+  output dir.
 - **Per-run state** — `/tmp/devops-bench-runs/<RUN_ID>/` (override the root with
   `BENCH_RUN_STATE_ROOT`): kubeconfig, gcloud config, tofu data dir.
 - **Cluster name** — `<token>-<CLUSTER_NAME>`, where the token is `c` + 7 hex

--- a/.agents/references/running-evals.md
+++ b/.agents/references/running-evals.md
@@ -67,9 +67,7 @@ Pick one mode:
   provider env the model backend needs — project, location (**`global`**), and
   the portable ADC marker (see the router in
   [known_issues.md](../../docs/appendix/known_issues.md)); the exact variable
-  names live in the wrapper. For the legacy oc arm additionally set
-  `AGENT_PROVIDER=google-vertex` so the model id becomes
-  `google-vertex/<model>`.
+  names live in the wrapper.
 - **API keys** — the runner sources `~/secrets.env` on the runner host when
   present (`set -a`, so plain assignments export). Put the keys your providers
   need there — `AGENT_API_KEY` for the agent contract, `GEMINI_API_KEY` /
@@ -108,7 +106,7 @@ skill rather than re-listing them inline.
 
 ## Launching (detached)
 
-`scripts/bastion/run_matrix.sh` (refactored arm: Task × Model × AgentConfig)
+`scripts/bastion/run_matrix.sh` (Task × Model × AgentConfig)
 runs the matrix **detached under `nohup`** (staged as
 `~/.matrix-runner-<stamp>.sh`, log at `~/matrix-runs/<stamp>.out`), polls for
 the `~/matrix-runs/<stamp>/.done` marker, and pulls results in remote mode. It
@@ -117,20 +115,12 @@ prints a `STAMP` (`<YYYYmmdd_HHMMSS>-<pid>`) on launch — record
 retry, and re-attach. If your poller dies the detached run keeps going —
 re-attach with `RESUME_STAMP=<stamp>` and the same command.
 
-`run_matrix_legacy.sh` (legacy arm: Task × Model, oc-only) shares the same
-wrapper mechanics, but drives the legacy evaluator entrypoint
-(`pkg/evaluator/evaluate.py`), which is **not part of this repository** — it
-only works if you place a legacy evaluator checkout at `pkg/` yourself
-(`sync-to-bastion.sh` ships that path when present and silently skips it
-otherwise). Its MCP/skills capabilities come from the global oc config, set
-once with `scripts/bastion/configure-oc.sh`.
-
 **Always `DRY_RUN=1` first** — it prints the expanded matrix + per-combo env
 without provisioning (and without requiring `PROJECT_ID`), so a typo in
 `MATRIX_MODELS` costs nothing instead of clusters.
 
-Example (ambient credentials, refactored arm; prefix `BENCH_REMOTE=1` + the
-`BASTION_*` env for remote):
+Example (ambient credentials; prefix `BENCH_REMOTE=1` + the `BASTION_*` env
+for remote):
 
 ```bash
 PROJECT_ID=<proj> BENCH_VERTEX=1 \
@@ -141,10 +131,6 @@ MATRIX_AGENT_CONFIGS="gcli+mcp+skills oc+mcp+skills" \
 RESULTS_DIR="results/<label>" \
   scripts/bastion/run_matrix.sh
 ```
-
-To run **both arms in parallel** (when you have the legacy evaluator on hand):
-sync once, then start each wrapper with `SKIP_SYNC=1` — the stamps carry the
-wrapper's PID, so parallel launches can't collide on state.
 
 ---
 
@@ -174,7 +160,7 @@ run is isolated by `RunEnv` (`devops_bench/core/run_env.py`):
 |---|---|
 | `MATRIX_TASKS` | Space-separated `task.yaml` paths, or `ALL` to enumerate every task. Default `tasks/common/opa-remediation/task.yaml`. |
 | `MATRIX_MODELS` | Space-separated model ids. Default `gemini-3.1-pro`. |
-| `MATRIX_AGENT_CONFIGS` | Refactored arm only. Each `oc\|gcli` `[+mcp][+skills]` (e.g. `gcli+mcp+skills`). Default `oc+mcp+skills`. |
+| `MATRIX_AGENT_CONFIGS` | Each `oc\|gcli` `[+mcp][+skills]` (e.g. `gcli+mcp+skills`). Default `oc+mcp+skills`. |
 | `MAX_PARALLEL` | Max combos running at once (default `3`). Each combo is its own cluster — mind quota. |
 | `PROJECT_ID` | Cloud project for the run. **Required** unless `DRY_RUN=1`. |
 | `CLUSTER_NAME` | Base cluster name (default `eval`); per-run names are derived from it (see *Run identity*). |

--- a/.agents/references/running-evals.md
+++ b/.agents/references/running-evals.md
@@ -76,13 +76,10 @@ Pick one mode:
   key rather than guessing.
 
 **Judge.** The wrapper defaults `JUDGE_PROVIDER=google` and
-`JUDGE_MODEL=gemini-3.1-pro`. On Vertex, keep the location `global` and use a
-`-preview` model id — set `JUDGE_MODEL=gemini-3.1-pro-preview` — because
-`gemini-3.x` previews 404 on regional endpoints (see the `404 Publisher model`
-row in [known_issues.md](../../docs/appendix/known_issues.md)). Note the
-wrapper exports the location under two variables read by different layers:
-`GCP_VERTEX_LOCATION` by the models layer (`devops_bench/models/gemini.py`,
-`models/claude.py`), `GOOGLE_CLOUD_LOCATION` by the antigravity agent.
+`JUDGE_MODEL=gemini-3.1-pro`. If judge calls return 404 or silently fail, work the
+`404 Publisher model` row in
+[known_issues.md](../../docs/appendix/known_issues.md) — it carries the full
+fix (the location and model-id requirements).
 
 ---
 
@@ -111,9 +108,11 @@ runs the matrix **detached under `nohup`** (staged as
 `~/.matrix-runner-<stamp>.sh`, log at `~/matrix-runs/<stamp>.out`), polls for
 the `~/matrix-runs/<stamp>/.done` marker, and pulls results in remote mode. It
 prints a `STAMP` (`<YYYYmmdd_HHMMSS>-<pid>`) on launch — record
-`RESUME_STAMP=<stamp>` in durable state; it is your handle for monitoring,
-retry, and re-attach. If your poller dies the detached run keeps going —
-re-attach with `RESUME_STAMP=<stamp>` and the same command.
+`RESUME_STAMP=<stamp>` in durable state; it is your handle for monitoring and
+re-attach. If your poller dies the detached run keeps going — re-attach with
+`RESUME_STAMP=<stamp>` and the same command. A **retry is a new launch**: run
+it *without* `RESUME_STAMP` (set, the wrapper attaches to the old run instead
+of launching), then record the new `STAMP` as the active attempt.
 
 **Always `DRY_RUN=1` first** — it prints the expanded matrix + per-combo env
 without provisioning (and without requiring `PROJECT_ID`), so a typo in

--- a/.agents/references/running-evals.md
+++ b/.agents/references/running-evals.md
@@ -186,8 +186,8 @@ run is isolated by `RunEnv` (`devops_bench/core/run_env.py`):
 | `BASTION_SSH_HOST` / `BASTION_SSH_USER` | Plain-ssh transport for any directly reachable VM (bypasses the cloud tunnel). |
 | `REMOTE_DIR` | Checkout dir on the VM (default `devops-bench`). Set a per-run value to avoid clobbering another session's checkout. |
 | `RESULTS_DIR` | Where pulled results land in remote mode (default `results/matrix`). |
-| `MCP_SERVER_BIN` | Cluster-aware MCP server binary (e.g. `k8s-mcp`) for `+mcp` combos. Default `/usr/local/bin/gke-mcp` — the specific binary the bastion setup script installs. |
-| `SKILLS_PATHS` | Skills source for `+skills` combos (default `$HOME/mcp-skills/skills`, cloned by `vm-setup.sh`). Currently empty on a fresh bastion: upstream gke-mcp removed its `skills/` directory, so the clone yields no skills ([#117](https://github.com/kubernetes-sigs/devops-bench/issues/117)). |
+| `MCP_SERVER_BIN` | Cluster-aware MCP server binary for `+mcp` combos (default: none — `+mcp` combos need it set; e.g. a provider-specific server such as `gke-mcp` when the cluster provider is GKE). |
+| `SKILLS_PATHS` | Skills directories for `+skills` combos (default: none — no skills are loaded unless set). |
 | `DRY_RUN` | Print the expanded matrix + per-combo env without provisioning. |
 | `RESUME_STAMP` | Skip launching; re-poll + pull an existing run by its stamp. |
 | `MATRIX_POLL_TIMEOUT_SEC` | Give up polling after this long (default `86400`); the detached run itself is unaffected. |

--- a/.agents/references/running-evals.md
+++ b/.agents/references/running-evals.md
@@ -160,7 +160,7 @@ run is isolated by `RunEnv` (`devops_bench/core/run_env.py`):
 |---|---|
 | `MATRIX_TASKS` | Space-separated `task.yaml` paths, or `ALL` to enumerate every task. Default `tasks/common/opa-remediation/task.yaml`. |
 | `MATRIX_MODELS` | Space-separated model ids. Default `gemini-3.1-pro`. |
-| `MATRIX_AGENT_CONFIGS` | Each `oc\|gcli` `[+mcp][+skills]` (e.g. `gcli+mcp+skills`). Default `oc+mcp+skills`. |
+| `MATRIX_AGENT_CONFIGS` | Each `oc\|gcli` `[+mcp][+skills]`, where `oc` is the config token for the OpenClaw agent and `gcli` for the Gemini CLI agent (e.g. `gcli+mcp+skills`). Default `oc+mcp+skills`. |
 | `MAX_PARALLEL` | Max combos running at once (default `3`). Each combo is its own cluster — mind quota. |
 | `PROJECT_ID` | Cloud project for the run. **Required** unless `DRY_RUN=1`. |
 | `CLUSTER_NAME` | Base cluster name (default `eval`); per-run names are derived from it (see *Run identity*). |

--- a/.agents/references/running-evals.md
+++ b/.agents/references/running-evals.md
@@ -21,27 +21,32 @@ file does not duplicate either.
 The matrix runs on the **runner host** — the machine where you invoke the
 wrapper. **Local is the default** (`nohup` on this host, no ssh/sync, outputs in
 `~/matrix-runs/<stamp>`). Set **`BENCH_REMOTE=1`** to sync the working tree to
-the **bastion** (a GCP VM, `tf/modules/bastion`) and run there over ssh, pulling
-results back. The snippets below show the bare command; in remote mode they run
-under the wrapper's ssh transport, so the same paths (`~/secrets.env`,
+the **bastion** — a remote runner VM, reachable over standard SSH or a cloud
+provider's tunneling CLI — and run there over ssh, pulling results back. The
+snippets below show the bare command; in remote mode they run under the
+wrapper's ssh transport, so the same paths (`~/secrets.env`,
 `~/matrix-runs/<stamp>`) live on the VM.
 
-**Bastion connection env (remote mode only).** By default the wrapper connects
-with `gcloud compute ssh --tunnel-through-iap`:
+**Bastion connection env (remote mode only).** The wrapper supports two
+transports:
 
-```bash
-export BASTION_VM=<your-vm> BASTION_ZONE=us-central1-a BASTION_PROJECT=<proj>
-```
+- **Plain `ssh`/`scp`** — any VM you can reach directly. Set
+  `BASTION_SSH_HOST` (and optionally `BASTION_SSH_USER`).
+- **Cloud tunnel CLI** — when `BASTION_SSH_HOST` is unset, the wrapper falls
+  back to the provider tunnel matching a VM provisioned by the repo's
+  `tf/modules/bastion` (that module targets GCP, so the tunnel is
+  `gcloud compute ssh --tunnel-through-iap`):
 
-Set `BASTION_SSH_HOST` (and optionally `BASTION_SSH_USER`) instead to use a
-plain `ssh`/`scp` transport, bypassing the IAP tunnel.
+  ```bash
+  export BASTION_VM=<your-vm> BASTION_ZONE=us-central1-a BASTION_PROJECT=<proj>
+  ```
 
 > [!IMPORTANT]
-> **Get the bastion's identity from Terraform — don't assume the defaults**
-> (`bench-bastion` / `us-central1-a` / gcloud's active project). The bastion is
-> provisioned from `tf/modules/bastion`, which exports an `iap_ssh_command`
-> output — `tofu output iap_ssh_command` in the root module where you
-> instantiated it prints the exact
+> **On the tunnel transport, get the bastion's identity from Terraform — don't
+> assume the defaults** (`bench-bastion` / `us-central1-a` / the CLI's active
+> project). The bastion is provisioned from `tf/modules/bastion`, which exports
+> an `iap_ssh_command` output — `tofu output iap_ssh_command` in the root
+> module where you instantiated it prints the exact
 > `gcloud compute ssh <name> --zone <zone> --project <project>` form. Set
 > `BASTION_VM` / `BASTION_ZONE` / `BASTION_PROJECT` from that, and verify the
 > host is up before blaming credentials for a connection failure. Use
@@ -52,11 +57,13 @@ plain `ssh`/`scp` transport, bypassing the IAP tunnel.
 
 ## Authentication
 
-Pick one mode (recommend **Vertex/ADC** — no key handling, and the only mode
-that stays portable across the isolated per-run state dirs parallel runs
-create):
+Pick one mode:
 
-- **Vertex / ADC** — set `BENCH_VERTEX=1` and **no API keys**. The runner unsets
+- **Cloud IAM / instance-role credentials** — the runner host's ambient
+  credentials; no key handling, and the only mode that stays portable across
+  the isolated per-run state dirs parallel runs create. The wrapper currently
+  implements this mode for Vertex via application-default credentials (ADC):
+  set `BENCH_VERTEX=1` and **no API keys**. The runner unsets
   every API key `~/secrets.env` exported (`AGENT_API_KEY`, `GEMINI_API_KEY`,
   `GOOGLE_API_KEY`, `JUDGE_API_KEY`, `GOOGLE_GENAI_API_KEY`) so agents and
   judges fall back to the runner host's ADC (on the bastion, the VM service
@@ -176,11 +183,11 @@ run is isolated by `RunEnv` (`devops_bench/core/run_env.py`):
 | `PROJECT_ID` | Cloud project for the run. **Required** unless `DRY_RUN=1`. |
 | `CLUSTER_NAME` | Base cluster name (default `eval`); per-run names are derived from it (see *Run identity*). |
 | `AGENT_TIMEOUT_SEC` | Per-agent timeout (default `1200` in the matrix; the harness's own default of 600s is too low for infra-bearing tasks). |
-| `BENCH_VERTEX` | Run agents + judges on Vertex via the runner host's ADC (no API keys). |
+| `BENCH_VERTEX` | Run agents + judges on the runner host's ambient cloud credentials instead of API keys (currently implemented for Vertex/ADC). |
 | `BENCH_REMOTE` | Run on the bastion over ssh; unset runs every combo locally. |
 | `SKIP_SYNC` | Skip the working-tree sync to the bastion (after one real sync). |
-| `BASTION_VM` / `BASTION_ZONE` / `BASTION_PROJECT` | Bastion identity for the IAP transport (defaults: `bench-bastion` / `us-central1-a` / gcloud's active project). |
-| `BASTION_SSH_HOST` / `BASTION_SSH_USER` | Direct-ssh transport, bypassing the IAP tunnel. |
+| `BASTION_VM` / `BASTION_ZONE` / `BASTION_PROJECT` | Bastion identity for the cloud tunnel transport (GCP IAP; defaults: `bench-bastion` / `us-central1-a` / the CLI's active project). |
+| `BASTION_SSH_HOST` / `BASTION_SSH_USER` | Plain-ssh transport for any directly reachable VM (bypasses the cloud tunnel). |
 | `REMOTE_DIR` | Checkout dir on the VM (default `devops-bench`). Set a per-run value to avoid clobbering another session's checkout. |
 | `RESULTS_DIR` | Where pulled results land in remote mode (default `results/matrix`). |
 | `MCP_SERVER_BIN` | MCP server binary for `+mcp` combos (default `/usr/local/bin/gke-mcp`, where the bastion startup script installs it). |

--- a/.agents/references/running-evals.md
+++ b/.agents/references/running-evals.md
@@ -37,13 +37,13 @@ transports:
   `tf/modules/bastion` module targets, matching the VM it provisions:
 
   ```bash
-  export BASTION_VM=<your-vm> BASTION_ZONE=us-central1-a BASTION_PROJECT=<proj>
+  export BASTION_VM=<your-vm> BASTION_ZONE=<zone> BASTION_PROJECT=<proj>
   ```
 
 > [!IMPORTANT]
 > **On the tunnel transport, get the bastion's identity from Terraform — don't
-> assume the defaults** (`bench-bastion` / `us-central1-a` / the CLI's active
-> project). The bastion is provisioned from `tf/modules/bastion`, which exports
+> assume the wrapper's built-in defaults.** The bastion is provisioned from
+> `tf/modules/bastion`, which exports
 > an `iap_ssh_command` output — `tofu output iap_ssh_command` in the root
 > module where you instantiated it prints the exact connect command with the
 > real name, zone, and project. Set
@@ -168,7 +168,7 @@ run is isolated by `RunEnv` (`devops_bench/core/run_env.py`):
 | `BENCH_VERTEX` | Run agents + judges on the runner host's ambient cloud credentials instead of API keys (currently implemented for Vertex/ADC). |
 | `BENCH_REMOTE` | Run on the bastion over ssh; unset runs every combo locally. |
 | `SKIP_SYNC` | Skip the working-tree sync to the bastion (after one real sync). |
-| `BASTION_VM` / `BASTION_ZONE` / `BASTION_PROJECT` | Bastion identity for the cloud tunnel transport (defaults: `bench-bastion` / `us-central1-a` / the CLI's active project). |
+| `BASTION_VM` / `BASTION_ZONE` / `BASTION_PROJECT` | Bastion identity for the cloud tunnel transport. Don't rely on the wrapper's built-in defaults — set all three from the Terraform output (see *Choosing where to run*). |
 | `BASTION_SSH_HOST` / `BASTION_SSH_USER` | Plain-ssh transport for any directly reachable VM (bypasses the cloud tunnel). |
 | `REMOTE_DIR` | Checkout dir on the VM (default `devops-bench`). Set a per-run value to avoid clobbering another session's checkout. |
 | `RESULTS_DIR` | Where pulled results land in remote mode (default `results/matrix`). |

--- a/.agents/references/running-evals.md
+++ b/.agents/references/running-evals.md
@@ -65,7 +65,7 @@ Pick one mode:
   exported so agents and judges fall back to the runner host's ambient
   credentials (on the bastion, the VM's service account), then exports the
   provider env the model backend needs — project, location (**`global`**), and
-  the portable ADC marker (see the router in
+  the portable ambient-credential marker (see the router in
   [known_issues.md](../../docs/appendix/known_issues.md)); the exact variable
   names live in the wrapper.
 - **API keys** — the runner sources `~/secrets.env` on the runner host when
@@ -76,8 +76,10 @@ Pick one mode:
   key rather than guessing.
 
 **Judge.** The wrapper defaults `JUDGE_PROVIDER=google` and
-`JUDGE_MODEL=gemini-3.1-pro`. If judge calls return 404 or silently fail, work the
-`404 Publisher model` row in
+`JUDGE_MODEL=gemini-3.1-pro`; on the ambient-credentials backend the default id
+must be overridden to its `-preview` variant
+(`JUDGE_MODEL=gemini-3.1-pro-preview`). If judge calls return 404 or silently
+fail, work the `404 Publisher model` row in
 [known_issues.md](../../docs/appendix/known_issues.md) — it carries the full
 fix (the location and model-id requirements).
 
@@ -94,8 +96,8 @@ concurrently on a shared host, so unscoped wipes (`rm -rf
 /tmp/devops-bench-runs/*`, deleting every kind cluster, a bare `pkill`) take out
 sibling runs.
 
-For orphaned **cloud** resources (clusters, `gke-nodes-*` service accounts,
-leaked secrets), use the
+For orphaned **cloud** resources (clusters, node service accounts (e.g.
+`gke-nodes-*`), leaked secrets), use the
 [`cleanup-orphaned-resources`](../skills/cleanup-orphaned-resources/SKILL.md)
 skill rather than re-listing them inline.
 
@@ -118,8 +120,21 @@ of launching), then record the new `STAMP` as the active attempt.
 without provisioning (and without requiring `PROJECT_ID`), so a typo in
 `MATRIX_MODELS` costs nothing instead of clusters.
 
-Example (ambient credentials; prefix `BENCH_REMOTE=1` + the `BASTION_*` env
-for remote):
+Example (vendor-neutral: API keys from `~/secrets.env`, local runner; the
+default task provisions on kind, so no cloud cluster is spent):
+
+```bash
+PROJECT_ID=<proj> \
+MAX_PARALLEL=3 MATRIX_TASKS="tasks/common/opa-remediation/task.yaml" \
+MATRIX_MODELS="<model-id> <model-id-2>" \
+MATRIX_AGENT_CONFIGS="oc+mcp+skills" \
+RESULTS_DIR="results/<label>" \
+  scripts/bastion/run_matrix.sh
+```
+
+Provider-specific example (ambient credentials on the Vertex model backend;
+other backends can be added analogously; prefix `BENCH_REMOTE=1` + the
+`BASTION_*` env for remote):
 
 ```bash
 PROJECT_ID=<proj> BENCH_VERTEX=1 \
@@ -148,7 +163,7 @@ run is isolated by `RunEnv` (`devops_bench/core/run_env.py`):
 - **Cluster name** — `<token>-<CLUSTER_NAME>`, where the token is `c` + 7 hex
   chars derived from the run id. Deterministic: **the same combo always maps to
   the same cluster name**, which is why two runs of the *same* combo must never
-  overlap. The cluster module's node SA is
+  overlap. The cluster module names its node service account
   `gke-nodes-<slug:9>-<md5(cluster_name):6>` (`tf/modules/cluster/gke/main.tf`).
 
 ---
@@ -171,7 +186,7 @@ run is isolated by `RunEnv` (`devops_bench/core/run_env.py`):
 | `BASTION_SSH_HOST` / `BASTION_SSH_USER` | Plain-ssh transport for any directly reachable VM (bypasses the cloud tunnel). |
 | `REMOTE_DIR` | Checkout dir on the VM (default `devops-bench`). Set a per-run value to avoid clobbering another session's checkout. |
 | `RESULTS_DIR` | Where pulled results land in remote mode (default `results/matrix`). |
-| `MCP_SERVER_BIN` | MCP server binary for `+mcp` combos (default `/usr/local/bin/gke-mcp`, where the bastion startup script installs it). |
+| `MCP_SERVER_BIN` | Cluster-aware MCP server binary (e.g. `k8s-mcp`) for `+mcp` combos. Default `/usr/local/bin/gke-mcp` — the specific binary the bastion setup script installs. |
 | `SKILLS_PATHS` | Skills source for `+skills` combos (default `$HOME/mcp-skills/skills`, cloned by `vm-setup.sh`). Currently empty on a fresh bastion: upstream gke-mcp removed its `skills/` directory, so the clone yields no skills ([#117](https://github.com/kubernetes-sigs/devops-bench/issues/117)). |
 | `DRY_RUN` | Print the expanded matrix + per-combo env without provisioning. |
 | `RESUME_STAMP` | Skip launching; re-poll + pull an existing run by its stamp. |

--- a/.agents/references/unlimited-mode.md
+++ b/.agents/references/unlimited-mode.md
@@ -22,11 +22,11 @@ Match the failure against the router in
 then take exactly one action. Fixing the wrong class corrupts the eval, so when
 unsure, prefer recording over fixing.
 
-- **Retry** (infra flake — e.g. Vertex `429 RESOURCE_EXHAUSTED`, a transient ssh
+- **Retry** (infra flake — e.g. a model-provider `429 RESOURCE_EXHAUSTED`, a transient ssh
   drop, a transient API/quota error): re-run the combo after the
   clean-environment pre-flight. No code change.
 - **Fix + retry** (config / auth / host setup — e.g. a missing API enablement,
-  the Vertex ADC marker, the inotify limit, folder-trust): apply the router's
+  the ADC marker, the inotify limit, folder-trust): apply the router's
   documented fix, then retry. These are environment fixes, not eval-logic edits
   — but most of them mutate **shared** host/project/global state that a
   worktree does not isolate, so get operator approval (or pause sibling combos)

--- a/.agents/references/unlimited-mode.md
+++ b/.agents/references/unlimited-mode.md
@@ -27,7 +27,11 @@ unsure, prefer recording over fixing.
   clean-environment pre-flight. No code change.
 - **Fix + retry** (config / auth / host setup — e.g. a missing API enablement,
   the Vertex ADC marker, the inotify limit, folder-trust): apply the router's
-  documented fix, then retry. These are environment fixes, not eval-logic edits.
+  documented fix, then retry. These are environment fixes, not eval-logic edits
+  — but most of them mutate **shared** host/project/global state that a
+  worktree does not isolate, so get operator approval (or pause sibling combos)
+  before applying one mid-matrix; apply unattended only when the fix is scoped
+  to this worktree/run.
 - **Escalate / stop** (a real **model-capability** low score — the agent ran a
   clean trajectory and just did the task badly — or a **task-logic / rubric bug**
   the loop can't safely edit): surface it as a distinct outcome. Do **not**
@@ -49,6 +53,11 @@ unsure, prefer recording over fixing.
 5. **Re-sync** (remote only) and **restart only the failed combo(s)** as fresh
    single-combo runs (new stamp), after cleaning their leaked cloud resources.
 6. **Continue** the monitoring loop over the remaining + restarted combos.
+   Restarted combos run on a changed revision/config — record the revision and
+   environment on every combo's attempts, and report post-fix attempts as a
+   **separate batch** from the original matrix (or rerun all affected combos);
+   never silently combine them, or the comparison misattributes the fix to the
+   model.
 
 Keep commits local and scoped; do not push or merge shared branches unless the
 operator said so — surface the branch/diff for review instead.

--- a/.agents/references/unlimited-mode.md
+++ b/.agents/references/unlimited-mode.md
@@ -1,0 +1,103 @@
+# Unlimited / self-healing mode
+
+An **opt-in** loop that turns a recoverable failure into: classify → act
+(retry / fix+retry / escalate) → continue, until the whole run reaches a
+terminal-acceptable state or a stop condition trips. Load this **only** when the
+operator explicitly asks for it ("unlimited", "keep going until it finishes",
+"auto-fix and restart", "self-healing"). It builds on
+[`monitoring-and-recovery.md`](./monitoring-and-recovery.md) — reuse that loop,
+recovery, and heartbeat; this file only adds the decide-and-restart behavior.
+
+This reference is **agent-agnostic**. The capabilities it needs (isolated
+worktree, durable state file, sub-agents, scheduled wakeups) map to concrete
+tools in [`harness-capabilities.md`](./harness-capabilities.md); degrade
+gracefully when one is absent.
+
+---
+
+## Decision tree — classify every failure before acting
+
+Match the failure against the router in
+[`../../docs/appendix/known_issues.md`](../../docs/appendix/known_issues.md),
+then take exactly one action. Fixing the wrong class corrupts the eval, so when
+unsure, prefer recording over fixing.
+
+- **Retry** (infra flake — e.g. Vertex `429 RESOURCE_EXHAUSTED`, a transient ssh
+  drop, a transient API/quota error): re-run the combo after the
+  clean-environment pre-flight. No code change.
+- **Fix + retry** (config / auth / host setup — e.g. a missing API enablement,
+  the Vertex ADC marker, the inotify limit, folder-trust): apply the router's
+  documented fix, then retry. These are environment fixes, not eval-logic edits.
+- **Escalate / stop** (a real **model-capability** low score — the agent ran a
+  clean trajectory and just did the task badly — or a **task-logic / rubric bug**
+  the loop can't safely edit): surface it as a distinct outcome. Do **not**
+  silently retry or paper over it. A genuine low score is a real result; record it
+  and move on.
+
+---
+
+## The loop (for the fixable class)
+
+1. **Isolate.** Make changes in an **isolated git worktree / branch**, never the
+   shared checkout. Branch off the code under test.
+2. **Diagnose.** Name the bug and the minimal fix (use the review skills / the
+   known-issues router). Don't refactor unrelated code.
+3. **Fix**, scoped to that bug. Run unit tests / linting locally if they cover it
+   — never run an eval just to "test" a fix.
+4. **Log** the cycle in the durable state file: combo, symptom, root cause, the
+   change, commit id.
+5. **Re-sync** (remote only) and **restart only the failed combo(s)** as fresh
+   single-combo runs (new stamp), after cleaning their leaked cloud resources.
+6. **Continue** the monitoring loop over the remaining + restarted combos.
+
+Keep commits local and scoped; do not push or merge shared branches unless the
+operator said so — surface the branch/diff for review instead.
+
+---
+
+## STOP conditions (so "unlimited" still terminates)
+
+Stop the loop when **any** of these trips — report where you stopped:
+
+- **Goal met** — every combo is terminal-acceptable (passed, recorded as a
+  genuine model-capability result, or blocked after the cap).
+- **Attempt cap** — ≤ 2–3 fix/retry attempts **per combo**; after that, mark it
+  blocked and keep going on the rest. Never loop one combo forever.
+- **No progress** — consecutive attempts on a combo make no new progress (same
+  failure signature) → stop attempting it.
+- **Budget exhausted** — any given iteration, wall-clock, or token/cost budget.
+  Each restart costs a cluster plus tens of minutes; track combos
+  fixed/remaining.
+
+Keep durable state **outside** the loop (a state file): stamp, per-combo status,
+attempt counts, and the fix changelog, checkpointed every tick so a context reset
+resumes mid-flight.
+
+---
+
+## What NOT to auto-fix
+
+- **Real model misses** — a clean trajectory with a low score is a result, not a
+  bug. Record it.
+- **Task-authoring / rubric bugs** — wrong `expected_output`, a mis-scoped
+  criterion: needs human judgement; escalate (the
+  [`task-review`](../skills/task-review/SKILL.md) skill is the right vehicle).
+- **Anything you can't both name and resolve** with a scoped change.
+
+---
+
+## Living known-issues
+
+When you hit a failure mode **not** already in
+[`known_issues.md`](../../docs/appendix/known_issues.md), append a new router
+row so the next run benefits, matching the table's existing columns: **symptom →
+root cause → fix/recovery → class → resolved**. Keep it terse, don't duplicate
+an existing row, and never paste model scores or run tallies into the doc. This
+capture step is part of the run, not optional.
+
+---
+
+## Final report
+
+Deliver the normal results summary **plus** the fix changelog (each bug → change →
+commit) and the list of still-blocked combos with why each is blocked.

--- a/.agents/references/unlimited-mode.md
+++ b/.agents/references/unlimited-mode.md
@@ -26,7 +26,7 @@ unsure, prefer recording over fixing.
   drop, a transient API/quota error): re-run the combo after the
   clean-environment pre-flight. No code change.
 - **Fix + retry** (config / auth / host setup — e.g. a missing API enablement,
-  the ADC marker, the inotify limit, folder-trust): apply the router's
+  ambient credential markers, inotify limits, workspace trust settings): apply the router's
   documented fix, then retry. These are environment fixes, not eval-logic edits
   — but most of them mutate **shared** host/project/global state that a
   worktree does not isolate, so get operator approval (or pause sibling combos)

--- a/.agents/skills/diagnose-eval-failure/SKILL.md
+++ b/.agents/skills/diagnose-eval-failure/SKILL.md
@@ -111,5 +111,6 @@ rationale · the verdict (capability gap vs. rubric problem) · and the next act
 - Always check `status` first — never read a `failed` record as a model miss.
 - An absent score means the metric didn't run, not a zero.
 - Explain only; this skill does not fix the model or edit the task.
-- Quote the judge's `reason` verbatim where it's load-bearing; don't paraphrase
-  away the signal.
+- Quote the judge's `reason` where it's load-bearing — don't paraphrase away
+  the signal — but **redact secrets and personal data first**: a reason can
+  reproduce credentials or PII from the trajectory or tool output it judged.

--- a/.agents/skills/diagnose-eval-failure/SKILL.md
+++ b/.agents/skills/diagnose-eval-failure/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: diagnose-eval-failure
+description: Explain WHY a model scored low on an eval — read the judge's reasons and the agent's trajectory, compare against the task rubric, and produce a rationale (capability gap vs. task/rubric problem). Distinct from infrastructure failures. Invoke when someone asks "why did the model fail this task?", "why is OutcomeValidity low?", "explain this low score", or "did the agent actually do the work?".
+---
+
+# Diagnose an eval failure
+
+This skill answers a *graded* question: given a run that completed and was scored,
+**why did the model fall short?** It reads the judge's stated reasons and the
+agent's actual trajectory, lines them up against the task's rubric, and writes a
+rationale. It explains; it does not fix the model.
+
+It is **not** for infrastructure failures. A run that crashed, timed out, or
+failed to provision never got a fair shot at scoring — those go to the recovery
+router, not here.
+
+- Score / record field shapes → [`../../../docs/components/metrics.md`](../../../docs/components/metrics.md)
+- Recovery router for infra failures →
+  [`../../../docs/appendix/known_issues.md`](../../../docs/appendix/known_issues.md)
+- Capability → tool mapping for your harness →
+  [`../../references/harness-capabilities.md`](../../references/harness-capabilities.md)
+
+---
+
+## Flow
+
+### 1. Locate the run and confirm it was graded
+
+Find the run's `results.json` — under the combo dir for a matrix run, or under
+`results/run_…/` for a bare CLI run (layout in
+[`running-evals.md`](../../references/running-evals.md)). Check `status` on the
+record:
+
+- `status: "success"` → a real graded run. Continue.
+- `status: "failed"` → **infrastructure**, not a model miss. The record is skipped
+  by scoring and carries no scores; a low/absent score here is not the model's
+  fault. Redirect to the recovery router in
+  [`known_issues.md`](../../../docs/appendix/known_issues.md) and stop.
+
+(An absent score on a `success` record means the metric didn't *run* for that
+task, not that the model scored zero — see
+[`metrics.md`](../../../docs/components/metrics.md).)
+
+### 2. Read the judge signal
+
+In the record's `scores` map, read the entries in the order that matters:
+
+- **`OutcomeScore.reason`** — the composite's own breakdown (`c=…, rec_v=…,
+  cat_v=…`) tells you immediately whether the low score came from correctness,
+  from safety, or from coverage.
+- **Which correctness signal was used** — `VerificationCorrectness` wins over
+  `ChecklistScore`, which wins over `OutcomeValidity`. Check
+  **`VerificationCoverage`** before trusting `VerificationCorrectness`: coverage
+  below 1.0 means the fraction was computed over a subset of the declared
+  entries.
+- **`OutcomeValidity.reason`** — the headline "did it work" judgment.
+- **`ToolInvocation.reason`** — did it call the right tools / take a sane
+  trajectory (present only when MCP is on).
+- **`Check: <item>.reason`** for each `expected_output` requirement, and
+  **`ChecklistScore.reason`** for the passed/total ratio in words
+  (`"Passed 3 out of 5 checks."`).
+- **`GroundingAccuracy.reason`** — reads "Applied X out of Y documented
+  constraints (Critical: a/b)"; note it is on a **0–5 scale**, and a short
+  *critical* count caps the band even when the raw count looks fine.
+
+Bare-number entries (`DocRetrievalRate`, `ParameterRecallAccuracy`, the chaos
+performance numbers) have no `success` flag — read the magnitude. Field shapes
+and banding rules are in [`metrics.md`](../../../docs/components/metrics.md).
+
+### 3. Read what the agent actually did
+
+Read the agent's `trajectory` / `tools` (the steps and tool calls it actually
+made) and its `output`. Then read the task's `expected_output` rubric. Compare:
+what did the agent attempt, and where did it diverge from the intended outcome?
+
+### 4. Produce a rationale
+
+Synthesize, don't just restate the reasons:
+
+- **What the agent attempted** — the gist of its trajectory and final state.
+- **Where it diverged** — the specific step or omission that lost the outcome.
+- **Which judge criteria it missed and why** — tie each failed `reason` back to
+  what the agent did (or skipped).
+- **Capability gap vs. task/rubric problem** — decide which:
+  - *Capability gap*: the task is fair — it grades the outcome and accepts every
+    valid path — and the agent genuinely couldn't do it. Say so plainly.
+  - *Task/rubric problem*: the rubric looks wrong, ambiguous, or single-path
+    (penalizes a valid alternative solution, demands a placeholder the task never
+    supplied, or grades for something the prompt didn't ask). Flag it and
+    recommend the [`task-review`](../task-review/SKILL.md) skill — don't try to
+    fix the task here.
+
+### 5. Report
+
+Report: run id · task · model · the failed metrics with their `reason`s · your
+rationale · the verdict (capability gap vs. rubric problem) · and the next action
+(accept the result, or send the task to `task-review`).
+
+---
+
+## Wrong tool?
+
+- **The run crashed / timed out / failed to provision** (`status: "failed"`, or no
+  `results.json`) → infrastructure, not a model miss. Use the recovery router in
+  [`known_issues.md`](../../../docs/appendix/known_issues.md).
+- **The rubric itself is the problem** → recommend [`task-review`](../task-review/SKILL.md);
+  this skill diagnoses, it does not edit tasks.
+
+## Guardrails
+
+- Always check `status` first — never read a `failed` record as a model miss.
+- An absent score means the metric didn't run, not a zero.
+- Explain only; this skill does not fix the model or edit the task.
+- Quote the judge's `reason` verbatim where it's load-bearing; don't paraphrase
+  away the signal.

--- a/.agents/skills/docs-sync/SKILL.md
+++ b/.agents/skills/docs-sync/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: docs-sync
+description: Keep the docs current after a code change — map changed code areas to the docs that describe them, update those docs in place, and resolve known-issues rows the code has verifiably fixed. Invoke after editing the pipeline, adding a model/agent/task/metric, moving a directory, or whenever someone asks to "sync the docs", "update the docs for this change", or "do the docs still match the code?".
+---
+
+# Sync docs to a code change
+
+Code moved; the docs should move with it. This skill takes a change set and walks
+it back to the docs that describe the touched areas, updates those docs, and
+resolves stale recovery rows the code now fixes. It edits prose only — it does
+not change behavior.
+
+Follow the docs' existing conventions while editing: GFM, humanized (not
+journal-like or changelog-y), minimal, no contradictions or duplication, and
+**no model scores or result tallies** in any doc.
+
+- Codebase tree (what lives where) → Part B of
+  [`../../../docs/components/glossary.md`](../../../docs/components/glossary.md)
+- Capability → tool mapping for your harness →
+  [`../../references/harness-capabilities.md`](../../references/harness-capabilities.md)
+
+---
+
+## Flow
+
+### 1. Get the change set
+
+Take the diff or the list of changed files (e.g. `git diff --name-only main...`,
+or the working tree). Group the changes by area — a model provider, a deployer, an
+agent harness, the CLI, metrics, a task, the bastion scripts, a directory move.
+
+### 2. Learn where things are documented
+
+Tree-walk `docs/` (`components/`, `how-to/`, `appendix/`) and the directory
+structure in [`glossary.md`](../../../docs/components/glossary.md) Part B. Also
+read the nearest `AGENTS.md` to the changed code — the root
+[`AGENTS.md`](../../../AGENTS.md) or
+[`tasks/AGENTS.md`](../../../tasks/AGENTS.md) — since those route contributors
+and often need the same edit as the docs.
+
+### 3. Map changed area → affected docs
+
+| Changed code area | Docs to update |
+|---|---|
+| Model provider (`devops_bench/models/`) | [`model_providers.md`](../../../docs/components/model_providers.md) + [`add-a-model-provider.md`](../../../docs/how-to/add-a-model-provider.md) |
+| Deployer / cloud provider (`devops_bench/deployers/`, `devops_bench/providers/`, `tf/`) | [`infra.md`](../../../docs/components/infra.md) + [`tf/README.md`](../../../tf/README.md) |
+| Agent harness (`devops_bench/agents/`) | [`agents.md`](../../../docs/components/agents.md) + [`add-an-agent-harness.md`](../../../docs/how-to/add-an-agent-harness.md) |
+| Pipeline / CLI / run env (`devops_bench/evalharness/`, `cli.py`, `run.py`, `core/`) | [`architecture.md`](../../../docs/components/architecture.md) |
+| Metrics (`devops_bench/metrics/`) | [`metrics.md`](../../../docs/components/metrics.md) |
+| Chaos / verification (`devops_bench/chaos/`, `devops_bench/verification/`) | [`architecture.md`](../../../docs/components/architecture.md) + [`glossary.md`](../../../docs/components/glossary.md) |
+| Task schema / placeholders (`devops_bench/tasks/`, `tasks/`) | [`add-a-task.md`](../../../docs/how-to/add-a-task.md) + [`glossary.md`](../../../docs/components/glossary.md) + [`tasks/AGENTS.md`](../../../tasks/AGENTS.md) |
+| Bastion / matrix scripts (`scripts/bastion/`) | [`running-evals.md`](../../references/running-evals.md) + [`monitoring-and-recovery.md`](../../references/monitoring-and-recovery.md) |
+| Directory move / rename | the tree in [`glossary.md`](../../../docs/components/glossary.md) Part B + the relevant `AGENTS.md` |
+
+A change can touch more than one row (e.g. a new CLI flag that exposes a new
+metric). Update every doc the change actually affects, and only those.
+
+### 4. Update the affected docs
+
+Edit in place. Keep edits surgical — change the lines the code change made wrong,
+don't rewrite the page. Match the page's existing voice and structure. If a code
+change makes a documented example wrong, fix the example. Never paste a score
+table or run results into a doc.
+
+### 5. Resolve rows in the known-issues router
+
+This is the inverse of what the run skills do: they *append* freshly observed
+failures to [`known_issues.md`](../../../docs/appendix/known_issues.md); this
+skill *resolves* rows the code now fixes.
+
+For every Section 1 (router) or Section 2 (known hacks) row whose root cause your
+change set addresses:
+
+- **Confirm the fix exists in the code before touching the row.** Open the file
+  the row points at and verify the fix is actually there — cite the file and line
+  in your report. A row describes a *current* failure mode; resolve it only when
+  that failure mode can no longer happen.
+- Follow the page's own convention: Section 1 rows carry a **Resolved** column —
+  flip it (and reword the fix cell to point at the fix) rather than deleting the
+  row outright; a Section 2 hack whose stated **removal condition** is now met
+  gets its **Resolved** cell flipped (citing the fix), same as Section 1 —
+  don't delete the row.
+- If you're not certain the fix is complete, leave the row and say so — a stale
+  "still broken" row is safer than a wrong "all clear".
+
+### 6. Verify links + report
+
+Confirm every relative link you touched still resolves (open the target, or check
+the path exists). Then report: the change-set → doc map you applied, each file
+edited, and each known-issues row resolved **with the file/line that proves the
+fix**.
+
+---
+
+## Wrong tool?
+
+- **A new failure to record** (not a fix) → that belongs in the run skills, which
+  append to the known-issues router; this skill only resolves verified fixes.
+- **Authoring brand-new docs for a feature with no home yet** → write the page
+  under the matching `docs/` subtree (`components/` for what a thing is,
+  `how-to/` for a workflow), then add it to the tree in
+  [`glossary.md`](../../../docs/components/glossary.md) and the nearest
+  `AGENTS.md`.
+
+## Guardrails
+
+- No model scores, leaderboard standings, or result tallies in any doc — ever.
+- Never resolve a known-issues row without citing the code that fixes it.
+- Edit prose only; this skill does not change code behavior.
+- Keep edits minimal and humanized; don't turn a doc into a changelog.

--- a/.agents/skills/docs-sync/SKILL.md
+++ b/.agents/skills/docs-sync/SKILL.md
@@ -50,7 +50,7 @@ and often need the same edit as the docs.
 | Chaos / verification (`devops_bench/chaos/`, `devops_bench/verification/`) | [`architecture.md`](../../../docs/components/architecture.md) + [`glossary.md`](../../../docs/components/glossary.md) |
 | Task schema / placeholders (`devops_bench/tasks/`, `tasks/`) | [`add-a-task.md`](../../../docs/how-to/add-a-task.md) + [`glossary.md`](../../../docs/components/glossary.md) + [`tasks/AGENTS.md`](../../../tasks/AGENTS.md) |
 | Bastion / matrix scripts (`scripts/bastion/`) | [`running-evals.md`](../../references/running-evals.md) + [`monitoring-and-recovery.md`](../../references/monitoring-and-recovery.md) |
-| Directory move / rename | the tree in [`glossary.md`](../../../docs/components/glossary.md) Part B + the relevant `AGENTS.md` |
+| Directory move / rename | the tree in [`glossary.md`](../../../docs/components/glossary.md) Part B + the relevant `AGENTS.md` + a repo-wide search for the old path (`rg '<old-path>'`) — a move leaves stale paths in any doc, reference, or example that mentioned it |
 
 A change can touch more than one row (e.g. a new CLI flag that exposes a new
 metric). Update every doc the change actually affects, and only those.
@@ -86,7 +86,9 @@ change set addresses:
 ### 6. Verify links + report
 
 Confirm every relative link you touched still resolves (open the target, or check
-the path exists). Then report: the change-set → doc map you applied, each file
+the path exists), and when a link carries a `#fragment`, confirm the target
+heading still exists — a path check alone won't catch a renamed heading. Then
+report: the change-set → doc map you applied, each file
 edited, and each known-issues row resolved **with the file/line that proves the
 fix**.
 

--- a/.agents/skills/run-eval/SKILL.md
+++ b/.agents/skills/run-eval/SKILL.md
@@ -52,22 +52,23 @@ Work the **"Before any retry" checklist** in
 [`../../../docs/appendix/known_issues.md`](../../../docs/appendix/known_issues.md)
 before launching — stale per-run state and orphaned cloud resources are the top
 cause of a "fresh" run failing instantly. Keep it scoped to your run; for leaked
-clusters / `gke-nodes-*` SAs / secrets, use the
+clusters / node service accounts (e.g. `gke-nodes-*`) / secrets, use the
 [`cleanup-orphaned-resources`](../cleanup-orphaned-resources/SKILL.md) skill.
 
 ### 4. Launch the one combo (detached)
 
 Drive the wrapper with single-value `MATRIX_*`. It runs detached under `nohup`
 and prints a `STAMP` — record `RESUME_STAMP=<stamp>` in durable state; it is your
-handle for monitoring and re-attach. Example (ambient credentials; prefix
-`BENCH_REMOTE=1` + `BASTION_*` for remote):
+handle for monitoring and re-attach. Example (API keys from `~/secrets.env`,
+local runner; for ambient credentials add `BENCH_VERTEX=1`, and prefix
+`BENCH_REMOTE=1` + `BASTION_*` for remote — see
+[running-evals.md](../../references/running-evals.md) for both variants):
 
 ```bash
-PROJECT_ID=<proj> BENCH_VERTEX=1 \
-JUDGE_MODEL=gemini-3.1-pro-preview \
+PROJECT_ID=<proj> \
 MATRIX_TASKS="tasks/common/opa-remediation/task.yaml" \
-MATRIX_MODELS="gemini-3.1-pro-preview" \
-MATRIX_AGENT_CONFIGS="gcli+mcp+skills" \
+MATRIX_MODELS="<model-id>" \
+MATRIX_AGENT_CONFIGS="oc+mcp+skills" \
 RESULTS_DIR="results/<label>" \
   scripts/bastion/run_matrix.sh
 ```
@@ -126,7 +127,7 @@ the concrete fix — the
 - Never launch a second run of the **same** task+model+config concurrently —
   the run-id-derived cluster name is deterministic in the combo, so both runs
   would target the same cluster.
-- Always confirm clean teardown — a leftover cluster or `gke-nodes-*` SA from a
+- Always confirm clean teardown — a leftover cluster or node service account (e.g. `gke-nodes-*`) from a
   failed teardown makes a retry of the same combo fail with `409 already
   exists`.
 - Prefer leaving the run detached + re-attaching via `RESUME_STAMP` over a

--- a/.agents/skills/run-eval/SKILL.md
+++ b/.agents/skills/run-eval/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: run-eval
+description: Run ONE evaluation — a single Task × Model × AgentConfig — end to end, local or on the bastion; invoke when the user wants to run, evaluate, or "kick off" a single eval combo (e.g. "run opa-remediation on gemini-3.1-pro-preview", "evaluate this task once and watch it").
+---
+
+# Run a single eval
+
+The easy entrypoint for **one** eval run: one Task × one Model × one AgentConfig.
+A single run is just a 1×1×1 matrix, driven through the same wrapper everything
+else uses. This skill keeps the front-end lean — no concurrency, no combo math,
+no cross-combo safety. For those, use a different skill (see *Wrong tool?*).
+
+The run mechanics are shared and live in the references — **read them, don't
+re-derive them here:**
+
+- Local vs bastion, auth, clean pre-flight, launch, knobs, results layout →
+  [`../../references/running-evals.md`](../../references/running-evals.md)
+- Capability → tool mapping for your harness →
+  [`../../references/harness-capabilities.md`](../../references/harness-capabilities.md)
+
+---
+
+## Flow
+
+### 1. Choose where + how, then pin the one combo
+
+- **Local or bastion?** Local is the default; remote sets `BENCH_REMOTE=1` + the
+  `BASTION_*` connection env. **Auth:** prefer Vertex/ADC (`BENCH_VERTEX=1`, no
+  keys). Both covered in [running-evals.md](../../references/running-evals.md).
+- Pin exactly one **Task** (`task.yaml` path), one **Model**, and one
+  **AgentConfig** (`oc|gcli` `[+mcp][+skills]`), driven through
+  `scripts/bastion/run_matrix.sh`. (The legacy arm, `run_matrix_legacy.sh`,
+  needs a legacy evaluator checkout that is not part of this repo — see
+  [running-evals.md](../../references/running-evals.md).)
+- Ask the operator for anything not given — don't guess on the dimensions that
+  cost a cluster + time (budget roughly half an hour for an infra-bearing task).
+
+### 2. Preview with `DRY_RUN=1`
+
+Show the expanded (single) combo + per-combo env before spending a cluster:
+
+```bash
+DRY_RUN=1 \
+MATRIX_TASKS="tasks/common/opa-remediation/task.yaml" \
+MATRIX_MODELS="gemini-3.1-pro-preview" \
+MATRIX_AGENT_CONFIGS="gcli+mcp+skills" \
+  scripts/bastion/run_matrix.sh
+```
+
+### 3. Clean pre-flight
+
+Work the **"Before any retry" checklist** in
+[`../../../docs/appendix/known_issues.md`](../../../docs/appendix/known_issues.md)
+before launching — stale per-run state and orphaned cloud resources are the top
+cause of a "fresh" run failing instantly. Keep it scoped to your run; for leaked
+clusters / `gke-nodes-*` SAs / secrets, use the
+[`cleanup-orphaned-resources`](../cleanup-orphaned-resources/SKILL.md) skill.
+
+### 4. Launch the one combo (detached)
+
+Drive the wrapper with single-value `MATRIX_*`. It runs detached under `nohup`
+and prints a `STAMP` — record `RESUME_STAMP=<stamp>` in durable state; it is your
+handle for monitoring, retry, and re-attach. Example (Vertex; prefix
+`BENCH_REMOTE=1` + `BASTION_*` for remote):
+
+```bash
+PROJECT_ID=<proj> BENCH_VERTEX=1 \
+JUDGE_MODEL=gemini-3.1-pro-preview \
+MATRIX_TASKS="tasks/common/opa-remediation/task.yaml" \
+MATRIX_MODELS="gemini-3.1-pro-preview" \
+MATRIX_AGENT_CONFIGS="gcli+mcp+skills" \
+RESULTS_DIR="results/<label>" \
+  scripts/bastion/run_matrix.sh
+```
+
+(`MAX_PARALLEL` is irrelevant for one combo.) Full launch details, including the
+matrix knobs and the judge/auth settings, are in
+[running-evals.md](../../references/running-evals.md).
+
+### 5. Watch it
+
+Basic loop: poll the combo's `status` + `run.log` tail on an interval (~3–5 min
+for an infra-bearing task — **don't busy-poll**). If your poller dies the
+detached run continues; re-attach with `RESUME_STAMP=<stamp>` and the same
+command. For a resilient, hands-off watch that survives quiet stretches and dead
+watchers, follow
+[`../../references/monitoring-and-recovery.md`](../../references/monitoring-and-recovery.md)
+(for one combo it degenerates to one watcher + the keepalive loop).
+
+Classify a flake vs a real failure against the router in
+[known_issues.md](../../../docs/appendix/known_issues.md): infra flake → clean +
+retry (cap 2); real failure (auth/config, low score, task-logic) → do not retry,
+analyze.
+
+### 6. Summarize + where to read scores
+
+When the combo has a terminal `status` (or `.done`), report:
+**task · model · agent-config · auth-mode · exit · score · pass/fail checks.**
+Results land per the layout in
+[running-evals.md](../../references/running-evals.md); for how scoring works and
+how to interpret it, see
+[`../../../docs/components/metrics.md`](../../../docs/components/metrics.md). If
+it didn't pass, give the decisive log line (redact secrets), the root cause, and
+the concrete fix — the
+[`diagnose-eval-failure`](../diagnose-eval-failure/SKILL.md) skill covers the
+"why did the model score low" half. Then confirm teardown is clean.
+
+---
+
+## Wrong tool?
+
+- **More than one combo** (a matrix, a comparison) → use the
+  [`run-parallel-evals`](../run-parallel-evals/SKILL.md) skill — it adds combo
+  math, `MAX_PARALLEL`, and cross-combo parallel-safety.
+- **Explaining a low score on a graded run** → the
+  [`diagnose-eval-failure`](../diagnose-eval-failure/SKILL.md) skill.
+- **Cleaning up after an aborted run** → the
+  [`cleanup-orphaned-resources`](../cleanup-orphaned-resources/SKILL.md) skill.
+
+## Guardrails
+
+- One run still costs a real cluster (GKE, or kind on the runner host) plus tens
+  of minutes — confirm scale and `DRY_RUN=1` first.
+- Never print or commit API keys; redact secrets in summaries.
+- Never launch a second run of the **same** task+model+config concurrently —
+  the run-id-derived cluster name is deterministic in the combo, so both runs
+  would target the same cluster.
+- Always confirm clean teardown — a leftover cluster or `gke-nodes-*` SA from a
+  failed teardown makes a retry of the same combo fail with `409 already
+  exists`.
+- Prefer leaving the run detached + re-attaching via `RESUME_STAMP` over a
+  fragile foreground session.

--- a/.agents/skills/run-eval/SKILL.md
+++ b/.agents/skills/run-eval/SKILL.md
@@ -25,8 +25,9 @@ re-derive them here:**
 ### 1. Choose where + how, then pin the one combo
 
 - **Local or bastion?** Local is the default; remote sets `BENCH_REMOTE=1` + the
-  `BASTION_*` connection env. **Auth:** prefer Vertex/ADC (`BENCH_VERTEX=1`, no
-  keys). Both covered in [running-evals.md](../../references/running-evals.md).
+  `BASTION_*` connection env. **Auth:** ambient cloud credentials
+  (`BENCH_VERTEX=1`, no keys) or API keys — pick one. Both covered in
+  [running-evals.md](../../references/running-evals.md).
 - Pin exactly one **Task** (`task.yaml` path), one **Model**, and one
   **AgentConfig** (`oc|gcli` `[+mcp][+skills]`), driven through
   `scripts/bastion/run_matrix.sh`. (The legacy arm, `run_matrix_legacy.sh`,

--- a/.agents/skills/run-eval/SKILL.md
+++ b/.agents/skills/run-eval/SKILL.md
@@ -61,7 +61,7 @@ clusters / `gke-nodes-*` SAs / secrets, use the
 
 Drive the wrapper with single-value `MATRIX_*`. It runs detached under `nohup`
 and prints a `STAMP` — record `RESUME_STAMP=<stamp>` in durable state; it is your
-handle for monitoring, retry, and re-attach. Example (Vertex; prefix
+handle for monitoring, retry, and re-attach. Example (ambient credentials; prefix
 `BENCH_REMOTE=1` + `BASTION_*` for remote):
 
 ```bash
@@ -120,7 +120,7 @@ the concrete fix — the
 
 ## Guardrails
 
-- One run still costs a real cluster (GKE, or kind on the runner host) plus tens
+- One run still costs a real cluster (cloud, or kind on the runner host) plus tens
   of minutes — confirm scale and `DRY_RUN=1` first.
 - Never print or commit API keys; redact secrets in summaries.
 - Never launch a second run of the **same** task+model+config concurrently —

--- a/.agents/skills/run-eval/SKILL.md
+++ b/.agents/skills/run-eval/SKILL.md
@@ -29,8 +29,8 @@ re-derive them here:**
   (`BENCH_VERTEX=1`, no keys) or API keys — pick one. Both covered in
   [running-evals.md](../../references/running-evals.md).
 - Pin exactly one **Task** (`task.yaml` path), one **Model**, and one
-  **AgentConfig** (`oc|gcli` `[+mcp][+skills]`), driven through
-  `scripts/bastion/run_matrix.sh`.
+  **AgentConfig** (`oc|gcli` `[+mcp][+skills]`; `oc` = OpenClaw, `gcli` =
+  Gemini CLI), driven through `scripts/bastion/run_matrix.sh`.
 - Ask the operator for anything not given — don't guess on the dimensions that
   cost a cluster + time (budget roughly half an hour for an infra-bearing task).
 

--- a/.agents/skills/run-eval/SKILL.md
+++ b/.agents/skills/run-eval/SKILL.md
@@ -30,9 +30,7 @@ re-derive them here:**
   [running-evals.md](../../references/running-evals.md).
 - Pin exactly one **Task** (`task.yaml` path), one **Model**, and one
   **AgentConfig** (`oc|gcli` `[+mcp][+skills]`), driven through
-  `scripts/bastion/run_matrix.sh`. (The legacy arm, `run_matrix_legacy.sh`,
-  needs a legacy evaluator checkout that is not part of this repo — see
-  [running-evals.md](../../references/running-evals.md).)
+  `scripts/bastion/run_matrix.sh`.
 - Ask the operator for anything not given — don't guess on the dimensions that
   cost a cluster + time (budget roughly half an hour for an infra-bearing task).
 

--- a/.agents/skills/run-eval/SKILL.md
+++ b/.agents/skills/run-eval/SKILL.md
@@ -59,7 +59,7 @@ clusters / `gke-nodes-*` SAs / secrets, use the
 
 Drive the wrapper with single-value `MATRIX_*`. It runs detached under `nohup`
 and prints a `STAMP` — record `RESUME_STAMP=<stamp>` in durable state; it is your
-handle for monitoring, retry, and re-attach. Example (ambient credentials; prefix
+handle for monitoring and re-attach. Example (ambient credentials; prefix
 `BENCH_REMOTE=1` + `BASTION_*` for remote):
 
 ```bash
@@ -88,8 +88,10 @@ watchers, follow
 
 Classify a flake vs a real failure against the router in
 [known_issues.md](../../../docs/appendix/known_issues.md): infra flake → clean +
-retry (cap 2); real failure (auth/config, low score, task-logic) → do not retry,
-analyze.
+retry (cap 2) — a retry is a **new launch**, so run it *without* `RESUME_STAMP`
+(set, the wrapper attaches to the failed run instead of launching) and record
+the new `STAMP` as the active attempt; real failure (auth/config, low score,
+task-logic) → do not retry, analyze.
 
 ### 6. Summarize + where to read scores
 

--- a/.agents/skills/run-parallel-evals/SKILL.md
+++ b/.agents/skills/run-parallel-evals/SKILL.md
@@ -48,7 +48,8 @@ then pin the matrix axes — ask the operator for anything not given:
 
 1. **`MATRIX_TASKS`** — space-separated `task.yaml` paths, or `ALL`.
 2. **`MATRIX_MODELS`** — space-separated model ids.
-3. **`MATRIX_AGENT_CONFIGS`** — each `oc|gcli` `[+mcp][+skills]`.
+3. **`MATRIX_AGENT_CONFIGS`** — each `oc|gcli` `[+mcp][+skills]` (`oc` =
+   OpenClaw, `gcli` = Gemini CLI).
 4. **`MAX_PARALLEL`** — combos running at once (default 3).
 
 **Combo count = tasks × models × configs.** State it plus the rough wall-clock

--- a/.agents/skills/run-parallel-evals/SKILL.md
+++ b/.agents/skills/run-parallel-evals/SKILL.md
@@ -92,7 +92,7 @@ Work the **"Before any retry" checklist** in
 [known_issues.md](../../../docs/appendix/known_issues.md) before **every** launch —
 stale per-run state and orphaned cloud resources are the top cause of a "fresh"
 matrix failing instantly. Keep it scoped per run. For leaked clusters /
-`gke-nodes-*` SAs / secrets, use the
+node service accounts (e.g. `gke-nodes-*`) / secrets, use the
 [`cleanup-orphaned-resources`](../cleanup-orphaned-resources/SKILL.md) skill.
 
 **Smoke-gate before the full matrix.** Launch **one cheap combo first**
@@ -123,7 +123,9 @@ watcher and per-finish analysis to a mid tier.
 
 Classify each combo against the router in
 [known_issues.md](../../../docs/appendix/known_issues.md): **infra flake** → clean
-+ retry that one combo (cap 2 per combo; log every retry — never silently drop a
++ retry that one combo without `RESUME_STAMP` — set, the wrapper attaches to the
+failed run instead of launching — and record the new `STAMP` (cap 2 per combo;
+log every retry — never silently drop a
 combo); **real failure** (auth/config, low score, task-logic) → do not retry,
 analyze in Phase 5. If the whole runner died, re-attach with `RESUME_STAMP` then
 relaunch only the unfinished combos. For unlimited mode, a real task/code bug is
@@ -175,7 +177,7 @@ part of the run, not optional.
   the combo count and `DRY_RUN=1` first; mind project quota across
   `MAX_PARALLEL`.
 - Never print or commit API keys; redact secrets in summaries.
-- Always confirm clean teardown — leftover clusters / `gke-nodes-*` SAs make a
+- Always confirm clean teardown — leftover clusters / node service accounts (e.g. `gke-nodes-*`) make a
   retry of the same combo fail with `409 already exists`.
 - Cap retries (≤2/combo) and surface anything still failing rather than looping.
 - Prefer leaving the run detached + re-attaching via `RESUME_STAMP` over a fragile
@@ -184,10 +186,10 @@ part of the run, not optional.
   terminal **and** summarized; emit a periodic heartbeat instead.
 - **Cluster-mutation blast radius (with-mcp + a broadly privileged SA).** When
   the runner's service account has broad rights, a cluster-aware MCP server
-  (e.g. `gke-mcp` on the bastion) exposes every real cluster in the project as
+  (e.g. `k8s-mcp` or `gke-mcp` on the bastion) exposes every real cluster in the project as
   a writable target — an agent can start a cluster update/upgrade through the
   provider CLI against a cluster the eval never provisioned, a long-running
   op with no agent timeout, so the run **hangs** (no score) and may mutate an
   unrelated cluster. Mitigate: run in a project with **no other clusters**, or
-  watch the logs for `clusters update|upgrade|delete` and kill the offending
+  watch the logs for cluster mutation commands (e.g. `clusters update|upgrade|delete`) and kill the offending
   process. Don't auto-revert a change to a cluster you don't own.

--- a/.agents/skills/run-parallel-evals/SKILL.md
+++ b/.agents/skills/run-parallel-evals/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: run-parallel-evals
+description: Run a Task × Model × AgentConfig MATRIX of evals in parallel — local or on the bastion, with opt-in hands-off and unlimited/self-healing modes; invoke when the user wants a matrix, a comparison across models/configs, or to "run these evals in parallel" / "compare models on the same task".
+---
+
+# Run a parallel eval matrix
+
+Orchestrate a **Task × Model × AgentConfig** matrix end to end: expand the combos,
+launch them detached, monitor and retry flakes, then summarize and diagnose.
+
+This file keeps only what's **unique to running many combos at once**. Everything
+shared is in the references — read them, don't restate them:
+
+- Local vs bastion, auth, clean pre-flight, launch, knobs, results →
+  [`../../references/running-evals.md`](../../references/running-evals.md)
+- Monitoring / keepalive / recovery →
+  [`../../references/monitoring-and-recovery.md`](../../references/monitoring-and-recovery.md)
+- Unlimited / self-healing loop →
+  [`../../references/unlimited-mode.md`](../../references/unlimited-mode.md)
+- Capability → tool mapping (sub-agents, background runs, timers, durable state,
+  worktrees) → [`../../references/harness-capabilities.md`](../../references/harness-capabilities.md)
+- Failure router →
+  [`../../../docs/appendix/known_issues.md`](../../../docs/appendix/known_issues.md)
+- Reading scores →
+  [`../../../docs/components/metrics.md`](../../../docs/components/metrics.md)
+
+**Single combo?** Use [`run-eval`](../run-eval/SKILL.md). **Explaining a low
+score?** Use [`diagnose-eval-failure`](../diagnose-eval-failure/SKILL.md).
+
+---
+
+## Modes (opt-in)
+
+| Mode | When | What it adds |
+|---|---|---|
+| **Standard** | default | You drive Phases 1–5 directly. |
+| **Hands-off** | "must not stop", "monitor with subagents", long runs | Tiered-subagent monitoring + keepalive — [monitoring-and-recovery.md](../../references/monitoring-and-recovery.md). |
+| **Unlimited / self-healing** | "keep going until it finishes", "auto-fix and restart" | Diagnose → fix → re-sync → restart failed combos, capped — [unlimited-mode.md](../../references/unlimited-mode.md). |
+
+Resolve the mode in Phase 1; hands-off and unlimited are **explicit opt-in**.
+
+---
+
+## Phase 1 — Spec the matrix + combo math
+
+Choose **local vs bastion** and **auth** ([running-evals.md](../../references/running-evals.md)),
+then pin the matrix axes — ask the operator for anything not given:
+
+1. **`MATRIX_TASKS`** — space-separated `task.yaml` paths, or `ALL`.
+2. **`MATRIX_MODELS`** — space-separated model ids.
+3. **`MATRIX_AGENT_CONFIGS`** — each `oc|gcli` `[+mcp][+skills]`.
+4. **`MAX_PARALLEL`** — combos running at once (default 3).
+
+**Combo count = tasks × models × configs.** State it plus the rough wall-clock
+(tens of minutes per infra-bearing combo) so the operator can confirm scale
+before you spend clusters. Then `DRY_RUN=1` to print the expanded matrix.
+
+(The legacy Task × Model arm, `run_matrix_legacy.sh`, requires a legacy
+evaluator checkout at `pkg/` that is not part of this repo — see
+[running-evals.md](../../references/running-evals.md).)
+
+---
+
+## Phase 2 — Cross-combo parallel-safety pre-flight
+
+The one thing a matrix must get right that a single run needn't: combos run
+**concurrently**, so shared state across combos is a hazard. Each combo provisions
+and tears down **its own** cluster and writes its own results — the matrix is safe
+only as long as that isolation holds.
+
+- **Never run two of the *same* combo at once** — the run-id-derived cluster
+  name is deterministic in the combo, so two identical runs would target the
+  same cluster. Distinct combos are fine alongside each other.
+- **The legacy arm is oc-only by design** — its Gemini runner read trajectory
+  state from a shared per-user dir, which is not safe under concurrent runs
+  (see the header of `scripts/bastion/run_matrix_legacy.sh`). For parallel
+  gemini, use `run_matrix.sh`.
+- Pre-flight each selected task for per-run isolation gaps — parallel-safety is
+  mandatory for tasks (`tasks/AGENTS.md`), and the
+  [`task-review`](../task-review/SKILL.md) skill runs a thorough pass. The gaps
+  that bite a *matrix* specifically:
+  - a task that seeds a fixed, shared host path (e.g. a `$HOME` git fixture
+    without the cluster name in it) and deletes it on re-run — unsafe once the
+    matrix repeats the task across models/configs;
+  - a stack that grants project-level IAM to a **shared** service account
+    (teardown clobber across concurrent combos);
+  - duplicate `task_id`s among the selected tasks (ambiguous reporting);
+  - host capacity: sum kind clusters / disk / inotify limits across
+    `MAX_PARALLEL` (see the inotify row in
+    [known_issues.md](../../../docs/appendix/known_issues.md)).
+
+A doomed combo wastes a cluster and half an hour, so catch these before launch.
+
+---
+
+## Phase 3 — Clean pre-flight + launch (detached)
+
+Work the **"Before any retry" checklist** in
+[known_issues.md](../../../docs/appendix/known_issues.md) before **every** launch —
+stale per-run state and orphaned cloud resources are the top cause of a "fresh"
+matrix failing instantly. Keep it scoped per run. For leaked clusters /
+`gke-nodes-*` SAs / secrets, use the
+[`cleanup-orphaned-resources`](../cleanup-orphaned-resources/SKILL.md) skill.
+
+**Smoke-gate before the full matrix.** Launch **one cheap combo first**
+(`tasks/common/opa-remediation` provisions on kind — no cloud cluster) and
+verify its `results.json` has a **non-empty `trajectory`** (and `tools`
+populated for tool-using tasks), not just `exit=0`. An empty trajectory on a
+task the agent clearly acted on is a *silent* capture failure that scores still
+"succeed" through — it deflates every tool/checklist score (e.g. the
+`oc sessions` Node-not-on-PATH row in
+[known_issues.md](../../../docs/appendix/known_issues.md)). **Abort and fix
+before spending the full matrix** rather than discovering it across N invalid
+runs.
+
+Then launch per [running-evals.md](../../references/running-evals.md): build the
+env from Phase 1, run the wrapper as a background job, and **capture each
+`STAMP`** (`RESUME_STAMP=<stamp>`) plus the combo list in durable state. To run
+two wrappers in parallel, sync once then start each with `SKIP_SYNC=1`. If your
+poller dies the detached run continues — re-attach with `RESUME_STAMP`.
+
+---
+
+## Phase 4 — Monitor + retry flakes
+
+Follow [monitoring-and-recovery.md](../../references/monitoring-and-recovery.md):
+poll each combo's `status` + `run.log` on an interval (~3–5 min for infra-bearing
+tasks — **don't busy-poll**); under hands-off mode delegate polling to a cheap
+watcher and per-finish analysis to a mid tier.
+
+Classify each combo against the router in
+[known_issues.md](../../../docs/appendix/known_issues.md): **infra flake** → clean
++ retry that one combo (cap 2 per combo; log every retry — never silently drop a
+combo); **real failure** (auth/config, low score, task-logic) → do not retry,
+analyze in Phase 5. If the whole runner died, re-attach with `RESUME_STAMP` then
+relaunch only the unfinished combos. For unlimited mode, a real task/code bug is
+not the end — follow [unlimited-mode.md](../../references/unlimited-mode.md).
+
+---
+
+## Phase 5 — Summarize + diagnose
+
+When every combo is terminal (or `.done` is present), pull results and report per
+combo: **task · model · agent-config · auth-mode · exit · score ·
+#MCP-tool-calls · pass/fail checks.** Read and interpret scores per
+[metrics.md](../../../docs/components/metrics.md); results layout is in
+[running-evals.md](../../references/running-evals.md).
+
+**Aggregate for the dashboard:** the matrix runs one task per process, so combine
+the per-task `rows.json` into one batch run before ingest:
+
+```bash
+python -m devops_bench.results.aggregate <results-root> -o <results-root>
+```
+
+For every non-passing combo, give: the decisive log line (redact secrets), the
+**root cause** mapped to the router, whether it's **model vs harness** (clean
+trajectory + low score = model; early abort / auth error = harness/config —
+[`diagnose-eval-failure`](../diagnose-eval-failure/SKILL.md) covers the graded
+half), and the concrete fix. Then **verify teardown is clean** and report any
+residue.
+
+End with: total combos, passed/failed counts, best performer, the headline score
+table, and each failure's root cause + fix.
+
+---
+
+## Living known-issues
+
+When a combo fails in a way **not** already in
+[known_issues.md](../../../docs/appendix/known_issues.md), append a router row
+matching the table's columns — **symptom → root cause → fix/recovery → class →
+resolved** — so the next run benefits. Terse, no duplication of existing rows,
+and never paste model scores or run tallies into the doc. This capture step is
+part of the run, not optional.
+
+---
+
+## Guardrails
+
+- Each infra-bearing combo costs a real cluster plus tens of minutes — confirm
+  the combo count and `DRY_RUN=1` first; mind project quota across
+  `MAX_PARALLEL`.
+- Never print or commit API keys; redact secrets in summaries.
+- Always confirm clean teardown — leftover clusters / `gke-nodes-*` SAs make a
+  retry of the same combo fail with `409 already exists`.
+- Cap retries (≤2/combo) and surface anything still failing rather than looping.
+- Prefer leaving the run detached + re-attaching via `RESUME_STAMP` over a fragile
+  foreground session.
+- **Hands-off run:** never emit a completion signal until *every* combo is
+  terminal **and** summarized; emit a periodic heartbeat instead.
+- **Cluster-mutation blast radius (with-mcp + a broadly privileged SA).** When
+  the runner's service account has broad rights, a cluster-aware MCP server
+  (e.g. `gke-mcp` on the bastion) exposes every real cluster in the project as
+  a writable target — an agent can run `gcloud container clusters
+  update/upgrade` against a cluster the eval never provisioned, a long-running
+  op with no agent timeout, so the run **hangs** (no score) and may mutate an
+  unrelated cluster. Mitigate: run in a project with **no other clusters**, or
+  watch the logs for `clusters update|upgrade|delete` and kill the offending
+  process. Don't auto-revert a change to a cluster you don't own.

--- a/.agents/skills/run-parallel-evals/SKILL.md
+++ b/.agents/skills/run-parallel-evals/SKILL.md
@@ -55,10 +55,6 @@ then pin the matrix axes — ask the operator for anything not given:
 (tens of minutes per infra-bearing combo) so the operator can confirm scale
 before you spend clusters. Then `DRY_RUN=1` to print the expanded matrix.
 
-(The legacy Task × Model arm, `run_matrix_legacy.sh`, requires a legacy
-evaluator checkout at `pkg/` that is not part of this repo — see
-[running-evals.md](../../references/running-evals.md).)
-
 ---
 
 ## Phase 2 — Cross-combo parallel-safety pre-flight
@@ -71,10 +67,6 @@ only as long as that isolation holds.
 - **Never run two of the *same* combo at once** — the run-id-derived cluster
   name is deterministic in the combo, so two identical runs would target the
   same cluster. Distinct combos are fine alongside each other.
-- **The legacy arm is oc-only by design** — its Gemini runner read trajectory
-  state from a shared per-user dir, which is not safe under concurrent runs
-  (see the header of `scripts/bastion/run_matrix_legacy.sh`). For parallel
-  gemini, use `run_matrix.sh`.
 - Pre-flight each selected task for per-run isolation gaps — parallel-safety is
   mandatory for tasks (`tasks/AGENTS.md`), and the
   [`task-review`](../task-review/SKILL.md) skill runs a thorough pass. The gaps

--- a/.agents/skills/run-parallel-evals/SKILL.md
+++ b/.agents/skills/run-parallel-evals/SKILL.md
@@ -192,8 +192,8 @@ part of the run, not optional.
 - **Cluster-mutation blast radius (with-mcp + a broadly privileged SA).** When
   the runner's service account has broad rights, a cluster-aware MCP server
   (e.g. `gke-mcp` on the bastion) exposes every real cluster in the project as
-  a writable target — an agent can run `gcloud container clusters
-  update/upgrade` against a cluster the eval never provisioned, a long-running
+  a writable target — an agent can start a cluster update/upgrade through the
+  provider CLI against a cluster the eval never provisioned, a long-running
   op with no agent timeout, so the run **hangs** (no score) and may mutate an
   unrelated cluster. Mitigate: run in a project with **no other clusters**, or
   watch the logs for `clusters update|upgrade|delete` and kill the offending

--- a/.agents/skills/run-parallel-evals/SKILL.md
+++ b/.agents/skills/run-parallel-evals/SKILL.md
@@ -186,7 +186,7 @@ part of the run, not optional.
   terminal **and** summarized; emit a periodic heartbeat instead.
 - **Cluster-mutation blast radius (with-mcp + a broadly privileged SA).** When
   the runner's service account has broad rights, a cluster-aware MCP server
-  (e.g. `k8s-mcp` or `gke-mcp` on the bastion) exposes every real cluster in the project as
+  (e.g. `gke-mcp` when the cluster provider is GKE) exposes every real cluster in the project as
   a writable target — an agent can start a cluster update/upgrade through the
   provider CLI against a cluster the eval never provisioned, a long-running
   op with no agent timeout, so the run **hangs** (no score) and may mutate an

--- a/.agents/skills/task-review/SKILL.md
+++ b/.agents/skills/task-review/SKILL.md
@@ -42,7 +42,11 @@ doing it inline.
 
 Loads against the `Task` schema (validate by parsing, not by eye — typo'd keys are
 silently dropped). `task_id` is **globally unique** (`grep -rn '^task_id\|^id:'
-tasks/`). Required fields present: `task_id`, `name`, `prompt`, `expected_output`,
+tasks/`). The task's **directory basename is globally unique** across `tasks/**`
+(compare parent dir names of every `tasks/**/task.yaml`) — the matrix runner keys
+run IDs, cluster names, and output dirs on the folder name, not `task_id`, so
+`tasks/gcp/foo` and `tasks/kind/foo` collide even with distinct ids. Required
+fields present: `task_id`, `name`, `prompt`, `expected_output`,
 `infrastructure`. `infrastructure.deployer` is `tofu` or `noop` — **`noop` only for
 manifest-generation tasks** (no cluster). For `tofu`, `infrastructure.stack`
 resolves to an existing `tf/prebuilt/<dir>` (confirm the directory exists).

--- a/.agents/skills/task-review/SKILL.md
+++ b/.agents/skills/task-review/SKILL.md
@@ -30,7 +30,7 @@ Read these as the source of truth; don't reconstruct them from memory:
   Confirm what a run gets for free before asserting a collision is or isn't covered.
 
 Review-only: you **may** run schema/spec-parse checks and `uv run pytest`, from
-the project root; you must **not** run `tofu`/`gcloud`/`kind`/`kubectl` or
+the project root; you must **not** run `tofu`, cloud provider CLIs, `kind`, or `kubectl`, or
 launch an eval. Assess solvability, teardown, and parallel-safety by **reading**
 the stack and scripts — never by provisioning. If a capability is needed, consult
 [harness-capabilities](../../references/harness-capabilities.md) and degrade to
@@ -110,8 +110,8 @@ Flag any task/stack/prompt that pins one of these to a fixed value.
 4. **Node-SA names carry their own discriminator.** `tf/modules/cluster/gke`
    builds `account_id = "gke-nodes-<slug>-<md5(cluster_name)[:6]>"`, so two
    clusters whose names collide after slug truncation still get distinct service
-   accounts. This used to be a parallel-safety blocker for multi-cluster GKE
-   tasks and no longer is — do not flag it. A stack that names its own service
+   accounts. This used to be a parallel-safety blocker for multi-cluster
+   tasks on this deployer and no longer is — do not flag it. A stack that names its own service
    account without such a discriminator still should be flagged. The
    `409 gke-nodes-*` router row.
 5. **No per-task mutation of the shared VM service-account IAM.** A stack that

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -39,6 +39,7 @@ reviews:
     - path: "tasks/**"
       instructions: |
         Focus on benchmarking task definition schema validity, clarity of task descriptions, reproducible setup/teardown steps, and evaluation completeness.
+        Task directory basenames must be globally unique across tasks/** (e.g. tasks/gcp/foo and tasks/kind/foo collide). The matrix runner derives run IDs, cluster names, and output directories from the task directory's basename — not from task_id — so duplicate basenames make distinct tasks share infrastructure identity. Flag any added or renamed task directory whose basename duplicates an existing task directory's.
 
     # TODO: Update paths to devops_bench/skills/** and .agents/skills/** when top-level skills are refactored
     - path: "skills/**"


### PR DESCRIPTION
Agent skills for the day-to-day eval workflow — `run-eval` (single runs), `run-parallel-evals` (matrix runs), `diagnose-eval-failure` (working back from a bad score), and `docs-sync` (keeping docs honest as code changes) — plus references covering the matrix runner, monitoring and recovery, and unlimited mode.

For permission setup, the tool-neutral guidance in `.agents/skills/devops-bench-review/SKILL.md` remains the source of truth; no sample configs are shipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guidance for running individual and parallel evaluations locally or remotely.
  * Added monitoring, recovery, failure diagnosis, and opt-in self-healing procedures.
  * Added documentation synchronization guidance for keeping related documentation current.
  * Added safeguards for shared-environment changes, retries, isolation, and accurate result reporting.

* **Documentation**
  * Documented authentication, dry runs, detached execution, result locations, matrix configuration, and operational safeguards.
  * Documented globally unique task-directory naming requirements to prevent run and infrastructure collisions.
  * Clarified infrastructure-flake handling, fresh retry launches, and routing for model, infrastructure, and rubric issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->