### PR TITLE
Enforce unique task directory basenames in review guidelines

### DIFF
--- a/.agents/skills/task-review/SKILL.md
+++ b/.agents/skills/task-review/SKILL.md
@@ -45,9 +45,8 @@ silently dropped). `task_id` is **globally unique** (`grep -rn '^task_id\|^id:'
 tasks/`). The task's **directory basename is globally unique** across `tasks/**`
 (compare parent dir names of every `tasks/**/task.yaml`) — the matrix runner keys
 run IDs, cluster names, and output dirs on the folder name, not `task_id`, so
-`tasks/gcp/foo` and `tasks/kind/foo` collide even with distinct ids. This is the
-same invariant `.coderabbit.yaml` enforces on every PR under its `tasks/**`
-instructions. Required fields present: `task_id`, `name`, `prompt`, `expected_output`,
+`tasks/gcp/foo` and `tasks/kind/foo` collide even with distinct ids. Required
+fields present: `task_id`, `name`, `prompt`, `expected_output`,
 `infrastructure`. `infrastructure.deployer` is `tofu` or `noop` — **`noop` only for
 manifest-generation tasks** (no cluster). For `tofu`, `infrastructure.stack`
 resolves to an existing `tf/prebuilt/<dir>` (confirm the directory exists).

--- a/.agents/skills/task-review/SKILL.md
+++ b/.agents/skills/task-review/SKILL.md
@@ -42,7 +42,12 @@ doing it inline.
 
 Loads against the `Task` schema (validate by parsing, not by eye — typo'd keys are
 silently dropped). `task_id` is **globally unique** (`grep -rn '^task_id\|^id:'
-tasks/`). Required fields present: `task_id`, `name`, `prompt`, `expected_output`,
+tasks/`). The task's **directory basename is globally unique** across `tasks/**`
+(compare parent dir names of every `tasks/**/task.yaml`) — the matrix runner keys
+run IDs, cluster names, and output dirs on the folder name, not `task_id`, so
+`tasks/gcp/foo` and `tasks/kind/foo` collide even with distinct ids. This is the
+same invariant `.coderabbit.yaml` enforces on every PR under its `tasks/**`
+instructions. Required fields present: `task_id`, `name`, `prompt`, `expected_output`,
 `infrastructure`. `infrastructure.deployer` is `tofu` or `noop` — **`noop` only for
 manifest-generation tasks** (no cluster). For `tofu`, `infrastructure.stack`
 resolves to an existing `tf/prebuilt/<dir>` (confirm the directory exists).

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -39,6 +39,7 @@ reviews:
     - path: "tasks/**"
       instructions: |
         Focus on benchmarking task definition schema validity, clarity of task descriptions, reproducible setup/teardown steps, and evaluation completeness.
+        Task directory basenames must be globally unique across tasks/** (e.g. tasks/gcp/foo and tasks/kind/foo collide). The matrix runner derives run IDs, cluster names, and output directories from the task directory's basename — not from task_id — so duplicate basenames make distinct tasks share infrastructure identity. Flag any added or renamed task directory whose basename duplicates an existing task directory's.
 
     # TODO: Update paths to devops_bench/skills/** and .agents/skills/** when top-level skills are refactored
     - path: "skills/**"


### PR DESCRIPTION
The matrix runner (`scripts/bastion/run_matrix.sh`) derives run IDs, cluster names, and output directories from the task directory basename, not `task_id`, so two task directories with the same folder name (e.g. `tasks/gcp/foo` and `tasks/kind/foo`) would share infrastructure identity even with distinct ids.

Rather than collision-proofing the runner, this encodes basename uniqueness as an authoring invariant, enforced where reviews happen:

- `.coderabbit.yaml`: add the rule to the `tasks/**` path instructions so it fires automatically on every PR that adds or renames a task directory.
- `.agents/skills/task-review`: mirror the same check in the schema/metadata checklist, next to the existing `task_id` uniqueness check.

No collisions exist in the tree today.

Addresses the unresolved CodeRabbit finding on #124 (`.agents/references/running-evals.md`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that task directory names must be globally unique across all task paths.
  * Documented that directory names determine run IDs, cluster names, and output directories.
  * Added review guidance to identify naming collisions during task validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->