### PR TITLE
fix(deps): cap mcp below 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,10 @@ dependencies = [
     "deepeval>=4.0.3",
     "google-genai>=2.8.0",
     "jsonpath-ng>=1.6",
-    "mcp>=1.27.1",
+    # Capped below 2: the MCP client surface the api harness imports
+    # (``mcp.client.session`` / ``mcp.client.stdio``) is free to change across a
+    # major, and an unpinned floor lets a routine ``uv sync`` pull one mid-run.
+    "mcp>=1.27.1,<2",
     "pydantic>=2.0",
     "ruamel.yaml>=0.18.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -493,7 +493,7 @@ requires-dist = [
     { name = "deepeval", specifier = ">=4.0.3" },
     { name = "google-genai", specifier = ">=2.8.0" },
     { name = "jsonpath-ng", specifier = ">=1.6" },
-    { name = "mcp", specifier = ">=1.27.1" },
+    { name = "mcp", specifier = ">=1.27.1,<2" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "ruamel-yaml", specifier = ">=0.18.0" },


### PR DESCRIPTION
## What

Change the root `mcp` dependency from `mcp>=1.27.1` to `mcp>=1.27.1,<2`.

## Why

`mcp` is a **root** dependency — everyone installing the benchmark gets it — and it currently declares a floor with no ceiling.

The api harness imports the MCP client surface directly:

```python
# devops_bench/agents/api/mcp.py
from mcp.client.session import ClientSession
from mcp.client.stdio import StdioServerParameters, stdio_client
```

Semver puts no constraint on what a 2.0 release may do to that surface. Until the cap exists, a routine `uv sync`, a lockfile refresh, or a fresh install on a CI runner can resolve a breaking major without anyone touching this repo. The first symptom would be a benchmark run failing on a dependency nobody changed — an expensive thing to debug mid-eval, and an easy thing to prevent.

This is the standard reason to cap a direct dependency at the next major, and it is worth doing pre-emptively rather than reactively because the failure lands on whoever happens to sync next.

## Blast radius

**Resolution is unchanged.** `mcp` stays at 1.28.1 and no other package moves — the entire `uv.lock` diff is the one specifier line:

```diff
-    { name = "mcp", specifier = ">=1.27.1" },
+    { name = "mcp", specifier = ">=1.27.1,<2" },
```

So this is a guard, not an upgrade. Lifting it is a deliberate follow-up once the 2.x client API is known and the harness is ported.

## Testing

`uv run pytest` — 1212 passed.

## Context

Noticed while adding an ADK agent harness (#137). ADK's `McpToolset` caps itself at `mcp<2`, but only under its `mcp` / `all` / `test` extras, so that ceiling does not enter our resolution. Capping at the root covers both consumers. Filed separately because it touches the api harness and every future MCP consumer, and deserves review on its own terms rather than buried in a feature PR.

Tracked by #138.
