### PR TITLE
feat(agents): add an ADK agent harness

### DIFF
--- a/devops_bench/agents/adk/__init__.py
+++ b/devops_bench/agents/adk/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""In-process harness for agents built with the Agent Development Kit (ADK).
+
+The harness loads a caller-supplied ADK agent, drives it through ADK's own
+``Runner``, and folds the resulting event stream into the canonical trajectory.
+Importing this package pulls no SDK — :mod:`devops_bench.agents.adk.agent`
+imports ``google.adk`` lazily inside ``_execute`` so a host without the optional
+``adk`` extra can still import the agents tree.
+"""
+
+from __future__ import annotations

--- a/devops_bench/agents/adk/agent.py
+++ b/devops_bench/agents/adk/agent.py
@@ -234,6 +234,52 @@ def _append_instruction(agent: Any, text: str) -> bool:
     return True
 
 
+def _apply_instruction(agent: Any, text: str) -> tuple[int, list[str]]:
+    """Append ``text`` to every instruction-bearing agent in the tree.
+
+    Rules and skills are granted to the *run*, not to one node of it. The
+    benchmark grades a tree as a single agent, and a delegate that never sees
+    the operator brief can violate a constraint the root was told about.
+
+    Workflow agents (``SequentialAgent`` and friends) carry no instruction and
+    are skipped. A node using a callable instruction provider is named in the
+    returned list, so the caller can report it rather than drop it silently.
+    """
+    delivered = 0
+    refused: list[str] = []
+    for node in _iter_agents(agent):
+        if not hasattr(node, "instruction"):
+            continue
+        if _append_instruction(node, text):
+            delivered += 1
+        else:
+            refused.append(str(getattr(node, "name", None) or "<unnamed>"))
+    return delivered, refused
+
+
+def _attach_toolsets(agent: Any, toolsets: list[Any]) -> int:
+    """Attach ``toolsets`` to every tool-bearing agent in the tree.
+
+    ADK resolves tools from the *active* agent alone (``BaseLlmFlow`` asks
+    ``LlmAgent.canonical_tools``, which returns that agent's own ``tools``);
+    nothing is inherited from a parent. Attaching to the root only would leave
+    every delegate unable to touch the cluster the benchmark provisioned, and
+    the run would still report success — it would just score zero.
+
+    The toolset objects are shared across nodes rather than rebuilt per node,
+    so a binding still means one MCP server process. ``McpToolset.close`` is
+    documented as safe to call more than once, which is what ADK's cleanup does
+    when the same toolset is reachable from several agents.
+    """
+    attached = 0
+    for node in _iter_agents(agent):
+        if not hasattr(node, "tools"):
+            continue
+        node.tools = list(getattr(node, "tools", None) or []) + toolsets
+        attached += 1
+    return attached
+
+
 def _render_skills(paths: tuple[str, ...]) -> tuple[str, list[str]]:
     """Render discovered skills as an instruction section.
 
@@ -468,16 +514,20 @@ class AdkAgent(base.AgentHarness):
         if skills_section:
             sections.append(skills_section)
             metadata["skills"] = skill_names
-        if sections and not _append_instruction(prepared, "\n\n".join(sections)):
-            errors.append(
-                "agent uses a callable instruction provider; rules and skills were not delivered"
-            )
+        if sections:
+            delivered, refused = _apply_instruction(prepared, "\n\n".join(sections))
+            metadata["instruction_agents"] = delivered
+            if refused:
+                errors.append(
+                    "rules and skills were not delivered to agents using a callable "
+                    f"instruction provider: {', '.join(refused)}"
+                )
 
         toolsets, toolset_errors = _build_toolsets(self.mcp_servers)
         errors.extend(toolset_errors)
         if toolsets:
-            prepared.tools = list(prepared.tools or []) + toolsets
             metadata["mcp_toolsets"] = len(toolsets)
+            metadata["mcp_agents"] = _attach_toolsets(prepared, toolsets)
 
         return prepared, metadata, errors
 

--- a/devops_bench/agents/adk/agent.py
+++ b/devops_bench/agents/adk/agent.py
@@ -1,0 +1,489 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""In-process harness driving an agent built with the Agent Development Kit."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+from types import ModuleType
+from typing import TYPE_CHECKING, Any
+
+from devops_bench import core
+from devops_bench.agents import base
+from devops_bench.agents import config as agents_config
+from devops_bench.agents import result as agents_result
+from devops_bench.agents.adk import parsing
+from devops_bench.agents.shared import cli_capabilities
+from devops_bench.agents.shared import skills as shared_skills
+
+if TYPE_CHECKING:
+    from devops_bench.agents import capabilities
+
+__all__ = ["AdkAgent"]
+
+_log = core.get_logger("agents.adk")
+
+#: Optional dependency group carrying the ADK SDK.
+_EXTRA = "adk"
+
+#: Attribute an ADK agent module is expected to expose, matching the convention
+#: ADK's own loader follows.
+_ROOT_AGENT_ATTR = "root_agent"
+
+#: Submodule searched when a target package does not expose the root agent
+#: itself — again ADK's own ``<agent_dir>/agent.py`` convention.
+_AGENT_SUBMODULE = "agent"
+
+#: Identifiers for the throwaway session each run drives the agent through.
+_APP_NAME = "devops-bench"
+_USER_ID = "devops-bench"
+
+#: Budget for an MCP server to start and list its tools. Deliberately generous:
+#: a tool server that shells out to a cloud CLI can be slow on a cold start, and
+#: the SDK default is tuned for local in-memory servers.
+_MCP_STARTUP_TIMEOUT_SEC = 60.0
+
+
+def _looks_like_path(spec: str) -> bool:
+    """Report whether a target names a filesystem location, not a module.
+
+    A dotted module path (``my_pkg.agent``) and a filesystem path are both
+    plausible targets, so the two are told apart syntactically rather than by
+    probing the filesystem — a stray directory sharing a module's name must not
+    silently change which agent loads.
+    """
+    return spec.endswith(".py") or spec.startswith(("~", ".")) or os.sep in spec
+
+
+def _ensure_on_sys_path(directory: pathlib.Path) -> None:
+    """Prepend ``directory`` to ``sys.path`` when it is not already there."""
+    entry = str(directory)
+    if entry not in sys.path:
+        sys.path.insert(0, entry)
+
+
+def _import_file(path: pathlib.Path, module_name: str) -> ModuleType:
+    """Import a single ``.py`` file under ``module_name``, parent importable.
+
+    Args:
+        path: The ``.py`` file to load.
+        module_name: Name to register the module under. Callers name it after
+            the agent *directory* rather than the file, because ADK's layout
+            puts every agent in an ``agent.py`` and registering that name would
+            have each target clobber the last (and shadow any unrelated
+            top-level ``agent`` module).
+
+    Returns:
+        The executed module.
+
+    Raises:
+        ConfigError: When the file is missing or has no usable import spec.
+    """
+    if not path.is_file():
+        raise core.ConfigError(f"no ADK agent module at {path}")
+    _ensure_on_sys_path(path.parent)
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise core.ConfigError(f"cannot import an ADK agent module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    # Register before executing so a module that imports itself by name (or is
+    # re-imported by a dataclass/pydantic hook) resolves to this same object,
+    # and drop the half-built entry again if execution fails.
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+def _import_agent_module(spec: str) -> ModuleType:
+    """Import the module holding the ADK agent named by ``spec``.
+
+    Args:
+        spec: A dotted module path, a path to a ``.py`` file, or a path to an
+            agent directory laid out the way ADK expects
+            (``<dir>/agent.py`` exposing ``root_agent``).
+
+    Returns:
+        The imported module.
+
+    Raises:
+        ConfigError: When the target names nothing importable.
+    """
+    if not _looks_like_path(spec):
+        return importlib.import_module(spec)
+
+    path = pathlib.Path(os.path.expanduser(spec))
+    if not path.is_dir():
+        return _import_file(path, path.stem)
+
+    _ensure_on_sys_path(path.parent)
+    if (path / "__init__.py").is_file():
+        # A real package: import it by name so relative imports inside the
+        # agent resolve against the package rather than breaking.
+        return importlib.import_module(path.name)
+    return _import_file(path / f"{_AGENT_SUBMODULE}.py", path.name)
+
+
+def _resolve_root_agent(target: str) -> Any:
+    """Load the ADK agent named by ``AGENT_TARGET``.
+
+    Four spellings are accepted::
+
+        my_pkg.agent:root_agent   # explicit module + attribute
+        my_pkg.agent              # module, attribute defaults to root_agent
+        ~/agents/my_agent         # ADK agent directory (<dir>/agent.py)
+        ~/agents/my_agent/agent.py
+
+    When the resolved attribute is a factory rather than an agent it is called
+    with no arguments, so a team that builds its agent lazily needs no wrapper.
+
+    Args:
+        target: The configured target string.
+
+    Returns:
+        The ADK agent object.
+
+    Raises:
+        ConfigError: When the target is empty, names nothing importable,
+            or resolves to something that is not an ADK agent.
+    """
+    from google.adk.agents import BaseAgent
+
+    spec, _, attr = target.partition(":")
+    attr = attr or _ROOT_AGENT_ATTR
+
+    module = _import_agent_module(spec)
+    obj = getattr(module, attr, None)
+    if obj is None and hasattr(module, "__path__"):
+        # A package whose ``__init__`` does not re-export the agent: fall back
+        # to ADK's ``<package>/agent.py`` convention.
+        module = importlib.import_module(f"{module.__name__}.{_AGENT_SUBMODULE}")
+        obj = getattr(module, attr, None)
+    if obj is None:
+        raise core.ConfigError(f"module {module.__name__!r} exposes no {attr!r}")
+
+    if not isinstance(obj, BaseAgent) and callable(obj):
+        obj = obj()
+    if not isinstance(obj, BaseAgent):
+        raise core.ConfigError(
+            f"{module.__name__}:{attr} is a {type(obj).__name__}, not an ADK agent"
+        )
+    return obj
+
+
+def _iter_agents(agent: Any) -> list[Any]:
+    """Return ``agent`` and every descendant, depth-first."""
+    found = [agent]
+    for sub in getattr(agent, "sub_agents", None) or ():
+        found.extend(_iter_agents(sub))
+    return found
+
+
+def _apply_model(agent: Any, model: str) -> int:
+    """Point every agent in the tree at ``model`` and report how many changed.
+
+    A benchmark compares agents at a fixed model, so ``AGENT_MODEL`` overrides
+    whatever the team baked into its agent — including sub-agents, since a tree
+    left half-overridden would report a model it only partly ran.
+    """
+    changed = 0
+    for node in _iter_agents(agent):
+        if not hasattr(node, "model"):
+            continue
+        node.model = model
+        changed += 1
+    return changed
+
+
+def _append_instruction(agent: Any, text: str) -> bool:
+    """Append ``text`` to the agent's instruction, reporting whether it landed.
+
+    ADK also accepts a *callable* instruction provider. There is no sound way to
+    append to one, so the text is refused rather than silently dropped — the
+    caller surfaces that as an error on the result.
+    """
+    if not text:
+        return True
+    current = getattr(agent, "instruction", None)
+    if current is not None and not isinstance(current, str):
+        return False
+    agent.instruction = f"{current}\n\n{text}" if current else text
+    return True
+
+
+def _render_skills(paths: tuple[str, ...]) -> tuple[str, list[str]]:
+    """Render discovered skills as an instruction section.
+
+    ADK has no skills primitive, so skills are delivered the way rules are: as
+    text the agent reads. Discovery goes through the shared walk, so which files
+    count as skills cannot drift from the other harnesses.
+
+    Args:
+        paths: Skill source directories granted for the run.
+
+    Returns:
+        A ``(section, names)`` tuple; both are empty when nothing was found.
+    """
+    blocks: list[str] = []
+    names: list[str] = []
+    for skill in shared_skills.iter_skills(paths):
+        names.append(skill.name)
+        blocks.append(skill.content)
+    if not blocks:
+        return "", []
+    return "# Available skills\n\n" + "\n\n".join(blocks), names
+
+
+def _load_toolset_types() -> tuple[Any, Any, Any]:
+    """Return the ``(McpToolset, StdioConnectionParams, StdioServerParameters)`` types.
+
+    ``McpToolset`` was spelled ``MCPToolset`` in older ADK releases; both are
+    accepted so the harness is not pinned to one SDK minor.
+    """
+    from google.adk.tools.mcp_tool import mcp_session_manager, mcp_toolset
+    from mcp import StdioServerParameters
+
+    toolset = getattr(mcp_toolset, "McpToolset", None) or mcp_toolset.MCPToolset
+    return toolset, mcp_session_manager.StdioConnectionParams, StdioServerParameters
+
+
+def _build_toolsets(
+    mcp_servers: tuple[capabilities.McpBinding, ...],
+) -> tuple[list[Any], list[str]]:
+    """Build one ADK MCP toolset per binding that carries a launch command.
+
+    A binding with no command denotes a server the agent hosts itself, so it is
+    skipped — matching how the CLI harnesses read the same binding.
+
+    Args:
+        mcp_servers: Bindings granted for the run.
+
+    Returns:
+        A ``(toolsets, errors)`` tuple. ``errors`` is non-empty when the SDK's
+        MCP support could not be loaded at all, in which case no toolset is
+        returned and the caller reports that the agent ran without its tools.
+    """
+    # Reuse the shared builder so path-like commands resolve identically across
+    # harnesses. One binding in, at most one entry out, so pairing each binding
+    # with its own result keeps the tool filter attached to the right server
+    # even when an earlier binding carried no command.
+    pairs = [
+        (binding, entry)
+        for binding in mcp_servers
+        for entry in cli_capabilities.build_mcp_servers((binding,)).values()
+    ]
+    if not pairs:
+        return [], []
+
+    try:
+        toolset_cls, connection_cls, server_params_cls = _load_toolset_types()
+    except ImportError as exc:
+        return [], [f"ADK MCP support unavailable, agent ran without MCP tools: {exc}"]
+
+    toolsets: list[Any] = []
+    for binding, entry in pairs:
+        params = connection_cls(
+            server_params=server_params_cls(
+                command=entry["command"], args=list(entry.get("args", []))
+            ),
+            timeout=_MCP_STARTUP_TIMEOUT_SEC,
+        )
+        toolsets.append(
+            toolset_cls(
+                connection_params=params,
+                tool_filter=list(binding.tools) or None,
+            )
+        )
+    return toolsets, []
+
+
+def _dump_event(event: Any) -> dict:
+    """Serialize one ADK event into a JSON-safe mapping.
+
+    ``mode="json"`` is tried first because it renders enums and timestamps
+    faithfully, but it raises on a tool that returned an object pydantic cannot
+    encode. The fallback stringifies those leaves so one exotic tool result
+    costs a field's fidelity rather than the whole trajectory.
+    """
+    try:
+        return event.model_dump(mode="json", exclude_none=True)
+    except Exception as exc:  # noqa: BLE001 - any serializer failure must degrade, not abort
+        _log.debug("event did not serialize in json mode (%s); coercing", exc)
+        return json.loads(json.dumps(event.model_dump(mode="python"), default=str))
+
+
+def _drive(root_agent: Any, prompt: str, timeout_sec: float | None) -> tuple[list[dict], list[str]]:
+    """Run the agent to completion and collect its serialized event stream.
+
+    ``events`` is populated as the stream arrives rather than at the end: ADK
+    surfaces a failing tool by yielding an error event and *then* raising out of
+    the iterator, so a run that dies mid-way still has a partial trajectory
+    worth scoring. Both the timeout and the failure are recorded as errors and
+    returned alongside whatever was collected.
+
+    Args:
+        root_agent: The prepared ADK agent.
+        prompt: Task prompt to send as the user message.
+        timeout_sec: Wall-clock budget, or ``None`` for no limit.
+
+    Returns:
+        A ``(events, errors)`` tuple.
+    """
+    from google.adk.runners import InMemoryRunner
+    from google.genai import types
+
+    events: list[dict] = []
+    errors: list[str] = []
+
+    async def _consume() -> None:
+        runner = InMemoryRunner(root_agent, app_name=_APP_NAME)
+        try:
+            session = await runner.session_service.create_session(
+                app_name=_APP_NAME, user_id=_USER_ID
+            )
+            message = types.Content(role="user", parts=[types.Part(text=prompt)])
+            async for event in runner.run_async(
+                user_id=_USER_ID, session_id=session.id, new_message=message
+            ):
+                events.append(_dump_event(event))
+        finally:
+            await runner.close()
+
+    async def _main() -> None:
+        try:
+            if timeout_sec is None:
+                await _consume()
+            else:
+                await asyncio.wait_for(_consume(), timeout=timeout_sec)
+        except TimeoutError:
+            errors.append(f"ADK run exceeded the {timeout_sec}s budget")
+        except Exception as exc:  # noqa: BLE001 - keep the partial trajectory
+            errors.append(f"ADK run failed: {type(exc).__name__}: {exc}")
+
+    asyncio.run(_main())
+    return events, errors
+
+
+@base.AGENTS.register("adk")
+class AdkAgent(base.AgentHarness):
+    """Harness driving an Agent Development Kit agent in-process.
+
+    ``AGENT_TARGET`` names the agent to load — a dotted module path, an
+    ``agent_dir``, or either of those with an explicit ``:attribute``. The agent
+    is deep-copied before the run so the harness's edits (model override,
+    instruction text, MCP toolsets) never leak into the imported module and a
+    second run in the same process starts from the same baseline.
+
+    The trajectory comes from ADK's own event stream, so tool calls are recorded
+    as the agent makes them rather than reconstructed from its prose.
+    """
+
+    def __init__(self, config: agents_config.AgentConfig | None = None) -> None:
+        super().__init__(config)
+        caps = self.config.capabilities
+        self.mcp_servers = caps.mcp_servers
+        self.skills = caps.skills
+        self.rules = caps.rules
+
+    def _prepare(self, root_agent: Any) -> tuple[Any, dict, list[str]]:
+        """Apply the run's model, capabilities, and tools to a private copy.
+
+        Args:
+            root_agent: The agent as imported (left untouched).
+
+        Returns:
+            A ``(prepared_agent, metadata, errors)`` tuple.
+        """
+        prepared = root_agent.model_copy(deep=True)
+        metadata: dict = {"agent_name": getattr(prepared, "name", None)}
+        errors: list[str] = []
+
+        if self.config.model:
+            metadata["model_override_count"] = _apply_model(prepared, self.config.model)
+
+        sections: list[str] = []
+        if self.rules.text:
+            sections.append(self.rules.text)
+        skills_section, skill_names = _render_skills(self.skills.paths)
+        if skills_section:
+            sections.append(skills_section)
+            metadata["skills"] = skill_names
+        if sections and not _append_instruction(prepared, "\n\n".join(sections)):
+            errors.append(
+                "agent uses a callable instruction provider; rules and skills were not delivered"
+            )
+
+        toolsets, toolset_errors = _build_toolsets(self.mcp_servers)
+        errors.extend(toolset_errors)
+        if toolsets:
+            prepared.tools = list(prepared.tools or []) + toolsets
+            metadata["mcp_toolsets"] = len(toolsets)
+
+        return prepared, metadata, errors
+
+    def _execute(
+        self, prompt: str, workspace_path: pathlib.Path | None = None
+    ) -> agents_result.AgentResult:
+        # An ADK agent runs in-process and owns its own tool surface, so it has
+        # no subprocess to point at ``workspace_path``; the parameter is part of
+        # the base contract and deliberately unused here.
+        del workspace_path
+
+        try:
+            import google.adk  # noqa: F401
+        except ImportError as exc:
+            raise core.MissingDependencyError("the ADK agent harness", _EXTRA) from exc
+
+        target = (self.config.target or "").strip()
+        if not target:
+            return agents_result.AgentResult.errored(
+                "AGENT_TARGET must name the ADK agent to run "
+                "(e.g. 'my_pkg.agent:root_agent' or a path to an agent directory)"
+            )
+
+        try:
+            root_agent = _resolve_root_agent(target)
+        except (core.ConfigError, ImportError, AttributeError, TypeError) as exc:
+            return agents_result.AgentResult.errored(
+                f"could not load the ADK agent at {target!r}: {type(exc).__name__}: {exc}"
+            )
+
+        prepared, metadata, errors = self._prepare(root_agent)
+        events, run_errors = _drive(prepared, prompt, self.config.timeout_sec)
+        errors.extend(run_errors)
+
+        output, trajectory, tokens, parse_errors = parsing.parse_event_stream(events)
+        errors.extend(parse_errors)
+        metadata["event_count"] = len(events)
+
+        if not output and errors:
+            output = f"Error: {errors[0]}"
+
+        return agents_result.AgentResult(
+            output=output,
+            trajectory=trajectory,
+            tokens=tokens,
+            errors=errors,
+            metadata=metadata,
+        )

--- a/devops_bench/agents/adk/agent.py
+++ b/devops_bench/agents/adk/agent.py
@@ -17,12 +17,14 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import importlib
 import importlib.util
 import json
 import os
 import pathlib
 import sys
+from collections.abc import Iterator
 from types import ModuleType
 from typing import TYPE_CHECKING, Any
 
@@ -333,6 +335,38 @@ def _dump_event(event: Any) -> dict:
         return json.loads(json.dumps(event.model_dump(mode="python"), default=str))
 
 
+@contextlib.contextmanager
+def _in_workspace(workspace_path: pathlib.Path | None) -> Iterator[None]:
+    """Run the agent with the harness workspace as the process working directory.
+
+    The CLI harnesses launch their binary with ``cwd`` set to the harness-owned
+    workspace, so a task that says "write ``report.md``" produces a file the
+    orchestrator can diff and collect. An ADK agent runs in-process and has no
+    subprocess to point anywhere, so without this its filesystem tools resolve
+    relative paths against *the harness's* working directory: the deliverable
+    misses the artifact diff entirely, and it lands somewhere shared where the
+    next run can still see it.
+
+    ``chdir`` is process-global, which is safe here only because the harness
+    drives one agent at a time and the ADK run is confined to a single
+    ``asyncio.run``. The previous directory is always restored.
+
+    Args:
+        workspace_path: The harness-owned workspace, or ``None`` when the
+            orchestrator did not supply one (the agent then keeps the current
+            directory, as before).
+    """
+    if workspace_path is None:
+        yield
+        return
+    previous = os.getcwd()
+    os.chdir(workspace_path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
 def _drive(root_agent: Any, prompt: str, timeout_sec: float | None) -> tuple[list[dict], list[str]]:
     """Run the agent to completion and collect its serialized event stream.
 
@@ -397,6 +431,11 @@ class AdkAgent(base.AgentHarness):
 
     The trajectory comes from ADK's own event stream, so tool calls are recorded
     as the agent makes them rather than reconstructed from its prose.
+
+    The run happens with the harness-owned workspace as the process working
+    directory, matching the ``cwd`` the CLI harnesses give their subprocess, so
+    an agent with filesystem tools writes its deliverables where the
+    orchestrator collects them.
     """
 
     def __init__(self, config: agents_config.AgentConfig | None = None) -> None:
@@ -445,11 +484,6 @@ class AdkAgent(base.AgentHarness):
     def _execute(
         self, prompt: str, workspace_path: pathlib.Path | None = None
     ) -> agents_result.AgentResult:
-        # An ADK agent runs in-process and owns its own tool surface, so it has
-        # no subprocess to point at ``workspace_path``; the parameter is part of
-        # the base contract and deliberately unused here.
-        del workspace_path
-
         try:
             import google.adk  # noqa: F401
         except ImportError as exc:
@@ -469,8 +503,14 @@ class AdkAgent(base.AgentHarness):
                 f"could not load the ADK agent at {target!r}: {type(exc).__name__}: {exc}"
             )
 
+        # Prepared outside the workspace: ``_build_toolsets`` resolves path-like
+        # MCP commands against the current directory, and those are the
+        # operator's paths, not the agent's.
         prepared, metadata, errors = self._prepare(root_agent)
-        events, run_errors = _drive(prepared, prompt, self.config.timeout_sec)
+        if workspace_path is not None:
+            metadata["workspace"] = str(workspace_path)
+        with _in_workspace(workspace_path):
+            events, run_errors = _drive(prepared, prompt, self.config.timeout_sec)
         errors.extend(run_errors)
 
         output, trajectory, tokens, parse_errors = parsing.parse_event_stream(events)

--- a/devops_bench/agents/adk/agent.py
+++ b/devops_bench/agents/adk/agent.py
@@ -63,6 +63,11 @@ _USER_ID = "devops-bench"
 #: the SDK default is tuned for local in-memory servers.
 _MCP_STARTUP_TIMEOUT_SEC = 60.0
 
+#: Budget for releasing the runner once the run is over. Only a wedged MCP
+#: server gets anywhere near it; the cap is what stops one from turning a
+#: reported timeout into a hang.
+_CLOSE_TIMEOUT_SEC = 30.0
+
 
 def _looks_like_path(spec: str) -> bool:
     """Report whether a target names a filesystem location, not a module.
@@ -118,6 +123,35 @@ def _import_file(path: pathlib.Path, module_name: str) -> ModuleType:
     return module
 
 
+def _verify_imported_from(module: ModuleType, directory: pathlib.Path) -> ModuleType:
+    """Return ``module`` once confirmed to be the package under ``directory``.
+
+    ``import_module`` consults ``sys.modules`` before it consults ``sys.path``,
+    so prepending the agent's parent does not guarantee the name resolves to the
+    directory that was asked for: anything that already imported a package of
+    the same name wins, whether that is a stale ``PYTHONPATH`` entry or an
+    installed distribution sharing a generic directory name. Left unchecked the
+    harness would benchmark a different agent and still report success, so a
+    mismatch is raised rather than papered over.
+
+    Raises:
+        ConfigError: When the imported module does not live under ``directory``.
+    """
+    origin = getattr(module, "__file__", None)
+    if origin is not None:
+        try:
+            resolved = pathlib.Path(origin).resolve()
+        except OSError:
+            resolved = pathlib.Path(origin)
+        if resolved.is_relative_to(directory.resolve()):
+            return module
+    raise core.ConfigError(
+        f"the name {module.__name__!r} already resolves to "
+        f"{origin or '<no file>'}, not the agent at {directory}; rename the "
+        "agent directory or clear the conflicting module from the environment"
+    )
+
+
 def _import_agent_module(spec: str) -> ModuleType:
     """Import the module holding the ADK agent named by ``spec``.
 
@@ -143,7 +177,7 @@ def _import_agent_module(spec: str) -> ModuleType:
     if (path / "__init__.py").is_file():
         # A real package: import it by name so relative imports inside the
         # agent resolve against the package rather than breaking.
-        return importlib.import_module(path.name)
+        return _verify_imported_from(importlib.import_module(path.name), path)
     return _import_file(path / f"{_AGENT_SUBMODULE}.py", path.name)
 
 
@@ -413,6 +447,35 @@ def _in_workspace(workspace_path: pathlib.Path | None) -> Iterator[None]:
         os.chdir(previous)
 
 
+async def _close_quietly(runner: Any) -> None:
+    """Release ``runner`` even while the surrounding run is being cancelled.
+
+    A timeout cancels the coroutine that owns the runner, and the cancellation
+    keeps landing on whatever it awaits next — including the awaits inside
+    ``close()``. Left to inherit it, teardown stops half-way and leaks the MCP
+    server subprocess, which one binding shares across the whole tree.
+
+    So teardown runs as its own task and is awaited through ``shield``: a
+    cancellation aimed at us no longer reaches it, and the loop goes back to
+    waiting instead of returning early. ``_CLOSE_TIMEOUT_SEC`` bounds that wait
+    so a wedged server cannot turn a reported timeout into a hang. Nothing is
+    re-raised — the caller's timeout or failure is the error worth surfacing.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _CLOSE_TIMEOUT_SEC
+    closing = asyncio.ensure_future(runner.close())
+    while not closing.done():
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            _log.warning("ADK runner did not close within %ss", _CLOSE_TIMEOUT_SEC)
+            closing.cancel()
+            break
+        with contextlib.suppress(asyncio.CancelledError, TimeoutError):
+            await asyncio.wait_for(asyncio.shield(closing), timeout=remaining)
+    with contextlib.suppress(BaseException):
+        await closing
+
+
 def _drive(root_agent: Any, prompt: str, timeout_sec: float | None) -> tuple[list[dict], list[str]]:
     """Run the agent to completion and collect its serialized event stream.
 
@@ -448,7 +511,7 @@ def _drive(root_agent: Any, prompt: str, timeout_sec: float | None) -> tuple[lis
             ):
                 events.append(_dump_event(event))
         finally:
-            await runner.close()
+            await _close_quietly(runner)
 
     async def _main() -> None:
         try:

--- a/devops_bench/agents/adk/parsing.py
+++ b/devops_bench/agents/adk/parsing.py
@@ -1,0 +1,279 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parser for the serialized ADK event stream.
+
+An ADK run yields ``Event`` objects; the harness serializes each one and hands
+the resulting list here. Working on plain mappings rather than SDK objects keeps
+this module import-light (no ``google.adk`` dependency) and lets the tests
+exercise the fold against recorded event dumps.
+
+Each event carries a ``content.parts`` list. Three part shapes matter:
+
+| Part shape          | Meaning                                              |
+|---------------------|------------------------------------------------------|
+| ``function_call``   | The model asked for a tool (``id``, ``name``, ``args``) |
+| ``function_response`| The tool answered (``id``, ``name``, ``response``)   |
+| ``text``            | Assistant prose                                      |
+
+Calls and responses are correlated by the ``id`` ADK stamps on both sides, so a
+call and its result fold into one :class:`~devops_bench.agents.result.ToolCall`
+rather than two trajectory entries.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import deque
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from devops_bench.agents.result import ToolCall, empty_tokens
+
+__all__: list[str] = ["parse_event_stream"]
+
+# ``usage_metadata`` field -> the accumulator slot it feeds. ADK passes the
+# google-genai usage block through verbatim, so these are the genai names.
+_USAGE_FIELDS: dict[str, str] = {
+    "prompt_token_count": "prompt",
+    "cached_content_token_count": "cached",
+    "candidates_token_count": "output",
+    "thoughts_token_count": "reasoning",
+    "total_token_count": "total",
+}
+
+
+def _int_or_none(value: object) -> int | None:
+    """Coerce to ``int``, rejecting ``bool`` (a JSON ``true`` is not a count)."""
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _parts(event: Mapping[str, Any]) -> list[Any]:
+    """Return an event's ``content.parts`` list, or ``[]`` when it has none."""
+    content = event.get("content")
+    if not isinstance(content, Mapping):
+        return []
+    parts = content.get("parts")
+    return parts if isinstance(parts, list) else []
+
+
+def _is_user_content(event: Mapping[str, Any]) -> bool:
+    """Report whether the event's content is authored by the user.
+
+    Tool results ride on ``role="user"`` content too, so this only gates *text*
+    accumulation — never the function-call fold.
+    """
+    content = event.get("content")
+    return isinstance(content, Mapping) and content.get("role") == "user"
+
+
+def _response_text(response: Any) -> tuple[str, bool]:
+    """Render a tool response as trajectory text and report whether it failed.
+
+    Three response shapes reach here:
+
+    * an MCP tool result — ``{"content": [{"type": "text", ...}], "isError": ...}``,
+      rendered as the concatenated text blocks so the trajectory stays readable
+      instead of carrying the envelope,
+    * ADK's error convention — a mapping carrying a truthy ``error`` key,
+    * any other tool return value, rendered as sorted JSON.
+
+    Args:
+        response: The ``function_response.response`` payload.
+
+    Returns:
+        A ``(text, is_error)`` tuple.
+    """
+    if not isinstance(response, Mapping):
+        return ("" if response is None else str(response)), False
+
+    is_error = bool(response.get("isError")) or bool(response.get("error"))
+
+    blocks = response.get("content")
+    if isinstance(blocks, list):
+        texts = [
+            block["text"]
+            for block in blocks
+            if isinstance(block, Mapping) and isinstance(block.get("text"), str)
+        ]
+        if texts:
+            return "\n".join(texts), is_error
+
+    return json.dumps(response, sort_keys=True, default=str), is_error
+
+
+def _accumulate_usage(usage: Any, sums: dict[str, int], seen: set[str]) -> None:
+    """Add one event's ``usage_metadata`` into the running per-bucket sums.
+
+    ADK reports usage per LLM call, so a multi-turn tool loop emits one block
+    per turn and the run total is their sum. A field absent from every block
+    stays out of ``seen`` and is reported as ``None`` (unavailable) rather than
+    a fabricated zero.
+    """
+    if not isinstance(usage, Mapping):
+        return
+    for field, slot in _USAGE_FIELDS.items():
+        count = _int_or_none(usage.get(field))
+        if count is None:
+            continue
+        sums[slot] = sums.get(slot, 0) + count
+        seen.add(slot)
+
+
+def _canonical_tokens(sums: Mapping[str, int], seen: set[str]) -> dict[str, int | None]:
+    """Map the accumulated genai counts onto the canonical token buckets.
+
+    genai reports ``prompt_token_count`` as the *full* prompt with the cached
+    read as a subset of it, while the canonical ``input`` bucket excludes the
+    cached portion — so ``input`` is the difference, clamped at ``0`` so an
+    over-reported cache read can never produce a negative bucket. ``cache_write``
+    has no genai counterpart and stays ``None``.
+    """
+    tokens = empty_tokens()
+    if not seen:
+        return tokens
+
+    prompt = sums.get("prompt") if "prompt" in seen else None
+    cached = sums.get("cached") if "cached" in seen else None
+    inp = max(prompt - cached, 0) if prompt is not None and cached is not None else prompt
+
+    tokens.update(
+        input=inp,
+        cached=cached,
+        reasoning=sums.get("reasoning") if "reasoning" in seen else None,
+        output=sums.get("output") if "output" in seen else None,
+        total=sums.get("total") if "total" in seen else None,
+    )
+    return tokens
+
+
+def parse_event_stream(
+    events: Sequence[Any],
+) -> tuple[str, list[dict], dict[str, int | None], list[str]]:
+    """Fold a serialized ADK event stream into the canonical result shape.
+
+    The parser is lenient by design — an unrecognized part shape is skipped
+    rather than guessed at — but it never drops a signal silently: an event
+    carrying ADK's ``error_code`` / ``error_message`` and a tool response
+    matching no call both land on the returned ``errors`` list.
+
+    Partial events (ADK's streaming chunks) and thought parts are excluded from
+    the output text: the former would duplicate the text they are chunks of, and
+    the latter is reasoning the judge should not grade as an answer.
+
+    Args:
+        events: Serialized ``Event`` mappings in the order ADK yielded them.
+
+    Returns:
+        A ``(output, trajectory, tokens, errors)`` tuple. ``trajectory`` is a
+        list of ``ToolCall.to_dict()`` mappings in call order; a call whose
+        result never arrived stays ``status="called"`` with ``result=None``.
+    """
+    output_parts: list[str] = []
+    errors: list[str] = []
+    trajectory: list[ToolCall] = []
+    # Calls still awaiting a result: keyed by ADK's correlation id, with a FIFO
+    # queue for the id-less calls some models emit.
+    pending_by_id: dict[str, ToolCall] = {}
+    pending_unkeyed: deque[ToolCall] = deque()
+    sums: dict[str, int] = {}
+    seen: set[str] = set()
+
+    for index, event in enumerate(events):
+        if not isinstance(event, Mapping):
+            errors.append(f"event {index}: unexpected type {type(event).__name__}")
+            continue
+
+        code = event.get("error_code")
+        message = event.get("error_message")
+        if code or message:
+            errors.append(
+                f"event {index} reported {code or 'an error'}: {message or '<no detail>'}"
+            )
+
+        _accumulate_usage(event.get("usage_metadata"), sums, seen)
+
+        partial = bool(event.get("partial"))
+        user_content = _is_user_content(event)
+
+        for part in _parts(event):
+            if not isinstance(part, Mapping):
+                continue
+
+            call = part.get("function_call")
+            if isinstance(call, Mapping):
+                args = call.get("args")
+                entry = ToolCall(
+                    name=str(call.get("name", "")),
+                    args=dict(args) if isinstance(args, Mapping) else {},
+                )
+                trajectory.append(entry)
+                call_id = call.get("id")
+                if call_id is None:
+                    pending_unkeyed.append(entry)
+                else:
+                    pending_by_id[str(call_id)] = entry
+                continue
+
+            response = part.get("function_response")
+            if isinstance(response, Mapping):
+                _fold_response(response, pending_by_id, pending_unkeyed, errors, index)
+                continue
+
+            # ``thought`` marks a reasoning part: it is not the answer.
+            text = part.get("text")
+            if (
+                isinstance(text, str)
+                and text
+                and not partial
+                and not user_content
+                and not part.get("thought")
+            ):
+                output_parts.append(text)
+
+    output = "".join(output_parts)
+    tokens = _canonical_tokens(sums, seen)
+    return output, [entry.to_dict() for entry in trajectory], tokens, errors
+
+
+def _fold_response(
+    response: Mapping[str, Any],
+    pending_by_id: dict[str, ToolCall],
+    pending_unkeyed: deque[ToolCall],
+    errors: list[str],
+    index: int,
+) -> None:
+    """Attach one ``function_response`` to the call it answers.
+
+    Matching is by ADK's correlation ``id``; a response with no id is paired
+    with the oldest id-less call still awaiting a result, which is exact for a
+    stream that answers calls in the order they were made. A response matching
+    nothing is reported on ``errors`` rather than dropped.
+    """
+    call_id = response.get("id")
+    entry: ToolCall | None = None
+    if call_id is not None:
+        entry = pending_by_id.pop(str(call_id), None)
+    elif pending_unkeyed:
+        entry = pending_unkeyed.popleft()
+
+    if entry is None:
+        name = response.get("name") or "<unnamed>"
+        errors.append(
+            f"event {index}: tool response for {name!r} (id={call_id!r}) matched no pending call"
+        )
+        return
+
+    entry.result, is_error = _response_text(response.get("response"))
+    entry.status = "error" if is_error else "completed"

--- a/devops_bench/evalharness/default.py
+++ b/devops_bench/evalharness/default.py
@@ -74,6 +74,7 @@ _BUILTIN_AGENT_MODULES: tuple[str, ...] = (
     "devops_bench.agents.cli.openclaw",
     "devops_bench.agents.cli.antigravity",
     "devops_bench.agents.api.agent",
+    "devops_bench.agents.adk.agent",
 )
 
 # Aliases normalized to canonical agent keys before registry lookup.

--- a/docs/components/agents.md
+++ b/docs/components/agents.md
@@ -18,7 +18,7 @@ agent.run(prompt) -> AgentResult     # base: latency + safety net
 
 ## Supported harnesses
 
-Four harnesses ship today. Each self-registers under a canonical key.
+Five harnesses ship today. Each self-registers under a canonical key.
 
 | Key | Wraps | How it runs | Capabilities |
 | --- | --- | --- | --- |
@@ -26,6 +26,7 @@ Four harnesses ship today. Each self-registers under a canonical key.
 | `openclaw` | The **Openclaw Agent CLI** | `openclaw agent --local` with per-run isolated state/config; trajectory via `openclaw sessions export-trajectory` | MCP, skills, rules |
 | `antigravity` | The **Antigravity CLI** (`agy` binary) | Headless subprocess that keeps the real `HOME` so cached OAuth/ADC credentials work (see the trust-boundary note below); trajectory parsed from the transcript JSONL it writes, token usage read from the conversation DB | MCP, skills, rules |
 | `api` | **In-process** model call | Calls `get_model(provider, model)` and runs a model-agnostic MCP tool-use loop (`max_turns`, default 50) | MCP (spawns a stdio server), skills (served as tools), rules (system instruction) |
+| `adk` | Any agent built with the **Agent Development Kit** | Imports the agent named by `AGENT_TARGET` and drives a deep copy of it in-process through ADK's `Runner`; trajectory folded from the `function_call` / `function_response` parts of the event stream | MCP (attached as an `McpToolset`), skills (appended to the instruction), rules (appended to the instruction) |
 
 > `oc` is just a shorthand alias for the `openclaw` CLI; this doc uses `openclaw` throughout.
 
@@ -49,6 +50,14 @@ The CLI harnesses (`gemini`, `openclaw`) use it to route `AGENT_API_KEY` onto th
 binary's provider-specific env var(s) and pass the model through: the Gemini CLI
 gets `GEMINI_MODEL`, and openclaw gets a `--model provider/id` flag. Either way,
 the model is a runtime input, never baked into the harness.
+
+`adk` sits outside that contract on purpose: model routing belongs to ADK, which
+resolves a model string (and its credentials) itself. So `AGENT_PROVIDER` and
+`AGENT_API_KEY` are **not consumed** by this harness — authenticate the way ADK
+expects (`GOOGLE_API_KEY`, ADC, or a `BaseLlm` the agent constructs itself).
+`AGENT_MODEL` *is* honored: it overwrites `model` on the root agent **and every
+sub-agent**, so the whole tree runs on the model the benchmark says it did. Leave
+it unset to run the agent on whatever model its author configured.
 
 `antigravity` is the exception: it does not go through the shared contract. It
 writes `AGENT_API_KEY` straight onto `GEMINI_API_KEY` and `GOOGLE_API_KEY` and
@@ -86,7 +95,7 @@ each harness maps them onto its target.
 | `AGENT_MODEL` | unset | Model id; flows to the harness's target. |
 | `AGENT_PROVIDER` | unset | Provider key (e.g. `gemini`, `anthropic`, `google-vertex`). |
 | `AGENT_API_KEY` | unset | Routed onto the provider's key env var(s) via the shared contract; omitted for keyless backends (Vertex/Bedrock ADC). |
-| `AGENT_TARGET` | unset | Path to the CLI binary (`gemini` / `oc`). Ignored by `api`. |
+| `AGENT_TARGET` | unset | Path to the CLI binary (`gemini` / `oc`). For `adk`, the **import target** of the agent to run (see below); required there. Ignored by `api`. |
 | `AGENT_TIMEOUT_SEC` | `600` | Wall-clock budget for each external call. |
 | `AGENT_MAX_TURNS` | harness default (50 for `api`) | Caps the `api` tool-use loop. |
 
@@ -125,6 +134,34 @@ export AGENT_API_KEY="$ANTHROPIC_API_KEY"
 
 export BENCH_USE_MCP=false      # no MCP server is spawned; tools are dropped
 ```
+
+### Example: adk harness on an existing ADK agent
+
+The SDK is an optional extra, so install it first: `uv sync --extra adk`.
+
+```bash
+export BENCH_AGENT_TYPE=adk
+export AGENT_TARGET=~/agents/my_agent   # or my_pkg.agent:root_agent
+export AGENT_MODEL=gemini-2.5-pro       # optional; unset keeps the agent's own model
+
+export BENCH_USE_MCP=true
+export AGENT_MCP_SERVER="uv run k8s-mcp"
+export AGENT_ALLOWED_TOOLS="list_clusters,get_pods"
+```
+
+`AGENT_TARGET` accepts four spellings:
+
+| Target | Resolves to |
+| --- | --- |
+| `my_pkg.agent:root_agent` | that attribute of that module |
+| `my_pkg.agent` | `root_agent` in that module |
+| `~/agents/my_agent` | an ADK agent directory (`<dir>/agent.py` exposing `root_agent`) |
+| `~/agents/my_agent/agent.py` | that file's `root_agent` |
+
+If the resolved attribute is a factory rather than an agent, it is called with no
+arguments — an agent built lazily needs no wrapper. The imported agent is
+deep-copied before every run, so the harness's edits (model override, appended
+instruction text, MCP toolsets) never mutate the module a second run re-imports.
 
 ## Capabilities
 

--- a/docs/components/agents.md
+++ b/docs/components/agents.md
@@ -199,10 +199,13 @@ Two consequences worth knowing:
 - One MCP binding is still one server process. The same toolset object is shared
   across the tree rather than rebuilt per agent.
 
-The result metadata records what landed — `model_override_count`,
-`instruction_agents`, `mcp_agents`, and `mcp_toolsets` — so a run is auditable
-after the fact. If a sub-agent uses a *callable* instruction provider, only that
-agent is skipped, and it is named in the result's errors.
+The `AgentResult.metadata` mapping records what landed — `model_override_count`,
+`instruction_agents`, `mcp_agents`, and `mcp_toolsets`. Note this is on the
+in-process result, not the persisted one: the orchestrator's `results.json` does
+not currently carry harness metadata, so reading these back needs the
+`AgentResult` itself. If a sub-agent uses a *callable* instruction provider, only
+that agent is skipped, and it is named in the result's errors — which *are*
+persisted.
 
 > [!NOTE]
 > The trajectory records the tool calls a tree made but not **which** agent made

--- a/docs/components/agents.md
+++ b/docs/components/agents.md
@@ -163,6 +163,13 @@ arguments — an agent built lazily needs no wrapper. The imported agent is
 deep-copied before every run, so the harness's edits (model override, appended
 instruction text, MCP toolsets) never mutate the module a second run re-imports.
 
+The agent runs with the harness-owned workspace as the process working
+directory, matching the `cwd` the CLI harnesses hand their subprocess. An agent
+with filesystem tools that writes a relative path (`report.md`) therefore lands
+it where the orchestrator diffs and collects artifacts. Note this is a
+*process-wide* `chdir` for the duration of the run — safe because the harness
+drives one agent at a time, but worth knowing if you embed the harness yourself.
+
 ## Capabilities
 
 MCP tools, skills, and rules are the three augmentation axes, and they are

--- a/docs/components/agents.md
+++ b/docs/components/agents.md
@@ -26,7 +26,7 @@ Five harnesses ship today. Each self-registers under a canonical key.
 | `openclaw` | The **Openclaw Agent CLI** | `openclaw agent --local` with per-run isolated state/config; trajectory via `openclaw sessions export-trajectory` | MCP, skills, rules |
 | `antigravity` | The **Antigravity CLI** (`agy` binary) | Headless subprocess that keeps the real `HOME` so cached OAuth/ADC credentials work (see the trust-boundary note below); trajectory parsed from the transcript JSONL it writes, token usage read from the conversation DB | MCP, skills, rules |
 | `api` | **In-process** model call | Calls `get_model(provider, model)` and runs a model-agnostic MCP tool-use loop (`max_turns`, default 50) | MCP (spawns a stdio server), skills (served as tools), rules (system instruction) |
-| `adk` | Any agent built with the **Agent Development Kit** | Imports the agent named by `AGENT_TARGET` and drives a deep copy of it in-process through ADK's `Runner`; trajectory folded from the `function_call` / `function_response` parts of the event stream | MCP (attached as an `McpToolset`), skills (appended to the instruction), rules (appended to the instruction) |
+| `adk` | Any agent built with the **Agent Development Kit** | Imports the agent named by `AGENT_TARGET` and drives a deep copy of it in-process through ADK's `Runner`; trajectory folded from the `function_call` / `function_response` parts of the event stream | MCP (attached as an `McpToolset`), skills (appended to the instruction), rules (appended to the instruction) — all three applied to **every agent in the tree** |
 
 > `oc` is just a shorthand alias for the `openclaw` CLI; this doc uses `openclaw` throughout.
 
@@ -150,8 +150,8 @@ export AGENT_ALLOWED_TOOLS="list_clusters,get_pods"
 ```
 
 Because this harness does not consume `AGENT_PROVIDER` / `AGENT_API_KEY`, model
-credentials go through ADK's own resolution — `google-genai`, which reads the
-`GOOGLE_*` variables. To run on Vertex rather than AI Studio:
+credentials are resolved by ADK. For a Gemini model that means `google-genai`,
+which reads the `GOOGLE_*` variables — to run on Vertex rather than AI Studio:
 
 ```bash
 unset GOOGLE_API_KEY GEMINI_API_KEY     # either one wins over the Vertex switch
@@ -159,6 +159,12 @@ export GOOGLE_GENAI_USE_VERTEXAI=true
 export GOOGLE_CLOUD_PROJECT=my-project
 export GOOGLE_CLOUD_LOCATION=global
 ```
+
+For a non-Gemini model the agent supplies its own `BaseLlm` and credentials
+follow that provider's convention instead. ADK's `LiteLlm` wrapper covers
+Anthropic, OpenAI, and others, but it requires `google-adk[extensions]`, which
+the `adk` extra does not install. Token accounting also assumes `google-genai`
+usage field names, so a `LiteLlm`-backed run may report usage incompletely.
 
 `AGENT_TARGET` accepts four spellings:
 
@@ -173,6 +179,36 @@ If the resolved attribute is a factory rather than an agent, it is called with n
 arguments — an agent built lazily needs no wrapper. The imported agent is
 deep-copied before every run, so the harness's edits (model override, appended
 instruction text, MCP toolsets) never mutate the module a second run re-imports.
+
+### Multi-agent trees
+
+Everything the benchmark grants a run — the model override, the MCP toolset, the
+rules brief, and discovered skills — is applied to **every agent in the tree**,
+not just the root. ADK resolves tools from whichever agent is *active*
+(`LlmAgent.canonical_tools`) with no inheritance from a parent, so a root-only
+grant would leave any delegate unable to touch the cluster; and a delegate that
+never sees the operator brief can violate a constraint the root was told about.
+Workflow agents such as `SequentialAgent`, which hold no instruction or tools of
+their own, are stepped over.
+
+Two consequences worth knowing:
+
+- A coordinator its author deliberately left toolless **will** receive the MCP
+  toolset. That is the intended trade: an agent holding a tool it does not need
+  is recoverable, an acting agent with no cluster access is not.
+- One MCP binding is still one server process. The same toolset object is shared
+  across the tree rather than rebuilt per agent.
+
+The result metadata records what landed — `model_override_count`,
+`instruction_agents`, `mcp_agents`, and `mcp_toolsets` — so a run is auditable
+after the fact. If a sub-agent uses a *callable* instruction provider, only that
+agent is skipped, and it is named in the result's errors.
+
+> [!NOTE]
+> The trajectory records the tool calls a tree made but not **which** agent made
+> each one. For a single `LlmAgent` that is invisible; for a delegating tree it
+> means `transfer_to_agent` hops and the delegate's own calls are flattened
+> together.
 
 The agent runs with the harness-owned workspace as the process working
 directory, matching the `cwd` the CLI harnesses hand their subprocess. An agent

--- a/docs/components/agents.md
+++ b/docs/components/agents.md
@@ -149,6 +149,17 @@ export AGENT_MCP_SERVER="uv run k8s-mcp"
 export AGENT_ALLOWED_TOOLS="list_clusters,get_pods"
 ```
 
+Because this harness does not consume `AGENT_PROVIDER` / `AGENT_API_KEY`, model
+credentials go through ADK's own resolution — `google-genai`, which reads the
+`GOOGLE_*` variables. To run on Vertex rather than AI Studio:
+
+```bash
+unset GOOGLE_API_KEY GEMINI_API_KEY     # either one wins over the Vertex switch
+export GOOGLE_GENAI_USE_VERTEXAI=true
+export GOOGLE_CLOUD_PROJECT=my-project
+export GOOGLE_CLOUD_LOCATION=global
+```
+
 `AGENT_TARGET` accepts four spellings:
 
 | Target | Resolves to |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,10 @@ dependencies = [
     "ruamel.yaml>=0.18.0",
 ]
 
-# Provider SDKs are optional: install only the extras for the providers you use.
+# Provider SDKs and agent frameworks are optional: install only the extras you
+# use. ``adk`` is needed by the ``adk`` agent harness, not by any provider.
 [project.optional-dependencies]
+adk = ["google-adk>=2.7.1"]
 anthropic = ["anthropic>=0.104.1"]
 openai = ["openai>=1.0.0"]
 
@@ -66,6 +68,9 @@ dev = [
     "pytest-asyncio>=1.0.0",
     "pytest-mock>=3.15.1",
     # The provider extras keep the full adapter test suite runnable under `uv sync`.
+    # ``adk`` is deliberately excluded: resolving it pins opentelemetry and
+    # websockets *down* for every contributor. The ADK harness's SDK-backed
+    # tests skip without it; everything else about it is tested SDK-free.
     "devops-bench[anthropic,openai]",
 ]
 

--- a/tests/unit/agents/test_agents_adk.py
+++ b/tests/unit/agents/test_agents_adk.py
@@ -1,0 +1,668 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.agents.adk.
+
+The event fixtures below are verbatim ``Event.model_dump(mode="json")`` output
+captured from a real ADK run driven by a stub model, so the parser is exercised
+against the shape the SDK actually emits rather than an idealized one.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from devops_bench.agents import base, capabilities
+from devops_bench.agents import config as agents_config
+from devops_bench.agents.adk import agent as adk_mod
+from devops_bench.agents.adk import parsing
+
+# The dev group deliberately omits the ``adk`` extra, so every test that reaches
+# the SDK carries this marker. It is a marker rather than a module-level
+# ``importorskip`` because the parser and the preparation step are SDK-free by
+# design — skipping the whole module would stop proving that.
+requires_adk = pytest.mark.skipif(
+    importlib.util.find_spec("google.adk") is None,
+    reason="the optional 'adk' extra is not installed",
+)
+
+# --------------------------------------------------------------------------
+# Recorded event fixtures
+# --------------------------------------------------------------------------
+
+CALL_EVENT = {
+    "content": {
+        "parts": [
+            {
+                "function_call": {
+                    "id": "adk-ab74b8d2",
+                    "args": {"name": "web", "replicas": 3},
+                    "name": "scale_deployment",
+                }
+            }
+        ],
+        "role": "model",
+    },
+    "usage_metadata": {
+        "candidates_token_count": 10,
+        "prompt_token_count": 100,
+        "total_token_count": 110,
+    },
+    "invocation_id": "e-6a3b9866",
+    "author": "spike_agent",
+    "id": "c50884c8",
+}
+
+RESPONSE_EVENT = {
+    "content": {
+        "parts": [
+            {
+                "function_response": {
+                    "id": "adk-ab74b8d2",
+                    "name": "scale_deployment",
+                    "response": {"scaled": "web", "replicas": 3},
+                }
+            }
+        ],
+        "role": "user",
+    },
+    "author": "spike_agent",
+    "id": "89cd9467",
+}
+
+FINAL_EVENT = {
+    "content": {"parts": [{"text": "Scaled web to 3 replicas."}], "role": "model"},
+    "usage_metadata": {
+        "candidates_token_count": 20,
+        "prompt_token_count": 200,
+        "total_token_count": 220,
+    },
+    "author": "spike_agent",
+    "id": "817831b8",
+}
+
+MCP_RESPONSE_EVENT = {
+    "content": {
+        "parts": [
+            {
+                "function_response": {
+                    "id": "adk-2637655b",
+                    "name": "cluster_status",
+                    "response": {
+                        "content": [{"type": "text", "text": "cluster prod-1 is HEALTHY"}],
+                        "structuredContent": {"result": "cluster prod-1 is HEALTHY"},
+                        "isError": False,
+                    },
+                }
+            }
+        ],
+        "role": "user",
+    },
+    "author": "mcp_spike",
+    "id": "aa11",
+}
+
+MCP_CALL_EVENT = {
+    "content": {
+        "parts": [
+            {
+                "function_call": {
+                    "id": "adk-2637655b",
+                    "args": {"name": "prod-1"},
+                    "name": "cluster_status",
+                }
+            }
+        ],
+        "role": "model",
+    },
+    "author": "mcp_spike",
+    "id": "bb22",
+}
+
+
+# --------------------------------------------------------------------------
+# parse_event_stream
+# --------------------------------------------------------------------------
+
+
+def test_parse_event_stream_folds_call_and_response():
+    output, trajectory, tokens, errors = parsing.parse_event_stream(
+        [CALL_EVENT, RESPONSE_EVENT, FINAL_EVENT]
+    )
+
+    assert output == "Scaled web to 3 replicas."
+    assert errors == []
+    assert trajectory == [
+        {
+            "name": "scale_deployment",
+            "args": {"name": "web", "replicas": 3},
+            "result": '{"replicas": 3, "scaled": "web"}',
+            "status": "completed",
+        }
+    ]
+    # Usage is per LLM call, so the run total is the sum of both blocks.
+    assert tokens["input"] == 300
+    assert tokens["output"] == 30
+    assert tokens["total"] == 330
+    assert tokens["cached"] is None
+    assert tokens["cache_write"] is None
+
+
+def test_parse_event_stream_reads_mcp_result_text_and_success():
+    _, trajectory, _, errors = parsing.parse_event_stream([MCP_CALL_EVENT, MCP_RESPONSE_EVENT])
+
+    assert errors == []
+    assert trajectory[0]["result"] == "cluster prod-1 is HEALTHY"
+    assert trajectory[0]["status"] == "completed"
+
+
+def test_parse_event_stream_marks_mcp_is_error_as_failed():
+    failed = copy.deepcopy(MCP_RESPONSE_EVENT)
+    response = failed["content"]["parts"][0]["function_response"]["response"]
+    response["isError"] = True
+    response["content"] = [{"type": "text", "text": "permission denied"}]
+
+    _, trajectory, _, _ = parsing.parse_event_stream([MCP_CALL_EVENT, failed])
+
+    assert trajectory[0]["status"] == "error"
+    assert trajectory[0]["result"] == "permission denied"
+
+
+def test_parse_event_stream_marks_adk_error_payload_as_failed():
+    failed = copy.deepcopy(RESPONSE_EVENT)
+    failed["content"]["parts"][0]["function_response"]["response"] = {"error": "boom"}
+
+    _, trajectory, _, _ = parsing.parse_event_stream([CALL_EVENT, failed])
+
+    assert trajectory[0]["status"] == "error"
+
+
+def test_parse_event_stream_keeps_unanswered_calls_as_called():
+    parallel = {
+        "content": {
+            "parts": [
+                {"function_call": {"id": "a1", "name": "ok_tool", "args": {"x": 2}}},
+                {"function_call": {"id": "a2", "name": "boom_tool", "args": {"x": 9}}},
+            ],
+            "role": "model",
+        },
+        "author": "err_spike",
+    }
+    # ADK yields an error event and *then* raises, so both shapes must survive.
+    error_event = {"error_code": "RuntimeError", "error_message": "kaboom on 9"}
+
+    output, trajectory, _, errors = parsing.parse_event_stream([parallel, error_event])
+
+    assert [entry["status"] for entry in trajectory] == ["called", "called"]
+    assert [entry["result"] for entry in trajectory] == [None, None]
+    assert output == ""
+    assert errors == ["event 1 reported RuntimeError: kaboom on 9"]
+
+
+def test_parse_event_stream_reports_orphan_tool_response():
+    _, trajectory, _, errors = parsing.parse_event_stream([RESPONSE_EVENT])
+
+    assert trajectory == []
+    assert len(errors) == 1
+    assert "matched no pending call" in errors[0]
+
+
+def test_parse_event_stream_pairs_id_less_calls_in_order():
+    call_a = {"content": {"role": "model", "parts": [{"function_call": {"name": "a", "args": {}}}]}}
+    call_b = {"content": {"role": "model", "parts": [{"function_call": {"name": "b", "args": {}}}]}}
+    resp_a = {"content": {"role": "user", "parts": [{"function_response": {"response": "ra"}}]}}
+    resp_b = {"content": {"role": "user", "parts": [{"function_response": {"response": "rb"}}]}}
+
+    _, trajectory, _, errors = parsing.parse_event_stream([call_a, call_b, resp_a, resp_b])
+
+    assert errors == []
+    assert [(e["name"], e["result"]) for e in trajectory] == [("a", "ra"), ("b", "rb")]
+
+
+def test_parse_event_stream_skips_partial_and_thought_text():
+    events = [
+        {"content": {"role": "model", "parts": [{"text": "Scal"}]}, "partial": True},
+        {"content": {"role": "model", "parts": [{"text": "thinking...", "thought": True}]}},
+        {"content": {"role": "user", "parts": [{"text": "the original prompt"}]}},
+        {"content": {"role": "model", "parts": [{"text": "Scaled."}]}},
+    ]
+
+    output, _, _, errors = parsing.parse_event_stream(events)
+
+    assert output == "Scaled."
+    assert errors == []
+
+
+def test_parse_event_stream_reports_non_mapping_event():
+    _, _, _, errors = parsing.parse_event_stream(["not an event"])
+
+    assert errors == ["event 0: unexpected type str"]
+
+
+def test_parse_event_stream_reports_unavailable_tokens_as_none():
+    _, _, tokens, _ = parsing.parse_event_stream([MCP_CALL_EVENT, MCP_RESPONSE_EVENT])
+
+    assert set(tokens.values()) == {None}
+
+
+def test_parse_event_stream_subtracts_cached_from_input():
+    event = {
+        "usage_metadata": {
+            "prompt_token_count": 100,
+            "cached_content_token_count": 40,
+            "candidates_token_count": 5,
+            "thoughts_token_count": 7,
+            "total_token_count": 112,
+        }
+    }
+
+    _, _, tokens, _ = parsing.parse_event_stream([event])
+
+    assert tokens == {
+        "input": 60,
+        "cached": 40,
+        "cache_write": None,
+        "reasoning": 7,
+        "output": 5,
+        "total": 112,
+    }
+
+
+def test_parse_event_stream_clamps_over_reported_cache_read():
+    event = {
+        "usage_metadata": {"prompt_token_count": 10, "cached_content_token_count": 40},
+    }
+
+    _, _, tokens, _ = parsing.parse_event_stream([event])
+
+    assert tokens["input"] == 0
+
+
+# --------------------------------------------------------------------------
+# Target resolution helpers
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        ("my_pkg.agent", False),
+        ("my_pkg.agent:root_agent", False),
+        ("agent.py", True),
+        ("~/agents/mine", True),
+        ("./mine", True),
+        ("/opt/agents/mine", True),
+    ],
+)
+def test_looks_like_path(spec, expected):
+    assert adk_mod._looks_like_path(spec) is expected
+
+
+# --------------------------------------------------------------------------
+# Preparation (SDK-free: the harness only duck-types the agent object)
+# --------------------------------------------------------------------------
+
+
+class FakeAgent:
+    """Stand-in exposing the handful of attributes the harness touches."""
+
+    def __init__(self, name, model=None, instruction=None, tools=None, sub_agents=()):
+        self.name = name
+        self.model = model
+        self.instruction = instruction
+        self.tools = list(tools or [])
+        self.sub_agents = list(sub_agents)
+
+    def model_copy(self, *, deep=False):
+        return copy.deepcopy(self)
+
+
+def test_prepare_leaves_the_imported_agent_untouched():
+    original = FakeAgent("root", model="baked-in", instruction="be helpful")
+    harness = adk_mod.AdkAgent(agents_config.AgentConfig(model="bench-model"))
+
+    prepared, metadata, errors = harness._prepare(original)
+
+    assert errors == []
+    assert prepared is not original
+    assert original.model == "baked-in"
+    assert prepared.model == "bench-model"
+    assert metadata["model_override_count"] == 1
+
+
+def test_prepare_overrides_sub_agent_models_too():
+    root = FakeAgent("root", model="a", sub_agents=[FakeAgent("child", model="b")])
+    harness = adk_mod.AdkAgent(agents_config.AgentConfig(model="bench-model"))
+
+    prepared, metadata, _ = harness._prepare(root)
+
+    assert prepared.sub_agents[0].model == "bench-model"
+    assert metadata["model_override_count"] == 2
+
+
+def test_prepare_keeps_the_agents_own_model_when_unset():
+    root = FakeAgent("root", model="baked-in")
+    harness = adk_mod.AdkAgent(agents_config.AgentConfig(model=None))
+
+    prepared, metadata, _ = harness._prepare(root)
+
+    assert prepared.model == "baked-in"
+    assert "model_override_count" not in metadata
+
+
+def test_prepare_appends_rules_to_the_instruction():
+    root = FakeAgent("root", instruction="you are an operator")
+    harness = adk_mod.AdkAgent(
+        agents_config.AgentConfig(
+            capabilities=capabilities.AllCapabilities(
+                rules=capabilities.AgentRules(text="never delete data")
+            )
+        )
+    )
+
+    prepared, _, errors = harness._prepare(root)
+
+    assert errors == []
+    assert prepared.instruction == "you are an operator\n\nnever delete data"
+
+
+def test_prepare_appends_discovered_skills(tmp_path):
+    skill_dir = tmp_path / "skills" / "rollout"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: rollout\ndescription: roll out safely\n---\n\nDrain first.\n",
+        encoding="utf-8",
+    )
+    harness = adk_mod.AdkAgent(
+        agents_config.AgentConfig(
+            capabilities=capabilities.AllCapabilities(
+                skills=capabilities.SkillBinding(paths=(str(tmp_path / "skills"),))
+            )
+        )
+    )
+
+    prepared, metadata, errors = harness._prepare(FakeAgent("root"))
+
+    assert errors == []
+    assert metadata["skills"] == ["rollout"]
+    assert "# Available skills" in prepared.instruction
+    assert "Drain first." in prepared.instruction
+
+
+def test_prepare_reports_a_callable_instruction_provider():
+    root = FakeAgent("root", instruction=lambda ctx: "dynamic")
+    harness = adk_mod.AdkAgent(
+        agents_config.AgentConfig(
+            capabilities=capabilities.AllCapabilities(
+                rules=capabilities.AgentRules(text="never delete data")
+            )
+        )
+    )
+
+    _, _, errors = harness._prepare(root)
+
+    assert len(errors) == 1
+    assert "callable instruction provider" in errors[0]
+
+
+def test_prepare_attaches_one_toolset_per_mcp_binding(monkeypatch):
+    built: list[dict] = []
+
+    class FakeToolset:
+        def __init__(self, *, connection_params, tool_filter=None):
+            built.append({"params": connection_params, "tool_filter": tool_filter})
+
+    def fake_connection(*, server_params, timeout):
+        return {"server_params": server_params, "timeout": timeout}
+
+    def fake_server_params(*, command, args):
+        return {"command": command, "args": args}
+
+    monkeypatch.setattr(
+        adk_mod, "_load_toolset_types", lambda: (FakeToolset, fake_connection, fake_server_params)
+    )
+
+    harness = adk_mod.AdkAgent(
+        agents_config.AgentConfig(
+            capabilities=capabilities.AllCapabilities(
+                mcp_servers=(
+                    # A binding with no command is one the agent hosts itself.
+                    capabilities.McpBinding(name="builtin", command=(), tools=("ignored",)),
+                    capabilities.McpBinding(
+                        name="tools", command=("uv", "run", "k8s-mcp"), tools=("get_pods",)
+                    ),
+                )
+            )
+        )
+    )
+
+    prepared, metadata, errors = harness._prepare(FakeAgent("root"))
+
+    assert errors == []
+    assert metadata["mcp_toolsets"] == 1
+    assert len(prepared.tools) == 1
+    assert built[0]["tool_filter"] == ["get_pods"]
+    assert built[0]["params"]["server_params"] == {"command": "uv", "args": ["run", "k8s-mcp"]}
+
+
+def test_prepare_records_an_error_when_mcp_support_is_missing(monkeypatch):
+    def boom():
+        raise ImportError("no module named mcp")
+
+    monkeypatch.setattr(adk_mod, "_load_toolset_types", boom)
+
+    harness = adk_mod.AdkAgent(
+        agents_config.AgentConfig(
+            capabilities=capabilities.AllCapabilities(
+                mcp_servers=(capabilities.McpBinding(name="tools", command=("k8s-mcp",)),)
+            )
+        )
+    )
+
+    prepared, metadata, errors = harness._prepare(FakeAgent("root"))
+
+    assert prepared.tools == []
+    assert "mcp_toolsets" not in metadata
+    assert len(errors) == 1
+    assert "without MCP tools" in errors[0]
+
+
+# --------------------------------------------------------------------------
+# Harness wiring
+# --------------------------------------------------------------------------
+
+
+def test_adk_agent_is_registered():
+    assert base.AGENTS.get("adk") is adk_mod.AdkAgent
+
+
+def test_importing_the_harness_pulls_no_sdk() -> None:
+    """The module is on ``_BUILTIN_AGENT_MODULES``, so it loads on every run.
+
+    That means importing it must not require the optional ``adk`` extra — nor
+    drag in ``google.adk`` and ``mcp`` for operators running a different
+    harness. A fresh interpreter keeps earlier tests' imports out of the check.
+    """
+    script = textwrap.dedent(
+        """
+        import sys
+        import devops_bench.agents.adk.agent  # noqa: F401
+        heavy = ["google.adk", "mcp"]
+        hits = [m for m in sorted(sys.modules) if any(m == h or m.startswith(h + ".") for h in heavy)]
+        print("LEAKED:" + ",".join(hits) if hits else "OK")
+        sys.exit(1 if hits else 0)
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@requires_adk
+def test_execute_without_a_target_returns_an_errored_result():
+    result = adk_mod.AdkAgent(agents_config.AgentConfig(target=None)).run("scale web")
+
+    assert result.has_errors()
+    assert "AGENT_TARGET" in result.errors[0]
+    assert result.trajectory == []
+
+
+@requires_adk
+def test_execute_reports_an_unloadable_target():
+    config = agents_config.AgentConfig(target="devops_bench.agents.adk.parsing:not_an_agent")
+    result = adk_mod.AdkAgent(config).run("scale web")
+
+    assert result.has_errors()
+    assert "could not load the ADK agent" in result.errors[0]
+
+
+# --------------------------------------------------------------------------
+# SDK-backed paths
+# --------------------------------------------------------------------------
+
+_AGENT_FIXTURE = textwrap.dedent(
+    '''
+    """An ADK agent driven by a stub model, so the run needs no network."""
+
+    from google.adk.agents import LlmAgent
+    from google.adk.models import BaseLlm, LlmResponse
+    from google.genai import types
+
+
+    def scale_deployment(name: str, replicas: int) -> dict:
+        """Scale a deployment to the given replica count."""
+        return {"scaled": name, "replicas": replicas}
+
+
+    class StubLlm(BaseLlm):
+        model: str = "stub-model"
+        turn: int = 0
+
+        async def generate_content_async(self, llm_request, stream=False):
+            self.turn += 1
+            usage = types.GenerateContentResponseUsageMetadata(
+                prompt_token_count=100, candidates_token_count=10, total_token_count=110
+            )
+            if self.turn == 1:
+                part = types.Part.from_function_call(
+                    name="scale_deployment", args={"name": "web", "replicas": 3}
+                )
+                yield LlmResponse(
+                    content=types.Content(role="model", parts=[part]), usage_metadata=usage
+                )
+            else:
+                yield LlmResponse(
+                    content=types.Content(
+                        role="model", parts=[types.Part(text="Scaled web to 3 replicas.")]
+                    ),
+                    usage_metadata=usage,
+                )
+
+
+    root_agent = LlmAgent(name="fixture_agent", model=StubLlm(), tools=[scale_deployment])
+    '''
+)
+
+
+@pytest.fixture
+def agent_dir(tmp_path):
+    """Write an ADK agent directory laid out the way ADK expects."""
+    directory = tmp_path / "fixture_agent"
+    directory.mkdir()
+    (directory / "agent.py").write_text(_AGENT_FIXTURE, encoding="utf-8")
+    return directory
+
+
+@requires_adk
+def test_resolve_root_agent_from_an_agent_directory(agent_dir):
+    resolved = adk_mod._resolve_root_agent(str(agent_dir))
+
+    assert resolved.name == "fixture_agent"
+
+
+@requires_adk
+def test_resolve_root_agent_from_a_file_with_an_explicit_attribute(agent_dir):
+    resolved = adk_mod._resolve_root_agent(f"{agent_dir / 'agent.py'}:root_agent")
+
+    assert resolved.name == "fixture_agent"
+
+
+@requires_adk
+def test_resolve_root_agent_calls_a_factory(agent_dir):
+    (agent_dir / "agent.py").write_text(
+        _AGENT_FIXTURE + "\n\ndef build():\n    return root_agent\n", encoding="utf-8"
+    )
+
+    resolved = adk_mod._resolve_root_agent(f"{agent_dir}:build")
+
+    assert resolved.name == "fixture_agent"
+
+
+@requires_adk
+def test_resolve_root_agent_rejects_a_non_agent(agent_dir):
+    (agent_dir / "agent.py").write_text("root_agent = object()\n", encoding="utf-8")
+
+    with pytest.raises(Exception, match="not an ADK agent"):
+        adk_mod._resolve_root_agent(str(agent_dir))
+
+
+@requires_adk
+def test_execute_drives_a_real_adk_agent_end_to_end(agent_dir):
+    # No AGENT_MODEL: overriding it would replace the stub with a live model.
+    config = agents_config.AgentConfig(target=str(agent_dir), model=None)
+
+    result = adk_mod.AdkAgent(config).run("scale web to 3")
+
+    assert result.errors == []
+    assert result.output == "Scaled web to 3 replicas."
+    assert result.trajectory == [
+        {
+            "name": "scale_deployment",
+            "args": {"name": "web", "replicas": 3},
+            "result": '{"replicas": 3, "scaled": "web"}',
+            "status": "completed",
+        }
+    ]
+    assert result.tokens["total"] == 220
+    assert result.latency > 0
+    assert result.metadata["agent_name"] == "fixture_agent"
+    assert result.metadata["event_count"] == 3
+
+
+@requires_adk
+def test_execute_keeps_the_partial_trajectory_when_a_tool_raises(agent_dir):
+    (agent_dir / "agent.py").write_text(
+        _AGENT_FIXTURE.replace(
+            'return {"scaled": name, "replicas": replicas}',
+            'raise RuntimeError("kaboom")',
+        ),
+        encoding="utf-8",
+    )
+    config = agents_config.AgentConfig(target=str(agent_dir), model=None)
+
+    result = adk_mod.AdkAgent(config).run("scale web to 3")
+
+    # ADK raises out of the iterator, but the call it already yielded survives.
+    assert result.has_errors()
+    assert any("kaboom" in message for message in result.errors)
+    assert [entry["name"] for entry in result.trajectory] == ["scale_deployment"]
+    assert result.trajectory[0]["status"] == "called"

--- a/tests/unit/agents/test_agents_adk.py
+++ b/tests/unit/agents/test_agents_adk.py
@@ -463,6 +463,147 @@ def test_prepare_attaches_one_toolset_per_mcp_binding(monkeypatch):
     assert built[0]["params"]["server_params"] == {"command": "uv", "args": ["run", "k8s-mcp"]}
 
 
+class FakeWorkflowAgent:
+    """A node with children but no model, instruction, or tools of its own.
+
+    Stands in for ``SequentialAgent`` and friends, which the tree walk has to
+    step over rather than assign attributes onto.
+    """
+
+    def __init__(self, name, sub_agents=()):
+        self.name = name
+        self.sub_agents = list(sub_agents)
+
+    def model_copy(self, *, deep=False):
+        return copy.deepcopy(self)
+
+
+def _stub_toolset_types(monkeypatch):
+    """Point ``_load_toolset_types`` at cheap stand-ins and return the built list."""
+    built: list[object] = []
+
+    class FakeToolset:
+        def __init__(self, *, connection_params, tool_filter=None):
+            self.tool_filter = tool_filter
+            built.append(self)
+
+    monkeypatch.setattr(
+        adk_mod,
+        "_load_toolset_types",
+        lambda: (
+            FakeToolset,
+            lambda *, server_params, timeout: {"server_params": server_params},
+            lambda *, command, args: {"command": command, "args": args},
+        ),
+    )
+    return built
+
+
+def _mcp_harness(**caps):
+    return adk_mod.AdkAgent(
+        agents_config.AgentConfig(
+            capabilities=capabilities.AllCapabilities(
+                mcp_servers=(
+                    capabilities.McpBinding(
+                        name="tools", command=("uv", "run", "k8s-mcp"), tools=("get_pods",)
+                    ),
+                ),
+                **caps,
+            )
+        )
+    )
+
+
+def test_prepare_attaches_toolsets_to_every_agent_in_the_tree(monkeypatch):
+    """Every agent that can hold tools gets the run's MCP toolset.
+
+    Regression test for a real run. ADK resolves tools from the *active* agent
+    (`LlmAgent.canonical_tools`) with no inheritance from a parent, so attaching
+    to the root alone left a delegating tree unable to touch the cluster: the
+    sub-agent doing the cluster work reported no tools at all, and the run still
+    came back `status: success` with `errors: []` while scoring zero.
+    """
+    built = _stub_toolset_types(monkeypatch)
+    root = FakeAgent(
+        "root",
+        sub_agents=[
+            FakeAgent("operator"),
+            FakeAgent("reporter", tools=["write_file"]),
+        ],
+    )
+
+    prepared, metadata, errors = _mcp_harness()._prepare(root)
+
+    assert errors == []
+    assert metadata["mcp_toolsets"] == 1
+    assert metadata["mcp_agents"] == 3
+    operator, reporter = prepared.sub_agents
+    assert prepared.tools == built
+    assert operator.tools == built
+    # An agent's own tools survive alongside the attached toolset.
+    assert reporter.tools == ["write_file", *built]
+    # One binding is still one server process, shared across the tree.
+    assert len(built) == 1
+
+
+def test_prepare_delivers_rules_to_every_agent_in_the_tree():
+    """A delegate that never sees the operator brief can violate it."""
+    root = FakeAgent("root", instruction="coordinate", sub_agents=[FakeAgent("child")])
+    harness = adk_mod.AdkAgent(
+        agents_config.AgentConfig(
+            capabilities=capabilities.AllCapabilities(
+                rules=capabilities.AgentRules(text="never delete a namespace")
+            )
+        )
+    )
+
+    prepared, metadata, errors = harness._prepare(root)
+
+    assert errors == []
+    assert metadata["instruction_agents"] == 2
+    assert "never delete a namespace" in prepared.instruction
+    assert "never delete a namespace" in prepared.sub_agents[0].instruction
+
+
+def test_prepare_names_only_the_agents_that_refused_the_instruction():
+    root = FakeAgent("root", instruction="coordinate")
+    root.sub_agents = [
+        FakeAgent("dynamic", instruction=lambda ctx: "computed"),
+        FakeAgent("static", instruction="plain"),
+    ]
+    harness = adk_mod.AdkAgent(
+        agents_config.AgentConfig(
+            capabilities=capabilities.AllCapabilities(
+                rules=capabilities.AgentRules(text="never delete a namespace")
+            )
+        )
+    )
+
+    prepared, metadata, errors = harness._prepare(root)
+
+    assert len(errors) == 1
+    assert "dynamic" in errors[0]
+    assert "static" not in errors[0]
+    # The refusal is per node: the rest of the tree still got the brief.
+    assert metadata["instruction_agents"] == 2
+    assert "never delete a namespace" in prepared.sub_agents[1].instruction
+
+
+def test_prepare_steps_over_nodes_that_hold_no_tools_or_instruction(monkeypatch):
+    built = _stub_toolset_types(monkeypatch)
+    root = FakeWorkflowAgent("pipeline", sub_agents=[FakeAgent("worker", instruction="work")])
+    harness = _mcp_harness(rules=capabilities.AgentRules(text="never delete a namespace"))
+
+    prepared, metadata, errors = harness._prepare(root)
+
+    assert errors == []
+    # Only the LlmAgent-shaped child can hold either.
+    assert metadata["mcp_agents"] == 1
+    assert metadata["instruction_agents"] == 1
+    assert not hasattr(prepared, "tools")
+    assert prepared.sub_agents[0].tools == built
+
+
 def test_prepare_records_an_error_when_mcp_support_is_missing(monkeypatch):
     def boom():
         raise ImportError("no module named mcp")

--- a/tests/unit/agents/test_agents_adk.py
+++ b/tests/unit/agents/test_agents_adk.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import copy
 import importlib.util
+import os
 import subprocess
 import sys
 import textwrap
@@ -646,6 +647,56 @@ def test_execute_drives_a_real_adk_agent_end_to_end(agent_dir):
     assert result.latency > 0
     assert result.metadata["agent_name"] == "fixture_agent"
     assert result.metadata["event_count"] == 3
+
+
+@requires_adk
+def test_execute_runs_the_agent_inside_the_workspace(agent_dir, tmp_path):
+    """A relative path written by a tool must land where the diff is rooted.
+
+    Regression test for a real run: the agent wrote its `report.md` deliverable
+    into the operator's home directory, so the orchestrator's artifact diff came
+    back empty and the file was left behind for the next run to trip over.
+    """
+    (agent_dir / "agent.py").write_text(
+        _AGENT_FIXTURE.replace(
+            'return {"scaled": name, "replicas": replicas}',
+            'open("report.md", "w").write("done")\n    '
+            'return {"scaled": name, "replicas": replicas}',
+        ),
+        encoding="utf-8",
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    before = os.getcwd()
+    config = agents_config.AgentConfig(target=str(agent_dir), model=None)
+
+    result = adk_mod.AdkAgent(config).run("scale web to 3", workspace_path=workspace)
+
+    assert result.errors == []
+    assert (workspace / "report.md").read_text() == "done"
+    assert result.metadata["workspace"] == str(workspace)
+    # The process directory is global state; leaving it moved would silently
+    # relocate every later run.
+    assert os.getcwd() == before
+
+
+def test_in_workspace_restores_the_previous_directory_on_failure(tmp_path):
+    before = os.getcwd()
+
+    with pytest.raises(RuntimeError), adk_mod._in_workspace(tmp_path):
+        assert os.getcwd() == os.path.realpath(tmp_path)
+        raise RuntimeError("boom")
+
+    assert os.getcwd() == before
+
+
+def test_in_workspace_is_a_no_op_without_a_workspace():
+    before = os.getcwd()
+
+    with adk_mod._in_workspace(None):
+        assert os.getcwd() == before
+
+    assert os.getcwd() == before
 
 
 @requires_adk

--- a/tests/unit/agents/test_agents_adk.py
+++ b/tests/unit/agents/test_agents_adk.py
@@ -21,15 +21,21 @@ against the shape the SDK actually emits rather than an idealized one.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import copy
 import importlib.util
 import os
+import pathlib
 import subprocess
 import sys
 import textwrap
+from collections.abc import AsyncIterator
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
+from devops_bench import core
 from devops_bench.agents import base, capabilities
 from devops_bench.agents import config as agents_config
 from devops_bench.agents.adk import agent as adk_mod
@@ -143,7 +149,7 @@ MCP_CALL_EVENT = {
 # --------------------------------------------------------------------------
 
 
-def test_parse_event_stream_folds_call_and_response():
+def test_parse_event_stream_folds_call_and_response() -> None:
     output, trajectory, tokens, errors = parsing.parse_event_stream(
         [CALL_EVENT, RESPONSE_EVENT, FINAL_EVENT]
     )
@@ -166,7 +172,7 @@ def test_parse_event_stream_folds_call_and_response():
     assert tokens["cache_write"] is None
 
 
-def test_parse_event_stream_reads_mcp_result_text_and_success():
+def test_parse_event_stream_reads_mcp_result_text_and_success() -> None:
     _, trajectory, _, errors = parsing.parse_event_stream([MCP_CALL_EVENT, MCP_RESPONSE_EVENT])
 
     assert errors == []
@@ -174,7 +180,7 @@ def test_parse_event_stream_reads_mcp_result_text_and_success():
     assert trajectory[0]["status"] == "completed"
 
 
-def test_parse_event_stream_marks_mcp_is_error_as_failed():
+def test_parse_event_stream_marks_mcp_is_error_as_failed() -> None:
     failed = copy.deepcopy(MCP_RESPONSE_EVENT)
     response = failed["content"]["parts"][0]["function_response"]["response"]
     response["isError"] = True
@@ -186,7 +192,7 @@ def test_parse_event_stream_marks_mcp_is_error_as_failed():
     assert trajectory[0]["result"] == "permission denied"
 
 
-def test_parse_event_stream_marks_adk_error_payload_as_failed():
+def test_parse_event_stream_marks_adk_error_payload_as_failed() -> None:
     failed = copy.deepcopy(RESPONSE_EVENT)
     failed["content"]["parts"][0]["function_response"]["response"] = {"error": "boom"}
 
@@ -195,7 +201,7 @@ def test_parse_event_stream_marks_adk_error_payload_as_failed():
     assert trajectory[0]["status"] == "error"
 
 
-def test_parse_event_stream_keeps_unanswered_calls_as_called():
+def test_parse_event_stream_keeps_unanswered_calls_as_called() -> None:
     parallel = {
         "content": {
             "parts": [
@@ -217,7 +223,7 @@ def test_parse_event_stream_keeps_unanswered_calls_as_called():
     assert errors == ["event 1 reported RuntimeError: kaboom on 9"]
 
 
-def test_parse_event_stream_reports_orphan_tool_response():
+def test_parse_event_stream_reports_orphan_tool_response() -> None:
     _, trajectory, _, errors = parsing.parse_event_stream([RESPONSE_EVENT])
 
     assert trajectory == []
@@ -225,7 +231,7 @@ def test_parse_event_stream_reports_orphan_tool_response():
     assert "matched no pending call" in errors[0]
 
 
-def test_parse_event_stream_pairs_id_less_calls_in_order():
+def test_parse_event_stream_pairs_id_less_calls_in_order() -> None:
     call_a = {"content": {"role": "model", "parts": [{"function_call": {"name": "a", "args": {}}}]}}
     call_b = {"content": {"role": "model", "parts": [{"function_call": {"name": "b", "args": {}}}]}}
     resp_a = {"content": {"role": "user", "parts": [{"function_response": {"response": "ra"}}]}}
@@ -237,7 +243,7 @@ def test_parse_event_stream_pairs_id_less_calls_in_order():
     assert [(e["name"], e["result"]) for e in trajectory] == [("a", "ra"), ("b", "rb")]
 
 
-def test_parse_event_stream_skips_partial_and_thought_text():
+def test_parse_event_stream_skips_partial_and_thought_text() -> None:
     events = [
         {"content": {"role": "model", "parts": [{"text": "Scal"}]}, "partial": True},
         {"content": {"role": "model", "parts": [{"text": "thinking...", "thought": True}]}},
@@ -251,19 +257,19 @@ def test_parse_event_stream_skips_partial_and_thought_text():
     assert errors == []
 
 
-def test_parse_event_stream_reports_non_mapping_event():
+def test_parse_event_stream_reports_non_mapping_event() -> None:
     _, _, _, errors = parsing.parse_event_stream(["not an event"])
 
     assert errors == ["event 0: unexpected type str"]
 
 
-def test_parse_event_stream_reports_unavailable_tokens_as_none():
+def test_parse_event_stream_reports_unavailable_tokens_as_none() -> None:
     _, _, tokens, _ = parsing.parse_event_stream([MCP_CALL_EVENT, MCP_RESPONSE_EVENT])
 
     assert set(tokens.values()) == {None}
 
 
-def test_parse_event_stream_subtracts_cached_from_input():
+def test_parse_event_stream_subtracts_cached_from_input() -> None:
     event = {
         "usage_metadata": {
             "prompt_token_count": 100,
@@ -286,7 +292,7 @@ def test_parse_event_stream_subtracts_cached_from_input():
     }
 
 
-def test_parse_event_stream_clamps_over_reported_cache_read():
+def test_parse_event_stream_clamps_over_reported_cache_read() -> None:
     event = {
         "usage_metadata": {"prompt_token_count": 10, "cached_content_token_count": 40},
     }
@@ -312,7 +318,7 @@ def test_parse_event_stream_clamps_over_reported_cache_read():
         ("/opt/agents/mine", True),
     ],
 )
-def test_looks_like_path(spec, expected):
+def test_looks_like_path(spec, expected) -> None:
     assert adk_mod._looks_like_path(spec) is expected
 
 
@@ -324,18 +330,25 @@ def test_looks_like_path(spec, expected):
 class FakeAgent:
     """Stand-in exposing the handful of attributes the harness touches."""
 
-    def __init__(self, name, model=None, instruction=None, tools=None, sub_agents=()):
+    def __init__(
+        self,
+        name: str,
+        model: str | None = None,
+        instruction: object = None,
+        tools: list[object] | None = None,
+        sub_agents: tuple[object, ...] = (),
+    ) -> None:
         self.name = name
         self.model = model
         self.instruction = instruction
         self.tools = list(tools or [])
         self.sub_agents = list(sub_agents)
 
-    def model_copy(self, *, deep=False):
+    def model_copy(self, *, deep: bool = False) -> FakeAgent:
         return copy.deepcopy(self)
 
 
-def test_prepare_leaves_the_imported_agent_untouched():
+def test_prepare_leaves_the_imported_agent_untouched() -> None:
     original = FakeAgent("root", model="baked-in", instruction="be helpful")
     harness = adk_mod.AdkAgent(agents_config.AgentConfig(model="bench-model"))
 
@@ -348,7 +361,7 @@ def test_prepare_leaves_the_imported_agent_untouched():
     assert metadata["model_override_count"] == 1
 
 
-def test_prepare_overrides_sub_agent_models_too():
+def test_prepare_overrides_sub_agent_models_too() -> None:
     root = FakeAgent("root", model="a", sub_agents=[FakeAgent("child", model="b")])
     harness = adk_mod.AdkAgent(agents_config.AgentConfig(model="bench-model"))
 
@@ -358,7 +371,7 @@ def test_prepare_overrides_sub_agent_models_too():
     assert metadata["model_override_count"] == 2
 
 
-def test_prepare_keeps_the_agents_own_model_when_unset():
+def test_prepare_keeps_the_agents_own_model_when_unset() -> None:
     root = FakeAgent("root", model="baked-in")
     harness = adk_mod.AdkAgent(agents_config.AgentConfig(model=None))
 
@@ -368,7 +381,7 @@ def test_prepare_keeps_the_agents_own_model_when_unset():
     assert "model_override_count" not in metadata
 
 
-def test_prepare_appends_rules_to_the_instruction():
+def test_prepare_appends_rules_to_the_instruction() -> None:
     root = FakeAgent("root", instruction="you are an operator")
     harness = adk_mod.AdkAgent(
         agents_config.AgentConfig(
@@ -384,7 +397,7 @@ def test_prepare_appends_rules_to_the_instruction():
     assert prepared.instruction == "you are an operator\n\nnever delete data"
 
 
-def test_prepare_appends_discovered_skills(tmp_path):
+def test_prepare_appends_discovered_skills(tmp_path: pathlib.Path) -> None:
     skill_dir = tmp_path / "skills" / "rollout"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
@@ -407,7 +420,7 @@ def test_prepare_appends_discovered_skills(tmp_path):
     assert "Drain first." in prepared.instruction
 
 
-def test_prepare_reports_a_callable_instruction_provider():
+def test_prepare_reports_a_callable_instruction_provider() -> None:
     root = FakeAgent("root", instruction=lambda ctx: "dynamic")
     harness = adk_mod.AdkAgent(
         agents_config.AgentConfig(
@@ -423,17 +436,17 @@ def test_prepare_reports_a_callable_instruction_provider():
     assert "callable instruction provider" in errors[0]
 
 
-def test_prepare_attaches_one_toolset_per_mcp_binding(monkeypatch):
+def test_prepare_attaches_one_toolset_per_mcp_binding(monkeypatch: pytest.MonkeyPatch) -> None:
     built: list[dict] = []
 
     class FakeToolset:
-        def __init__(self, *, connection_params, tool_filter=None):
+        def __init__(self, *, connection_params: object, tool_filter: object = None) -> None:
             built.append({"params": connection_params, "tool_filter": tool_filter})
 
-    def fake_connection(*, server_params, timeout):
+    def fake_connection(*, server_params: object, timeout: float) -> dict:
         return {"server_params": server_params, "timeout": timeout}
 
-    def fake_server_params(*, command, args):
+    def fake_server_params(*, command: str, args: list[str]) -> dict:
         return {"command": command, "args": args}
 
     monkeypatch.setattr(
@@ -470,20 +483,20 @@ class FakeWorkflowAgent:
     step over rather than assign attributes onto.
     """
 
-    def __init__(self, name, sub_agents=()):
+    def __init__(self, name: str, sub_agents: tuple[object, ...] = ()) -> None:
         self.name = name
         self.sub_agents = list(sub_agents)
 
-    def model_copy(self, *, deep=False):
+    def model_copy(self, *, deep: bool = False) -> FakeWorkflowAgent:
         return copy.deepcopy(self)
 
 
-def _stub_toolset_types(monkeypatch):
+def _stub_toolset_types(monkeypatch: pytest.MonkeyPatch) -> list[object]:
     """Point ``_load_toolset_types`` at cheap stand-ins and return the built list."""
     built: list[object] = []
 
     class FakeToolset:
-        def __init__(self, *, connection_params, tool_filter=None):
+        def __init__(self, *, connection_params: object, tool_filter: object = None) -> None:
             self.tool_filter = tool_filter
             built.append(self)
 
@@ -499,7 +512,7 @@ def _stub_toolset_types(monkeypatch):
     return built
 
 
-def _mcp_harness(**caps):
+def _mcp_harness(**caps: object) -> adk_mod.AdkAgent:
     return adk_mod.AdkAgent(
         agents_config.AgentConfig(
             capabilities=capabilities.AllCapabilities(
@@ -514,7 +527,9 @@ def _mcp_harness(**caps):
     )
 
 
-def test_prepare_attaches_toolsets_to_every_agent_in_the_tree(monkeypatch):
+def test_prepare_attaches_toolsets_to_every_agent_in_the_tree(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Every agent that can hold tools gets the run's MCP toolset.
 
     Regression test for a real run. ADK resolves tools from the *active* agent
@@ -546,7 +561,7 @@ def test_prepare_attaches_toolsets_to_every_agent_in_the_tree(monkeypatch):
     assert len(built) == 1
 
 
-def test_prepare_delivers_rules_to_every_agent_in_the_tree():
+def test_prepare_delivers_rules_to_every_agent_in_the_tree() -> None:
     """A delegate that never sees the operator brief can violate it."""
     root = FakeAgent("root", instruction="coordinate", sub_agents=[FakeAgent("child")])
     harness = adk_mod.AdkAgent(
@@ -565,7 +580,7 @@ def test_prepare_delivers_rules_to_every_agent_in_the_tree():
     assert "never delete a namespace" in prepared.sub_agents[0].instruction
 
 
-def test_prepare_names_only_the_agents_that_refused_the_instruction():
+def test_prepare_names_only_the_agents_that_refused_the_instruction() -> None:
     root = FakeAgent("root", instruction="coordinate")
     root.sub_agents = [
         FakeAgent("dynamic", instruction=lambda ctx: "computed"),
@@ -589,7 +604,9 @@ def test_prepare_names_only_the_agents_that_refused_the_instruction():
     assert "never delete a namespace" in prepared.sub_agents[1].instruction
 
 
-def test_prepare_steps_over_nodes_that_hold_no_tools_or_instruction(monkeypatch):
+def test_prepare_steps_over_nodes_that_hold_no_tools_or_instruction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     built = _stub_toolset_types(monkeypatch)
     root = FakeWorkflowAgent("pipeline", sub_agents=[FakeAgent("worker", instruction="work")])
     harness = _mcp_harness(rules=capabilities.AgentRules(text="never delete a namespace"))
@@ -604,8 +621,10 @@ def test_prepare_steps_over_nodes_that_hold_no_tools_or_instruction(monkeypatch)
     assert prepared.sub_agents[0].tools == built
 
 
-def test_prepare_records_an_error_when_mcp_support_is_missing(monkeypatch):
-    def boom():
+def test_prepare_records_an_error_when_mcp_support_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def boom() -> None:
         raise ImportError("no module named mcp")
 
     monkeypatch.setattr(adk_mod, "_load_toolset_types", boom)
@@ -631,7 +650,7 @@ def test_prepare_records_an_error_when_mcp_support_is_missing(monkeypatch):
 # --------------------------------------------------------------------------
 
 
-def test_adk_agent_is_registered():
+def test_adk_agent_is_registered() -> None:
     assert base.AGENTS.get("adk") is adk_mod.AdkAgent
 
 
@@ -660,7 +679,7 @@ def test_importing_the_harness_pulls_no_sdk() -> None:
 
 
 @requires_adk
-def test_execute_without_a_target_returns_an_errored_result():
+def test_execute_without_a_target_returns_an_errored_result() -> None:
     result = adk_mod.AdkAgent(agents_config.AgentConfig(target=None)).run("scale web")
 
     assert result.has_errors()
@@ -669,7 +688,7 @@ def test_execute_without_a_target_returns_an_errored_result():
 
 
 @requires_adk
-def test_execute_reports_an_unloadable_target():
+def test_execute_reports_an_unloadable_target() -> None:
     config = agents_config.AgentConfig(target="devops_bench.agents.adk.parsing:not_an_agent")
     result = adk_mod.AdkAgent(config).run("scale web")
 
@@ -726,7 +745,7 @@ _AGENT_FIXTURE = textwrap.dedent(
 
 
 @pytest.fixture
-def agent_dir(tmp_path):
+def agent_dir(tmp_path: pathlib.Path) -> pathlib.Path:
     """Write an ADK agent directory laid out the way ADK expects."""
     directory = tmp_path / "fixture_agent"
     directory.mkdir()
@@ -735,21 +754,21 @@ def agent_dir(tmp_path):
 
 
 @requires_adk
-def test_resolve_root_agent_from_an_agent_directory(agent_dir):
+def test_resolve_root_agent_from_an_agent_directory(agent_dir: pathlib.Path) -> None:
     resolved = adk_mod._resolve_root_agent(str(agent_dir))
 
     assert resolved.name == "fixture_agent"
 
 
 @requires_adk
-def test_resolve_root_agent_from_a_file_with_an_explicit_attribute(agent_dir):
+def test_resolve_root_agent_from_a_file_with_an_explicit_attribute(agent_dir: pathlib.Path) -> None:
     resolved = adk_mod._resolve_root_agent(f"{agent_dir / 'agent.py'}:root_agent")
 
     assert resolved.name == "fixture_agent"
 
 
 @requires_adk
-def test_resolve_root_agent_calls_a_factory(agent_dir):
+def test_resolve_root_agent_calls_a_factory(agent_dir: pathlib.Path) -> None:
     (agent_dir / "agent.py").write_text(
         _AGENT_FIXTURE + "\n\ndef build():\n    return root_agent\n", encoding="utf-8"
     )
@@ -760,15 +779,150 @@ def test_resolve_root_agent_calls_a_factory(agent_dir):
 
 
 @requires_adk
-def test_resolve_root_agent_rejects_a_non_agent(agent_dir):
+def test_resolve_root_agent_rejects_a_non_agent(agent_dir: pathlib.Path) -> None:
     (agent_dir / "agent.py").write_text("root_agent = object()\n", encoding="utf-8")
 
     with pytest.raises(Exception, match="not an ADK agent"):
         adk_mod._resolve_root_agent(str(agent_dir))
 
 
+def test_import_agent_module_rejects_a_name_already_bound_elsewhere(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A cached module of the same name must not stand in for the target.
+
+    ``import_module`` reads ``sys.modules`` before ``sys.path``, so prepending
+    the agent's parent cannot win against a name that is already imported. The
+    harness would otherwise benchmark whatever got there first and report a
+    clean success.
+    """
+    directory = tmp_path / "collides"
+    directory.mkdir()
+    (directory / "__init__.py").write_text("root_agent = None\n", encoding="utf-8")
+
+    impostor = ModuleType("collides")
+    impostor.__file__ = str(tmp_path / "elsewhere" / "collides" / "__init__.py")
+    monkeypatch.setitem(sys.modules, "collides", impostor)
+
+    with pytest.raises(core.ConfigError, match="already resolves to"):
+        adk_mod._import_agent_module(str(directory))
+
+
+def test_import_agent_module_accepts_the_package_it_asked_for(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard must not reject a package genuinely loaded from the target."""
+    monkeypatch.setattr(sys, "path", list(sys.path))
+    monkeypatch.setattr(sys, "modules", dict(sys.modules))
+    directory = tmp_path / "genuine_agent_pkg"
+    directory.mkdir()
+    (directory / "__init__.py").write_text("root_agent = 'here'\n", encoding="utf-8")
+
+    module = adk_mod._import_agent_module(str(directory))
+
+    assert module.root_agent == "here"
+
+
+class SlowClosingRunner:
+    """Runner whose ``close()`` needs several awaits to release its session.
+
+    ``close()`` awaiting at all is the whole point: that is where an inherited
+    cancellation would land, and ``progress`` records how far teardown got.
+    """
+
+    progress: list[str] = []
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.session_service = self
+
+    async def create_session(self, **kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(id="s1")
+
+    async def run_async(self, **kwargs: object) -> AsyncIterator[object]:
+        await asyncio.sleep(10)
+        yield  # pragma: no cover - the budget always expires first
+
+    async def close(self) -> None:
+        type(self).progress.append("started")
+        for _ in range(3):
+            await asyncio.sleep(0.01)
+        type(self).progress.append("finished")
+
+
 @requires_adk
-def test_execute_drives_a_real_adk_agent_end_to_end(agent_dir):
+def test_drive_finishes_teardown_after_the_budget_expires(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cancellation that ends the run must not cut teardown short.
+
+    One MCP binding is shared across the whole tree, so a ``close()`` that
+    stops half-way leaves the server subprocess running for the rest of the
+    session.
+    """
+    SlowClosingRunner.progress = []
+    import google.adk.runners as adk_runners
+
+    monkeypatch.setattr(adk_runners, "InMemoryRunner", SlowClosingRunner)
+
+    events, errors = adk_mod._drive(object(), "prompt", 0.02)
+
+    assert SlowClosingRunner.progress == ["started", "finished"]
+    assert events == []
+    assert errors == ["ADK run exceeded the 0.02s budget"]
+
+
+def test_close_quietly_finishes_under_repeated_cancellation() -> None:
+    """Teardown must not inherit cancellations aimed at the run that owns it.
+
+    The budget expiring cancels the owning coroutine once, which teardown
+    survives on its own. A second cancellation — a Ctrl-C landing on a run
+    whose budget has already blown — is what lands *inside* ``close()``, and a
+    bare ``await runner.close()`` stops there with the MCP server still up.
+    """
+    SlowClosingRunner.progress = []
+    runner = SlowClosingRunner()
+
+    async def scenario() -> None:
+        async def owner() -> None:
+            try:
+                await asyncio.sleep(10)
+            finally:
+                await adk_mod._close_quietly(runner)
+
+        task = asyncio.ensure_future(owner())
+        await asyncio.sleep(0.01)
+        for _ in range(3):
+            task.cancel()
+            await asyncio.sleep(0.01)
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    asyncio.run(scenario())
+
+    assert SlowClosingRunner.progress == ["started", "finished"]
+
+
+@requires_adk
+def test_close_quietly_gives_up_on_a_wedged_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A server that never releases must not replace a timeout with a hang."""
+    monkeypatch.setattr(adk_mod, "_CLOSE_TIMEOUT_SEC", 0.05)
+    cancelled: list[bool] = []
+
+    class WedgedRunner:
+        async def close(self) -> None:
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                cancelled.append(True)
+                raise
+
+    asyncio.run(adk_mod._close_quietly(WedgedRunner()))
+
+    assert cancelled == [True]
+
+
+@requires_adk
+def test_execute_drives_a_real_adk_agent_end_to_end(agent_dir: pathlib.Path) -> None:
     # No AGENT_MODEL: overriding it would replace the stub with a live model.
     config = agents_config.AgentConfig(target=str(agent_dir), model=None)
 
@@ -791,7 +945,9 @@ def test_execute_drives_a_real_adk_agent_end_to_end(agent_dir):
 
 
 @requires_adk
-def test_execute_runs_the_agent_inside_the_workspace(agent_dir, tmp_path):
+def test_execute_runs_the_agent_inside_the_workspace(
+    agent_dir: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
     """A relative path written by a tool must land where the diff is rooted.
 
     Regression test for a real run: the agent wrote its `report.md` deliverable
@@ -821,7 +977,7 @@ def test_execute_runs_the_agent_inside_the_workspace(agent_dir, tmp_path):
     assert os.getcwd() == before
 
 
-def test_in_workspace_restores_the_previous_directory_on_failure(tmp_path):
+def test_in_workspace_restores_the_previous_directory_on_failure(tmp_path: pathlib.Path) -> None:
     before = os.getcwd()
 
     with pytest.raises(RuntimeError), adk_mod._in_workspace(tmp_path):
@@ -831,7 +987,7 @@ def test_in_workspace_restores_the_previous_directory_on_failure(tmp_path):
     assert os.getcwd() == before
 
 
-def test_in_workspace_is_a_no_op_without_a_workspace():
+def test_in_workspace_is_a_no_op_without_a_workspace() -> None:
     before = os.getcwd()
 
     with adk_mod._in_workspace(None):
@@ -841,7 +997,7 @@ def test_in_workspace_is_a_no_op_without_a_workspace():
 
 
 @requires_adk
-def test_execute_keeps_the_partial_trajectory_when_a_tool_raises(agent_dir):
+def test_execute_keeps_the_partial_trajectory_when_a_tool_raises(agent_dir: pathlib.Path) -> None:
     (agent_dir / "agent.py").write_text(
         _AGENT_FIXTURE.replace(
             'return {"scaled": name, "replicas": replicas}',

--- a/uv.lock
+++ b/uv.lock
@@ -131,6 +131,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -187,6 +196,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "authlib"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
 ]
 
 [[package]]
@@ -470,6 +492,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+adk = [
+    { name = "google-adk" },
+]
 anthropic = [
     { name = "anthropic" },
 ]
@@ -491,6 +516,7 @@ dev = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.104.1" },
     { name = "deepeval", specifier = ">=4.0.3" },
+    { name = "google-adk", marker = "extra == 'adk'", specifier = ">=2.7.1" },
     { name = "google-genai", specifier = ">=2.8.0" },
     { name = "jsonpath-ng", specifier = ">=1.6" },
     { name = "mcp", specifier = ">=1.27.1" },
@@ -498,7 +524,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "ruamel-yaml", specifier = ">=0.18.0" },
 ]
-provides-extras = ["anthropic", "openai"]
+provides-extras = ["adk", "anthropic", "openai"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -544,6 +570,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.141.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
 ]
 
 [[package]]
@@ -645,26 +687,64 @@ wheels = [
 ]
 
 [[package]]
+name = "google-adk"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiosqlite" },
+    { name = "authlib" },
+    { name = "click" },
+    { name = "fastapi" },
+    { name = "google-auth", extra = ["pyopenssl"] },
+    { name = "google-genai" },
+    { name = "graphviz" },
+    { name = "httpx" },
+    { name = "jsonschema" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "python-multipart" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "starlette" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "tzlocal" },
+    { name = "uvicorn" },
+    { name = "watchdog" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/55/63336b5cd9679a32b36cb14971a7461811db20126bb63cb092fe653b8d54/google_adk-2.7.1.tar.gz", hash = "sha256:0485bfba1a04960a3784eb67531491475be1a3f8acefcc5c880a906857ecb3e2", size = 3806947, upload-time = "2026-08-17T18:33:11.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ed/6b3da8b43525d9b28a95836abb1042abc26fe1e8be9f63eb01c18b70d4d4/google_adk-2.7.1-py3-none-any.whl", hash = "sha256:cd21e37c9846a80086fd880924aa5548e625ef85178122b40cda81ef5316129f", size = 4396591, upload-time = "2026-08-17T18:33:09.596Z" },
+]
+
+[[package]]
 name = "google-auth"
-version = "2.55.1"
+version = "2.57.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/6f/f3f4ac177c67bbee8fe8e88f2ab4f36af88c44a096e165c5217accf6e5d3/google_auth-2.55.1.tar.gz", hash = "sha256:fb2d9b730f2c9b8d326ec8d7222f21aef2ead15bf0513793d6442485d87af0a1", size = 349527, upload-time = "2026-06-25T23:39:27.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/1d/f6d3ca1ad0725f2e08a1c6915640748a52de2e66596160a4d53b010cccf0/google_auth-2.55.1-py3-none-any.whl", hash = "sha256:eada68dfd52b3b81191827601e2a0c3fa12540c818534b630ddc5355769c3995", size = 252349, upload-time = "2026-06-25T23:38:52.946Z" },
+    { url = "https://files.pythonhosted.org/packages/00/f3/8508a702c094af5f6e89773f4dfdeee74913df0f41a02c21b5e7dc3d75cd/google_auth-2.57.0-py3-none-any.whl", hash = "sha256:180dafe015cfb62193bea26b677500fab5b9fd51a1e825ebf3ad9b182047ae59", size = 259728, upload-time = "2026-08-24T21:55:08.449Z" },
 ]
 
 [package.optional-dependencies]
+pyopenssl = [
+    { name = "cryptography" },
+]
 requests = [
     { name = "requests" },
 ]
 
 [[package]]
 name = "google-genai"
-version = "2.10.0"
+version = "2.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -678,9 +758,18 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/fe/b796087493c3c55371aa58b9f264841ace5bfdf8c668cafa7afa33c44bec/google_genai-2.10.0.tar.gz", hash = "sha256:77912cd558cd7dfd5b75c25fd1c609e78d7954dde583331104022a46ea90f9ee", size = 600039, upload-time = "2026-06-24T01:33:18.157Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/1a/a834dfed90cf32dba900b533a1d14dcdefbda398bda5661d2a5a60fdc9fc/google_genai-2.19.0.tar.gz", hash = "sha256:d8f4126643793a7de230c396bcd142d21c948c8bb57507580e152549a7a41d9d", size = 659496, upload-time = "2026-08-19T23:05:43.276Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/39/00bcfd94de255d24249401efff4f48d77bf6066b46447e519fa193c0c299/google_genai-2.10.0-py3-none-any.whl", hash = "sha256:d5350311567ae660c24cbc1752aee4b3d660f89c0106d2dcd2a69978c35afe1e", size = 957974, upload-time = "2026-06-24T01:33:16.296Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e8/de0accd8cd004cf11252ca53fc5c3dda59bcf1856abfc7609842ceba7363/google_genai-2.19.0-py3-none-any.whl", hash = "sha256:36e0326dd886b52ef765be4c46042732b46b21f637abbe060e3db7c3de23974c", size = 1051056, upload-time = "2026-08-19T23:05:41.462Z" },
+]
+
+[[package]]
+name = "graphviz"
+version = "0.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b3/3ac91e9be6b761a4b30d66ff165e54439dcd48b83f4e20d644867215f6ca/graphviz-0.21.tar.gz", hash = "sha256:20743e7183be82aaaa8ad6c93f8893c923bd6658a04c32ee115edb3c8a835f78", size = 200434, upload-time = "2025-06-15T09:35:05.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/4c/e0ce1ef95d4000ebc1c11801f9b944fa5910ecc15b5e351865763d8657f8/graphviz-0.21-py3-none-any.whl", hash = "sha256:54f33de9f4f911d7e84e4191749cac8cc5653f815b06738c54db9a15ab8b1e42", size = 47300, upload-time = "2025-06-15T09:35:04.433Z" },
 ]
 
 [[package]]
@@ -875,6 +964,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
     { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
     { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.7.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/e0/27a6a081ae25420eda6768ceae05d7022a7f2447f420588843f2a44e4298/joserfc-1.7.4.tar.gz", hash = "sha256:b3bc561672ae541b17a9237053b48a03dacddd92d68047b3ecdfb4b5714a88ed", size = 234027, upload-time = "2026-07-19T15:43:02.739Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/bf/249dcd99b3376375910b7fa922383b57792975c8758f50d44612e749226c/joserfc-1.7.4-py3-none-any.whl", hash = "sha256:32d46c2cd5e3203c13e87a6c61333cab310b1ba80cd54b4c4f386a848a122463", size = 71000, upload-time = "2026-07-19T15:43:01.299Z" },
 ]
 
 [[package]]
@@ -1160,41 +1261,41 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.43.0"
+version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912, upload-time = "2026-06-24T15:19:35.434Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl", hash = "sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714", size = 61311, upload-time = "2026-05-21T16:32:28.822Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.43.0"
+version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/eb/5041074274ac0956b03637cc039d434569112468e875eddfcc9a0674ce06/opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9", size = 254744, upload-time = "2026-06-24T15:20:08.467Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/f7/b390bd9bfd703bf98a68fea1f27786c6872331fd617164a54b8a59bdc008/opentelemetry_sdk-1.42.1.tar.gz", hash = "sha256:8c834e8f8c9ba4171d4ec843d0cb8a67e4c7394d3f9e9297e582cbd9456ddbf7", size = 239262, upload-time = "2026-05-21T16:33:04.641Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/e3/b17be23af124201c9f52eececd4cc8ddfed1597d37b4ee771895d325805c/opentelemetry_sdk-1.43.0-py3-none-any.whl", hash = "sha256:d1323a547c1ce69d6a069a17a44b7da82bb8b332051ecb074041f87642c86823", size = 178852, upload-time = "2026-06-24T15:19:52.169Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/6b/4287766cfbde577ae2272e8884abac325aeaac0d64f41c61d5b8cc595105/opentelemetry_sdk-1.42.1-py3-none-any.whl", hash = "sha256:083cd4bbfaa5aa7b5a9e552430d9951219967cfb27aa61feb13a77aba1fc839d", size = 170907, upload-time = "2026-05-21T16:32:45.894Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.64b0"
+version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/99/4d7dd6df64795951413ce6e815f8cf1eb191daf7196ae86574589643d5f3/opentelemetry_semantic_conventions-0.63b1.tar.gz", hash = "sha256:3daf963611334b365e98a57438183eb012d3bfb40b2d931a9af613476b8701a9", size = 148340, upload-time = "2026-05-21T16:33:05.455Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7a/7fe66f5f3682b1dd47d88cc4e11f1c6c0966b737de2d16671146e23c39a5/opentelemetry_semantic_conventions-0.63b1-py3-none-any.whl", hash = "sha256:dfe5ef4dee82586b746f522b818ceb298d00b3d59f660042bd79404bff8d0682", size = 203713, upload-time = "2026-05-21T16:32:47.016Z" },
 ]
 
 [[package]]
@@ -2031,6 +2132,27 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/5b/879b2f932adfa7a053c360d50bc896c977fa6426109185f7c12ebdd0cb9d/tzlocal-5.4.4.tar.gz", hash = "sha256:8dbb8660838688a7b6ba4fed31d18dedf842afb4d47ca050d6d891c2c15f3be4", size = 31170, upload-time = "2026-06-29T08:03:40.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/a4/017a7a6cbe387d961a688ec31364ae60a5c4e22c96ae9921b79a947c855d/tzlocal-5.4.4-py3-none-any.whl", hash = "sha256:aae09f0126a8a86fa736be266eb4a471380d26a0de3bc14844e7821fee3e2a15", size = 18115, upload-time = "2026-06-29T08:03:38.666Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2068,6 +2190,30 @@ wheels = [
 ]
 
 [[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
 name = "wcwidth"
 version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2078,47 +2224,33 @@ wheels = [
 
 [[package]]
 name = "websockets"
-version = "16.0"
+version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
-    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
-    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
-    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
-    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
-    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
-    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
-    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
-    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
-    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
-    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
-    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
-    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds a fifth agent harness, registered as `--agent-type adk`, that runs any agent built with the [Agent Development Kit](https://google.github.io/adk-docs/) against a benchmark task and recovers a scoreable trajectory from it.

```bash
uv sync --extra adk

export BENCH_AGENT_TYPE=adk
export AGENT_TARGET=~/agents/my_agent   # or my_pkg.agent:root_agent
export AGENT_MODEL=gemini-2.5-pro       # optional; unset keeps the agent's own model
```

The harness imports the agent named by `AGENT_TARGET`, deep-copies it, applies the benchmark's capabilities (MCP toolset, skills, rules), drives it in-process through ADK's `Runner`, and folds the `function_call` / `function_response` parts of the event stream into a trajectory.

## Why in-process rather than A2A

A2A can issue a prompt to a deployed agent but exposes no trajectory, and trajectory is most of what the benchmark scores. ADK's `Runner` event stream exposes both the answer and the tool calls, so the harness drives the agent in-process instead of POSTing to a deployed service. That is a deliberate scope boundary — see *Known limitations* below.

## Design notes

**Deep copy per run.** The imported agent is `model_copy(deep=True)`-ed before every run, so the harness's edits — model override, appended instruction text, attached toolsets — never mutate the module that a second run re-imports.

**Capabilities apply to the whole tree.** The model override, the MCP toolset, the rules brief, and discovered skills are applied to *every* agent in the tree, not just the root. ADK resolves tools from whichever agent is **active** (`LlmAgent.canonical_tools`, no inheritance from a parent), so a root-only grant leaves a delegate unable to touch the cluster. This was a real defect, found by pointing the harness at a delegating tree — see *Testing*.

Two consequences worth a reviewer's eye:

- A coordinator its author deliberately left toolless **will** receive the MCP toolset. That's the intended trade: an agent holding a tool it doesn't need is recoverable, an acting agent with no cluster access is not.
- One MCP binding is still one server process. The same toolset object is shared across the tree rather than rebuilt per agent (`McpToolset.close` is documented as safe to call more than once, which is what ADK's cleanup does when a toolset is reachable from several agents).

Workflow agents (`SequentialAgent` and friends) hold no instruction or tools of their own and are stepped over. An agent using a *callable* instruction provider can't be appended to; only that agent is skipped, and it is named in the result's errors rather than dropped silently. `AgentResult.metadata` records what landed — `model_override_count`, `instruction_agents`, `mcp_agents`, `mcp_toolsets`. Note these live on the in-process result only: the orchestrator's `results.json` carries no harness metadata today. That's pre-existing and harness-agnostic, not introduced here; the last commit corrects the doc wording rather than widening this PR to change the result record.

**Import hygiene.** All `google.adk` imports are function-local. `import devops_bench.agents.adk.agent` pulls neither `google.adk` nor `mcp`, enforced by a subprocess test — the SDK is an optional extra and must stay one.

**The trajectory parser is SDK-free.** `parsing.py` operates on serialized event mappings, so the bulk of the logic is testable without the extra installed. 9 of the 43 new tests need the SDK and skip cleanly without it.

**Workspace as cwd.** The run happens with the harness-owned workspace as the process working directory, matching the `cwd` the CLI harnesses give their subprocess. See the second commit — this was a real defect found in e2e, not a precaution.

## Provider contract

`adk` sits outside the shared `AGENT_PROVIDER` contract on purpose: model routing belongs to ADK, which resolves a model string and its credentials itself. `AGENT_PROVIDER` and `AGENT_API_KEY` are **not consumed**. Authenticate the way ADK expects. Running on Vertex rather than AI Studio needs:

```bash
unset GOOGLE_API_KEY GEMINI_API_KEY     # either one silently wins over the Vertex switch
export GOOGLE_GENAI_USE_VERTEXAI=true
export GOOGLE_CLOUD_PROJECT=my-project
export GOOGLE_CLOUD_LOCATION=global
```

This is documented in `docs/components/agents.md`. Mapping the bench's `AGENT_*` contract onto ADK's `GOOGLE_*` automatically is a reasonable follow-up; I left it manual and documented rather than guessing at the mapping.

## Testing

**Unit:** 43 new tests. Full suite passes both ways — `1255 passed` with `--extra adk`, `1246 passed, 9 skipped` without it. `ruff check`, `ruff format --check`, `hack/boilerplate.py`, and `pre-commit run --all-files` all clean.

**Single-agent, end to end** on a real cluster:

1. Smoke test — probe agent, no cluster: import → deep copy → model override → `Runner` → event stream → trajectory.
2. `tasks/common/opa-remediation` on kind, with a live `gke-mcp` toolset: 30 tool calls, `status: success`, `errors: []`, `VerificationCoverage: 1.0`, `OutcomeScore: 0.8165`.
3. Same task re-run after the workspace fix, confirming the fix and no regression — identical scores, `generated_files/report.md` now collected.
4. A forced MCP probe against the live server, to check the result-envelope unwrapping against a real response rather than a recorded fixture.

**Multi-agent tree.** The runs above used a single `LlmAgent`, which cannot distinguish a root-only grant from a tree-wide one. Re-running against a three-node delegating tree (toolless coordinator → cluster operator → reporter, with callbacks recording ground truth independently of the harness) exposed the defect the last commit fixes:

| | before | after |
| --- | --- | --- |
| operator sub-agent's tools | `[]` | `["McpToolset"]` |
| operator sub-agent got the rules brief | no | yes |
| real MCP calls made by the sub-agent | 0 | 6 |
| reporter's own tools preserved | — | `["function", "McpToolset"]` |

The pre-fix run reported `status: success` with `errors: []` and scored `0.0` — a harness fault was indistinguishable from an agent that simply failed the task, which is why the fix ships with tests that assert the tree shape rather than just the root.

Also confirmed by these runs, previously untested: delegation itself, the workspace `cwd` holding across a two-hop delegation (a sub-agent wrote a relative path and the orchestrator collected it), and callbacks firing without breaking the harness.

**Scoring parity.** A delegating tree then ran the same `opa-remediation` task the single agent did, start to finish:

| | single `LlmAgent` | three-node tree |
| --- | --- | --- |
| `OutcomeScore` | 0.8165 | **0.8165** |
| `VerificationCoverage` | 1.0 | 1.0 |
| `status` / `errors` | success / `[]` | success / `[]` |
| trajectory entries | 30 | 30 (26 `run_shell` + 3 `transfer_to_agent` + 1 `write_file`) |

Same score, full verification coverage, so a tree is graded exactly like a single agent. (The matching entry counts are coincidence — the tree spends 3 of its 30 on delegation hops.) The tree split the work as intended — the operator sub-agent made all 26 cluster calls and handed off, the reporter wrote the deliverable — and both sub-agents held their own tools *plus* the attached toolset (`["function", "McpToolset"]`), confirming the grant lands alongside rather than replacing. The one failed judge check was the same one the single agent missed (an omitted policy-enforcement detail in the report), which is agent quality, not harness behaviour.

That run also used a quarantined `HOME`, because earlier runs of this task family had left `opa-repo-*.git` and a `remediation-report.md` in the real home directory — where this task provisions its own repo. I audited all 26 shell commands afterwards: every one is legitimate task work, no attempt to read the task definition or rubric.

I used throwaway probe agents rather than a real one, with tools of their own, so that any failure was unambiguously the harness's and so harness-attached toolsets had to land *alongside* existing tools.

The one judge check that failed in (2) and (3) was the agent omitting a policy detail from its report — agent quality, not harness behaviour.

## Lockfile churn

Declaring the extra moves 246 lines of `uv.lock`, because uv resolves extras universally — declaring `adk` folds `google-adk`'s constraints into the single shared resolution even for people who never install it. Net effect: `google-auth` 2.55.1→2.57.0 and `google-genai` 2.10.0→2.19.0 up; `opentelemetry-api`/`-sdk` 1.43.0→1.42.1, `opentelemetry-semantic-conventions` 0.64b0→0.63b1, and `websockets` 16.0→15.0.1 down. Full suite passes on the new resolution. This is the same trade-off the existing `anthropic` and `openai` extras already make, but flagging it explicitly since the downgrades are the kind of thing worth a reviewer's eye.

## Known limitations

Deliberately out of scope, listed so nobody assumes otherwise:

- **In-process only.** An agent that exists solely as a deployed A2A service cannot be evaluated by this harness.
- **Sub-agent attribution is flattened.** Capabilities now reach every agent, but the *trajectory* still records tool calls without which agent made each one, so `transfer_to_agent` hops and a delegate's own calls sit side by side. Invisible for a single `LlmAgent`; cosmetic but real for a tree.
- **`AGENT_MAX_TURNS` is not wired.** It remains api-harness-only. ADK's own `RunConfig.max_llm_calls` default of 500 is the effective backstop.
- **Non-Gemini models are not reachable out of the box.** ADK's `LiteLlm` wrapper needs `google-adk[extensions]`, which the `adk` extra does not install (`adk = ["google-adk>=2.7.1"]`; no `litellm` in the lock). I verified `LiteLlm` imports and constructs fine *with* that extra, so this is a packaging choice we can revisit, not a design limit — left out here to keep the lockfile churn to what the core needs. Token accounting also assumes genai usage field names, so a `LiteLlm`-backed run may report usage incompletely.
- **Harness metadata is not persisted.** `results.json` carries no `metadata`, so the `mcp_agents` / `instruction_agents` counts are in-process only. Pre-existing and not ADK-specific.

I'd rather land the core and let real usage decide which of these matter than pre-emptively guess.

## Related

- #136 caps `mcp<2`. Independent, but relevant: ADK's `McpToolset` caps itself at `mcp<2` only under extras we don't request, so this PR would otherwise inherit no ceiling.

- Tracked by #138 (ADK support, end to end).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional ADK harness for running Agent Development Kit agents in-process.
  * Supports configurable models, instructions, skills, MCP tools, multi-agent trees, timeouts, and workspace isolation.
  * Captures assistant responses, tool-call trajectories, token usage, and execution errors.
  * Supports flexible agent target formats and preserves partial results when runs encounter failures.

* **Documentation**
  * Added setup, configuration, target resolution, and behavior guidance for the ADK harness.

* **Tests**
  * Added comprehensive coverage for parsing, configuration, execution, tool handling, errors, and optional dependency behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->