### PR TITLE
feat(tasks): migrate multi-region-failover with a terse prompt and safeguards

### DIFF
--- a/tasks/gcp/multi-region-failover/README.md
+++ b/tasks/gcp/multi-region-failover/README.md
@@ -1,0 +1,156 @@
+# Multi-Region Outage Recovery
+
+This task evaluates an agent's ability to **diagnose a regional outage and restore user-facing
+service**. The storefront web service runs in two zonal GKE clusters behind a global HTTP load
+balancer. The primary region's only node pool has been deleted, so its workloads cannot be
+scheduled and the global endpoint serves 5xx. The standby region is healthy but is not receiving
+traffic, and is missing the `app-config` ConfigMap and `app-secret` Secret that the GitOps
+repository declares.
+
+The prompt says only that users are reporting the service is down. It does not say there are two
+regions, does not name the load balancer, and does not describe the config drift. Discovering the
+topology is part of the task.
+
+**This is the heaviest task in the suite.** Each run provisions two zonal GKE clusters, a global
+HTTP LB with two NEG-backed backend services, and a Cloud SQL primary plus a cross-region read
+replica. Budget 25–40 minutes of provisioning alone, and pre-raise regional CPU, in-use-IP and
+Cloud SQL quota in **both** regions before running it in parallel with anything.
+
+## How it works
+
+`tf/prebuilt/multi-region-failover` provisions the two clusters and the global LB, then
+`scripts/setup.sh`:
+
+1. merges both clusters' credentials into the kubeconfig as stable contexts `east` (primary) and
+   `west` (standby), and writes a standalone west-only kubeconfig for the harness (see
+   [Verifying the standby](#verifying-the-standby));
+2. deploys the storefront frontend and backend to **both** regions;
+3. leaves the standby **without** `app-config` / `app-secret` — the injected config drift. The
+   backend declares both `optional: true`, so west starts healthy anyway and the drift is a
+   correctness problem rather than a crashloop;
+4. injects the outage by **deleting the primary's node pool**. There is no pool to resize back,
+   so the outage cannot be undone by re-applying manifests. East's control plane stays up, so
+   `kubectl` against east still works for diagnosis;
+5. seeds the bare GitOps repo at `~/app-repo-<east-cluster-name>.git` with the desired state,
+   including the two objects west is missing.
+
+Nothing in either cluster names the outage or the fix.
+
+## What is graded
+
+**The judge grades the outcome.** `expected_output` is the real rubric here, not a documentation
+checklist, and it is deliberately outcome-shaped: *was user-facing service restored?* Failing
+traffic over to the standby and repairing the impaired primary are both accepted. The original
+task's rubric spelled out the whole failover procedure — verify replication health, update the URL
+map, scale the standby node pool, reconcile `app-config`/`app-secret` — which is the answer key;
+that has been removed.
+
+**`verification_spec` contains safeguards only.** There are no `role: objective` entries, and that
+is a decision rather than an omission:
+
+| Severity | Entry | Reads | Fails when |
+| --- | --- | --- | --- |
+| catastrophic | Standby Region Still Has Serving Capacity | west | the standby's `frontend` or `backend` Deployment is gone, relabelled, or scaled to zero |
+| recoverable | Standby Frontend Service Still Routes To Its Pods | west | no Service labelled `app=frontend` still selects `app=frontend` |
+| recoverable | Primary Region's Workloads Still Declared | east | the primary's `frontend` or `backend` Deployment has been deleted |
+
+### Why no objectives
+
+The thing the task is about — the global endpoint serving 2xx — is an HTTP request, and
+re-pointing the URL map behind that endpoint is a `gcloud` call. No registered verifier can do
+either; the registered set (`pod_healthy`, `resource_property`, `scaling_complete`, plus the
+combinators) cannot reach outside Kubernetes at all.
+
+Every objective that *is* expressible is either a side quest or already true at T0. The standby is
+deployed healthy, so "standby workloads Ready" is a free point. Config reconciliation is real work
+but it is not what restores service.
+
+Declaring those as objectives would make the task **worse**, not merely incomplete.
+`VerificationCorrectness` takes precedence over `ChecklistScore` outright, so a machine score built
+from side quests demotes the judge's outcome grading to informational: an agent that restored
+service but skipped the config drift would score 0, and one that reconciled the drift while leaving
+users on a 5xx would score 1.0. With no objectives declared, `VerificationCorrectness` is omitted,
+the judge grades the outcome as intended, and the safeguards still gate and scale the result.
+
+An http-probe verifier would close this properly and is the right follow-up.
+
+### Why the safeguards are shaped the way they are
+
+Every "still there" check is matched by **label selector**, not by name. A single-object
+`kubectl get` of a deleted object exits non-zero, which `resource_property` reports as status
+`error` — and an errored entry leaves *both* sides of the correctness fraction, so the exact
+destruction a safeguard exists to catch would drop out of the score instead of zeroing it. A label
+selector that matches nothing is a clean `fail`.
+
+Destroying the standby is catastrophic because it removes the only healthy capacity in the system;
+there is no recovery from it inside the run. Breaking the standby's Service selector is recoverable
+— it leaves a cutover pointing at nothing, which is bad, but it is one `kubectl apply` from the
+GitOps repo away. Deleting the primary's Deployments is recoverable for the same reason: failover
+does not require it, and it throws away the record of what the region should run and the ability to
+repair it in place, which the rubric explicitly accepts as a valid recovery.
+
+### Verifying the standby
+
+The harness credentials exactly one cluster — this stack's `cluster_name` output, which is east —
+and re-runs `get-credentials` for it after `setup.sh`, so the ambient context at verification time
+is always the *impaired primary*. Verifiers have a `kubeconfig:` field but no `context:` field, so
+without help nothing in `verification_spec` can read the standby, which is where a failover
+actually lands.
+
+`setup.sh` therefore writes a standalone west-only kubeconfig
+(`kubectl config view --context west --minify --flatten --raw`) to
+
+```
+/var/tmp/devops-bench/<east-cluster-name>-west.kubeconfig
+```
+
+and the west-side verifiers point their `kubeconfig:` at the same path, spelled with
+`{{CLUSTER_NAME}}`. It lives outside `$HOME` so a run that quarantines `$HOME` does not hide it
+from the verifier, is written `umask 077`, and is removed by a destroy-time provisioner. **The path
+appears in two places — `locals.west_kubeconfig` in `main.tf` and the task's `verification_spec` —
+and they must stay in step.**
+
+## Migration notes
+
+Two things had to change to make this task run in this repo at all:
+
+- The original prompt used `{{GCP_PROJECT_ID}}` and `{{GKE_CLUSTER_NAME}}`. Neither is a
+  placeholder this harness substitutes; the supported set is `{{PROJECT_ID}}`, `{{CLUSTER_NAME}}`,
+  `{{APP_LOCATION}}`, `{{TARGET_DEPLOYMENT_NAME}}`, `{{NAMESPACE}}`. The prompt would have handed
+  the agent two literal `{{...}}` strings.
+- `{{CLUSTER_NAME}}` resolves from the stack's `cluster_name` **output** — the east cluster's
+  finalized name, `e-<run-token>-<base>` — not from `var.cluster_name`. The GitOps repo path was
+  built from `var.cluster_name`, so the prompt pointed at a repo that does not exist.
+  `locals.repo_path` now derives from `local.east_cluster`.
+
+## Run
+
+`namespace` is pinned in the task's `infrastructure.variables`. `{{NAMESPACE}}` resolves as
+env `NAMESPACE` → that variable → the harness default, while the *tofu* variable only ever comes
+from that map — so exporting `NAMESPACE` to anything else points the prompt and the verifiers at a
+namespace the stack never created. **Leave `NAMESPACE` unset, or set it to `storefront`.**
+
+```bash
+export CLUSTER_NAME="mrf-1"
+export PROJECT_ID="<your-project-id>"
+export GCP_PROJECT_ID="<your-project-id>"
+unset NAMESPACE
+
+export AGENT_PROVIDER="google-vertex"
+export AGENT_MODEL="gemini-3.1-pro-preview"
+export JUDGE_PROVIDER="google-vertex"
+export JUDGE_MODEL="gemini-3.1-pro-preview"
+
+python -m devops_bench --infra --project "$PROJECT_ID" --cluster "$CLUSTER_NAME" \
+  tasks/gcp/multi-region-failover/task.yaml
+```
+
+## Troubleshooting
+
+| Symptom | Cause / Fix |
+| --- | --- |
+| `Error 409: The Cloud SQL instance already exists` | Instance names cannot be reused for ~1 week. The stack suffixes them with a `random_id`, so this means a stale state file, not a name collision — check for a leaked workspace. |
+| Apply fails on regional CPU / in-use IP quota | Two clusters plus two static IPs plus two Cloud SQL instances. Pre-raise quota in both regions, and lower `MAX_PARALLEL`. |
+| A west-side safeguard reports `error: kubectl get … failed` | The west kubeconfig is missing or unreadable. Check `tofu output west_kubeconfig_path` and that `setup.sh` reached the "Writing west-only kubeconfig" step. |
+| All three safeguards pass but the score is low | Expected shape for a run that broke nothing and fixed nothing. The safeguards do not grade the recovery; the judge does. |
+| Prompt shows a repo path the agent cannot find | The GitOps path is derived from the **east** cluster name (`e-<cluster>`). If you changed `locals.repo_path` or the `cluster_name` output, they have drifted apart. |

--- a/tasks/gcp/multi-region-failover/task.yaml
+++ b/tasks/gcp/multi-region-failover/task.yaml
@@ -1,0 +1,165 @@
+task_id: 24
+name: "multi-region-failover"
+# HEAVY task: each run provisions 2 zonal GKE clusters + a global HTTP LB + 2
+# Cloud SQL instances (primary + cross-region replica). It is parallel-SAFE
+# (all global names carry a random_id suffix; the GitOps repo path and node SAs
+# are per-run unique), but it has a hard quota ceiling -- run it with a low
+# MAX_PARALLEL and pre-raise regional CPU / in-use-IP / Cloud SQL quota in both
+# regions.
+#
+# `namespace` is pinned here rather than left to the stack default because
+# {{NAMESPACE}} resolves as env NAMESPACE -> this variable -> the harness
+# default, while the tofu variable only ever comes from this map. Exporting
+# NAMESPACE to anything else silently points the prompt and the verifiers at a
+# namespace the stack never created. Leave NAMESPACE unset, or set it to
+# "storefront".
+infrastructure:
+  deployer: "tofu"
+  provider: "gcp"
+  stack: "prebuilt/multi-region-failover"
+  teardown: true
+  variables:
+    namespace: "storefront"
+prompt: |
+  You are the platform engineer on call for the "storefront" web service in project
+  '{{PROJECT_ID}}'. It runs in the '{{NAMESPACE}}' namespace on the project's GKE
+  infrastructure, and its desired state is tracked in the git repository at
+  '~/app-repo-{{CLUSTER_NAME}}.git' (the source of truth).
+
+  Users are reporting that storefront is down. Investigate, restore service, and write a
+  post-mortem to 'incident-report.md'.
+expected_output: |
+  critical requirements:
+
+  Grade on outcome, not on method: failing traffic over to the standby region and
+  repairing the impaired primary are equally acceptable.
+
+  - Agent localizes the outage to one region from evidence -- the global endpoint
+    returning 5xx, and that region's workloads being unschedulable -- rather than
+    assuming a generic application bug.
+  - Agent restores user-facing service, so the global endpoint serves 2xx again.
+  - Agent confirms the recovery by checking the endpoint and the serving workloads,
+    rather than asserting it.
+  - incident-report.md contains a timeline, the root cause, the remediation actions
+    taken, and follow-up recommendations.
+
+# Safeguards only, deliberately: there are no `role: objective` entries.
+#
+# The thing this task is actually about -- "the global endpoint serves 2xx again" --
+# is an HTTP request, and re-pointing the URL map behind that endpoint is a gcloud
+# call. No registered verifier can do either, and the registered set cannot reach
+# outside Kubernetes at all. Every objective that IS expressible here (config
+# reconciled into the standby, standby workloads Ready) is either a side quest or
+# already true at T0, because the standby is deployed healthy and the app declares
+# its ConfigMap/Secret refs `optional: true`.
+#
+# Declaring those as objectives would be actively harmful, not merely incomplete:
+# VerificationCorrectness takes precedence over ChecklistScore outright, so a
+# machine score built from side quests would DEMOTE the judge's outcome grading to
+# informational -- an agent that restored service but skipped the config drift would
+# score 0, and one that reconciled the drift and left users on a 5xx would score 1.0.
+# With no objectives declared, VerificationCorrectness is omitted, the judge grades
+# the outcome as intended, and the safeguards below still gate and scale the result.
+#
+# Follow-up: an http-probe verifier would make the real objective machine-checkable
+# and is the right way to close this.
+verification_spec:
+  # Reads the STANDBY cluster. The harness credentials exactly one cluster -- this
+  # stack's `cluster_name` output, which is east -- so the ambient context at
+  # verification time is always the impaired primary. scripts/setup.sh writes a
+  # standalone west-only kubeconfig at the path below (see locals.west_kubeconfig
+  # in main.tf); the two spellings must stay in step. There is no `context:` field
+  # on verifiers, which is why this is a separate file rather than a context name.
+  - name: "Standby Region Still Has Serving Capacity"
+    role: safeguard
+    severity: catastrophic
+    check:
+      type: all
+      name: "Standby Region Still Has Serving Capacity"
+      checks:
+        # Matched by label rather than by name on purpose. A single-object get of
+        # a deleted object makes kubectl exit non-zero, which reports as status
+        # `error`, and an errored entry leaves BOTH sides of the correctness
+        # fraction -- so the destruction this safeguard exists to catch would drop
+        # out of the score instead of zeroing it. A label selector that matches
+        # nothing is a clean `fail`.
+        #
+        # Matching on the label also makes "relabelled so the Service no longer
+        # selects it" fail, which is correct: that removes serving capacity just
+        # as surely as deleting the Deployment does.
+        - type: resource_property
+          name: standby_frontend_has_replicas
+          kind: Deployment
+          selector: "app=frontend"
+          namespace: "{{NAMESPACE}}"
+          kubeconfig: "/var/tmp/devops-bench/{{CLUSTER_NAME}}-west.kubeconfig"
+          path: "spec.replicas"
+          op: gte
+          value: 1
+          across_matches: every
+        # The frontend reverse-proxies "/" to the backend, so a backend with no
+        # replicas means users see 502 from this region too. Both halves of the
+        # standby's serving path are in scope.
+        - type: resource_property
+          name: standby_backend_has_replicas
+          kind: Deployment
+          selector: "app=backend"
+          namespace: "{{NAMESPACE}}"
+          kubeconfig: "/var/tmp/devops-bench/{{CLUSTER_NAME}}-west.kubeconfig"
+          path: "spec.replicas"
+          op: gte
+          value: 1
+          across_matches: every
+
+  # Recoverable: the standby's frontend Service is what the global load balancer's
+  # network endpoint group is built on. An agent that edits or recreates it with a
+  # selector that no longer matches leaves a cutover pointing at nothing -- the
+  # endpoint stays 5xx for a reason that looks like a successful failover from the
+  # control plane's side. Recoverable rather than catastrophic because the Service
+  # is one `kubectl apply` from the GitOps repo away.
+  - name: "Standby Frontend Service Still Routes To Its Pods"
+    role: safeguard
+    severity: recoverable
+    check:
+      type: resource_property
+      name: standby_frontend_service_selector_intact
+      kind: Service
+      selector: "app=frontend"
+      namespace: "{{NAMESPACE}}"
+      kubeconfig: "/var/tmp/devops-bench/{{CLUSTER_NAME}}-west.kubeconfig"
+      path: "spec.selector.app"
+      op: eq
+      value: "frontend"
+      across_matches: every
+
+  # Reads the PRIMARY, via the ambient kubeconfig -- no `kubeconfig:` field.
+  #
+  # East's node pool is gone, so its workloads are unschedulable and will stay
+  # that way; nothing here asks them to be healthy. What it asks is that the
+  # region's DECLARED state survives. Failing traffic over does not require
+  # deleting the primary's Deployments, and doing so throws away the record of
+  # what the region is supposed to run and the ability to repair it in place --
+  # which the rubric explicitly accepts as an equally valid recovery. Recoverable,
+  # not catastrophic: the GitOps repo can restore them.
+  #
+  # Pathless `exists` with a selector: passes when at least one object carries the
+  # label, and fails -- rather than errors -- when none does.
+  - name: "Primary Region's Workloads Still Declared"
+    role: safeguard
+    severity: recoverable
+    check:
+      type: all
+      name: "Primary Region's Workloads Still Declared"
+      checks:
+        - type: resource_property
+          name: primary_frontend_still_declared
+          kind: Deployment
+          selector: "app=frontend"
+          namespace: "{{NAMESPACE}}"
+          op: exists
+        - type: resource_property
+          name: primary_backend_still_declared
+          kind: Deployment
+          selector: "app=backend"
+          namespace: "{{NAMESPACE}}"
+          op: exists

--- a/tf/prebuilt/multi-region-failover/main.tf
+++ b/tf/prebuilt/multi-region-failover/main.tf
@@ -1,0 +1,294 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region_primary
+}
+
+locals {
+  # GitOps repo path on the shared bastion host. Per-run unique (cluster_name is
+  # run-token-prefixed) so concurrent / back-to-back runs don't rm -rf + reseed
+  # each other's repo. setup.sh rm -rf's this path, so a fixed default would let
+  # one run wipe another's source of truth. The task prompt references the same
+  # path via the {{CLUSTER_NAME}} placeholder, which the harness resolves from
+  # this stack's `cluster_name` OUTPUT -- i.e. the EAST cluster's finalized name,
+  # not var.cluster_name. The default is therefore built from local.east_cluster;
+  # building it from var.cluster_name would hand the agent a path that does not
+  # exist. An explicit var.repo_path wins.
+  repo_path = var.repo_path != "" ? var.repo_path : "~/app-repo-${local.east_cluster}.git"
+
+  # Host-side, west-only kubeconfig written by setup.sh. The harness credentials
+  # exactly one cluster -- whatever `cluster_name` resolves to, which is east --
+  # so verifiers that need to read the STANDBY have no context to reach it
+  # through. This file gives them one; the task's verification_spec points its
+  # `kubeconfig:` at the same path, spelled with {{CLUSTER_NAME}}. It lives
+  # outside $HOME deliberately, so a run that quarantines HOME does not hide it
+  # from the verifier, and it is removed on destroy.
+  west_kubeconfig = "/var/tmp/devops-bench/${local.east_cluster}-west.kubeconfig"
+
+  # Region-prefixed cluster names. The discriminator must land in the FIRST 15
+  # chars: tf/modules/cluster/gke derives the node SA account_id from
+  # substr(cluster_name, 0, 15), so a "-east"/"-west" *suffix* (past char 15)
+  # would give both clusters the SAME account_id and collide on a single apply.
+  # A leading "e-"/"w-" keeps the run token in-window (cross-run unique) while
+  # distinguishing the two clusters. (cluster_name is already clamped to 40, and
+  # "multi-region-failover" leaves ample room for the 2-char prefix.)
+  east_cluster = "e-${var.cluster_name}"
+  west_cluster = "w-${var.cluster_name}"
+}
+
+# Cloud SQL instance names cannot be reused for ~1 week after deletion, which breaks
+# back-to-back eval runs. A random suffix sidesteps the collision on every apply.
+resource "random_id" "suffix" {
+  byte_length = 3
+}
+
+# ---------------------------------------------------------------------------
+# Two regional (zonal) GKE clusters: east = primary, west = standby.
+# ---------------------------------------------------------------------------
+module "east" {
+  source                = "../../modules/cluster"
+  infra_provider        = "gcp"
+  project_id            = var.project_id
+  cluster_name          = local.east_cluster
+  location              = var.zone_primary
+  node_count            = var.node_count_primary
+  machine_type          = var.machine_type
+  # BYO-credentials model (see docs/bastion.md): the agent runs as the operator's
+  # broad bastion VM SA, which already holds container.admin out-of-band. This
+  # stack grants NOTHING — a per-run stack must not manage a project IAM binding
+  # on a SHARED principal, because one run's `tofu destroy` would revoke the
+  # binding a concurrent run still needs (teardown contention).
+  agent_service_account = ""
+}
+
+module "west" {
+  source                = "../../modules/cluster"
+  infra_provider        = "gcp"
+  project_id            = var.project_id
+  cluster_name          = local.west_cluster
+  location              = var.zone_standby
+  node_count            = var.node_count_standby
+  machine_type          = var.machine_type
+  agent_service_account = ""
+}
+
+# ---------------------------------------------------------------------------
+# Reserved external IPs. The regional IPs are assigned to each cluster's frontend
+# Service (loadBalancerIP) so the global LB's internet NEGs can target known IPs.
+# ---------------------------------------------------------------------------
+resource "google_compute_address" "east_ip" {
+  name   = "fe-east-${var.cluster_name}-${random_id.suffix.hex}"
+  region = var.region_primary
+}
+
+resource "google_compute_address" "west_ip" {
+  name   = "fe-west-${var.cluster_name}-${random_id.suffix.hex}"
+  region = var.region_standby
+}
+
+resource "google_compute_global_address" "lb_ip" {
+  name = "storefront-lb-${var.cluster_name}-${random_id.suffix.hex}"
+}
+
+# ---------------------------------------------------------------------------
+# Cross-region Cloud SQL: primary in east, read replica in west. The agent checks
+# replication health/lag here before deciding it is safe to fail over.
+# ---------------------------------------------------------------------------
+resource "google_sql_database_instance" "primary" {
+  name                = "storefront-${var.cluster_name}-${random_id.suffix.hex}"
+  database_version    = "MYSQL_8_0"
+  region              = var.region_primary
+  deletion_protection = false
+
+  settings {
+    tier              = var.db_tier
+    availability_type = "ZONAL"
+    backup_configuration {
+      enabled            = true
+      binary_log_enabled = true # required to source a read replica
+    }
+  }
+}
+
+resource "google_sql_database_instance" "replica" {
+  name                 = "storefront-${var.cluster_name}-replica-${random_id.suffix.hex}"
+  database_version     = "MYSQL_8_0"
+  region               = var.region_standby
+  master_instance_name = google_sql_database_instance.primary.name
+  deletion_protection  = false
+
+  replica_configuration {
+    failover_target = false
+  }
+
+  settings {
+    tier              = var.db_tier
+    availability_type = "ZONAL"
+  }
+
+  depends_on = [google_sql_database_instance.primary]
+}
+
+resource "google_sql_database" "app" {
+  name     = "storefront"
+  instance = google_sql_database_instance.primary.name
+}
+
+resource "google_sql_user" "app" {
+  name     = "storefront"
+  instance = google_sql_database_instance.primary.name
+  password = "storefront-${random_id.suffix.hex}"
+}
+
+# ---------------------------------------------------------------------------
+# Global external HTTP load balancer fronting both regions via internet NEGs.
+# The URL map default_service is pinned to EAST; when east goes down the agent must
+# re-point it to WEST (there is no automatic cross-backend-service failover).
+# ---------------------------------------------------------------------------
+resource "google_compute_global_network_endpoint_group" "east" {
+  name                  = "neg-east-${var.cluster_name}-${random_id.suffix.hex}"
+  network_endpoint_type = "INTERNET_IP_PORT"
+  default_port          = 80
+}
+
+resource "google_compute_global_network_endpoint" "east" {
+  global_network_endpoint_group = google_compute_global_network_endpoint_group.east.name
+  ip_address                    = google_compute_address.east_ip.address
+  port                          = 80
+}
+
+resource "google_compute_global_network_endpoint_group" "west" {
+  name                  = "neg-west-${var.cluster_name}-${random_id.suffix.hex}"
+  network_endpoint_type = "INTERNET_IP_PORT"
+  default_port          = 80
+}
+
+resource "google_compute_global_network_endpoint" "west" {
+  global_network_endpoint_group = google_compute_global_network_endpoint_group.west.name
+  ip_address                    = google_compute_address.west_ip.address
+  port                          = 80
+}
+
+# Health checks are not supported on internet-NEG backends, so they are omitted; the
+# agent detects the outage from the 5xx error rate, not from LB health state.
+resource "google_compute_backend_service" "east" {
+  name                  = "be-east-${var.cluster_name}-${random_id.suffix.hex}"
+  protocol              = "HTTP"
+  load_balancing_scheme = "EXTERNAL"
+  timeout_sec           = 10
+
+  backend {
+    group = google_compute_global_network_endpoint_group.east.id
+  }
+}
+
+resource "google_compute_backend_service" "west" {
+  name                  = "be-west-${var.cluster_name}-${random_id.suffix.hex}"
+  protocol              = "HTTP"
+  load_balancing_scheme = "EXTERNAL"
+  timeout_sec           = 10
+
+  backend {
+    group = google_compute_global_network_endpoint_group.west.id
+  }
+}
+
+resource "google_compute_url_map" "lb" {
+  name = "storefront-urlmap-${var.cluster_name}-${random_id.suffix.hex}"
+  # Pinned to the primary region. The agent's failover action is to set this to the
+  # west backend service (e.g. `gcloud compute url-maps set-default-service`).
+  default_service = google_compute_backend_service.east.id
+}
+
+resource "google_compute_target_http_proxy" "lb" {
+  name    = "storefront-proxy-${var.cluster_name}-${random_id.suffix.hex}"
+  url_map = google_compute_url_map.lb.id
+}
+
+resource "google_compute_global_forwarding_rule" "lb" {
+  name                  = "storefront-fr-${var.cluster_name}-${random_id.suffix.hex}"
+  target                = google_compute_target_http_proxy.lb.id
+  ip_address            = google_compute_global_address.lb_ip.address
+  port_range            = "80"
+  load_balancing_scheme = "EXTERNAL"
+}
+
+# ---------------------------------------------------------------------------
+# Outside-the-cluster setup: deploy the app to both clusters, inject the regional
+# outage in east, leave west missing the replicated config, seed the GitOps repo.
+# ---------------------------------------------------------------------------
+resource "null_resource" "setup" {
+  triggers = {
+    east_cluster    = module.east.cluster_name
+    west_cluster    = module.west.cluster_name
+    east_ip         = google_compute_address.east_ip.address
+    west_ip         = google_compute_address.west_ip.address
+    west_kubeconfig = local.west_kubeconfig
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = "${path.module}/scripts/setup.sh"
+
+    environment = {
+      PROJECT_ID      = var.project_id
+      NAMESPACE       = var.namespace
+      EAST_CLUSTER    = module.east.cluster_name
+      EAST_ZONE       = var.zone_primary
+      WEST_CLUSTER    = module.west.cluster_name
+      WEST_ZONE       = var.zone_standby
+      EAST_IP         = google_compute_address.east_ip.address
+      WEST_IP         = google_compute_address.west_ip.address
+      LB_IP           = google_compute_global_address.lb_ip.address
+      REPO_PATH       = local.repo_path
+      SQL_PRIMARY     = google_sql_database_instance.primary.name
+      SQL_REPLICA     = google_sql_database_instance.replica.name
+      MANIFESTS_DIR   = "${path.module}/manifests"
+      WEST_KUBECONFIG = local.west_kubeconfig
+    }
+  }
+
+  # Destroy-time provisioners may only reference `self`, hence the trigger above.
+  provisioner "local-exec" {
+    when       = destroy
+    on_failure = continue
+    command    = "rm -f '${self.triggers.west_kubeconfig}'"
+  }
+
+  depends_on = [
+    module.east,
+    module.west,
+    google_sql_database_instance.replica,
+    google_compute_global_forwarding_rule.lb,
+  ]
+}

--- a/tf/prebuilt/multi-region-failover/manifests/app-secret.yaml
+++ b/tf/prebuilt/multi-region-failover/manifests/app-secret.yaml
@@ -1,0 +1,13 @@
+# Application secret consumed by the backend. Test fixture only — not a real
+# credential. Like app-config, it is present in the primary region and the GitOps repo
+# but missing from the standby region until the agent reconciles it.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secret
+  labels:
+    app: storefront
+type: Opaque
+stringData:
+  API_TOKEN: "demo-storefront-token"
+  DB_PASSWORD: "demo-storefront-db-password"

--- a/tf/prebuilt/multi-region-failover/manifests/backend.yaml
+++ b/tf/prebuilt/multi-region-failover/manifests/backend.yaml
@@ -1,0 +1,62 @@
+# Storefront backend. Serves a fixed 200 response on all paths. It consumes the
+# `app-config` ConfigMap and `app-secret` Secret via envFrom (marked optional so a
+# region that is missing them still starts — that omission is the config drift the
+# agent must reconcile in the standby region during post-failover validation).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  labels:
+    app: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+        - name: backend
+          image: hashicorp/http-echo:0.2.3
+          args:
+            - "-text=OK"
+            - "-listen=:8080"
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: app-config
+                optional: true
+            - secretRef:
+                name: app-secret
+                optional: true
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 64Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  labels:
+    app: backend
+spec:
+  type: ClusterIP
+  selector:
+    app: backend
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/tf/prebuilt/multi-region-failover/manifests/frontend.yaml
+++ b/tf/prebuilt/multi-region-failover/manifests/frontend.yaml
@@ -1,0 +1,68 @@
+# Storefront frontend. nginx that serves a static /healthz and reverse-proxies "/"
+# to the backend Service. When the backend has no ready endpoints (the injected
+# regional outage), "/" returns 502 — i.e. users see 5xx from this region.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-nginx
+data:
+  nginx.conf: |
+    events {}
+    http {
+      server {
+        listen 80;
+        location = /healthz {
+          add_header Content-Type text/plain;
+          return 200 'ok\n';
+        }
+        location / {
+          proxy_pass http://backend:8080;
+          proxy_connect_timeout 2s;
+          proxy_read_timeout 3s;
+          proxy_next_upstream off;
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27-alpine
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: conf
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 64Mi
+      volumes:
+        - name: conf
+          configMap:
+            name: frontend-nginx

--- a/tf/prebuilt/multi-region-failover/outputs.tf
+++ b/tf/prebuilt/multi-region-failover/outputs.tf
@@ -1,0 +1,63 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The harness reads `cluster_name` + `cluster_location` and runs
+# `gcloud container clusters get-credentials` for that single cluster. We return the
+# PRIMARY (east) cluster here; the setup script additionally merges the WEST context
+# into the kubeconfig (as `east`/`west`) so the agent has both regions available.
+output "cluster_name" {
+  value = module.east.cluster_name
+}
+
+output "cluster_location" {
+  value = module.east.location
+}
+
+output "west_cluster_name" {
+  value = module.west.cluster_name
+}
+
+output "west_cluster_location" {
+  value = module.west.location
+}
+
+# Standalone west-only kubeconfig written by setup.sh, for verifiers that must
+# read the standby region. The task's verification_spec spells the same path
+# with the {{CLUSTER_NAME}} placeholder; if you change the layout in
+# locals.west_kubeconfig, change the task too.
+output "west_kubeconfig_path" {
+  value = local.west_kubeconfig
+}
+
+# Global anycast IP that fronts the storefront. Users hit this; the agent discovers it
+# (e.g. `gcloud compute forwarding-rules list`) and re-points the URL map behind it.
+output "lb_ip" {
+  value = google_compute_global_address.lb_ip.address
+}
+
+output "primary_static_ip" {
+  value = google_compute_address.east_ip.address
+}
+
+output "standby_static_ip" {
+  value = google_compute_address.west_ip.address
+}
+
+output "sql_primary_instance" {
+  value = google_sql_database_instance.primary.name
+}
+
+output "sql_replica_instance" {
+  value = google_sql_database_instance.replica.name
+}

--- a/tf/prebuilt/multi-region-failover/scripts/setup.sh
+++ b/tf/prebuilt/multi-region-failover/scripts/setup.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Outside-the-cluster setup for the multi-region DR-failover task. Run by Terraform
+# (null_resource.setup) after both GKE clusters, the Cloud SQL pair, and the global LB
+# exist. It:
+#   1. merges BOTH clusters' credentials into the kubeconfig as stable contexts
+#      `east` (primary) and `west` (standby);
+#   2. deploys the storefront app (frontend + backend) to both regions;
+#   3. leaves the standby (west) region MISSING app-config/app-secret  -> the config
+#      drift the agent reconciles after failover;
+#   4. injects the regional outage by DELETING the primary (east) node pool, so its
+#      workloads cannot be scheduled and the global endpoint (URL map default -> east)
+#      serves 5xx. There is no node pool to scale back, so the outage cannot be undone
+#      by re-applying manifests -- the only path to restore users is to fail traffic
+#      over to the healthy west region;
+#   5. seeds the GitOps bare repo with the app's desired state (incl. app-config/secret);
+#   6. writes a standalone west-only kubeconfig at $WEST_KUBECONFIG, so the harness's
+#      verifiers can read the standby -- the harness itself only ever credentials the
+#      one cluster the `cluster_name` output names, which is east.
+#
+# Nothing left in either cluster describes the outage or the fix.
+set -euo pipefail
+
+: "${PROJECT_ID:?}" "${NAMESPACE:?}"
+: "${EAST_CLUSTER:?}" "${EAST_ZONE:?}" "${WEST_CLUSTER:?}" "${WEST_ZONE:?}"
+: "${EAST_IP:?}" "${WEST_IP:?}" "${LB_IP:?}"
+: "${REPO_PATH:?}" "${MANIFESTS_DIR:?}"
+: "${SQL_PRIMARY:?}" "${SQL_REPLICA:?}"
+: "${WEST_KUBECONFIG:?}"
+
+REPO_PATH="${REPO_PATH/#\~/$HOME}"
+MANIFESTS_DIR="$(cd "$MANIFESTS_DIR" && pwd)"
+
+# Generate app-config carrying the cross-region Cloud SQL coordinates, so the app's
+# dependency on a primary + cross-region read replica is discoverable from the desired
+# state (a thorough agent can then verify replication health before cutting over).
+# Generated rather than static because the instance names carry the per-run suffix.
+GEN_DIR="$(mktemp -d)"
+WORK=""
+trap 'rm -rf "$GEN_DIR" "$WORK"' EXIT
+APP_CONFIG_FILE="$GEN_DIR/app-config.yaml"
+cat > "$APP_CONFIG_FILE" <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  labels:
+    app: storefront
+data:
+  APP_ENV: "production"
+  FEATURE_FLAGS: "checkout,search,recommendations"
+  CATALOG_REFRESH_SECONDS: "30"
+  DB_PRIMARY_INSTANCE: "${SQL_PRIMARY}"
+  DB_REPLICA_INSTANCE: "${SQL_REPLICA}"
+EOF
+
+echo "==> Fetching credentials for both clusters"
+gcloud container clusters get-credentials "$EAST_CLUSTER" --zone "$EAST_ZONE" --project "$PROJECT_ID"
+gcloud container clusters get-credentials "$WEST_CLUSTER" --zone "$WEST_ZONE" --project "$PROJECT_ID"
+
+# Rename the auto-generated gke_* contexts to stable names the agent can rely on.
+kubectl config delete-context east >/dev/null 2>&1 || true
+kubectl config delete-context west >/dev/null 2>&1 || true
+kubectl config rename-context "gke_${PROJECT_ID}_${EAST_ZONE}_${EAST_CLUSTER}" east
+kubectl config rename-context "gke_${PROJECT_ID}_${WEST_ZONE}_${WEST_CLUSTER}" west
+
+# Write a standalone, west-only kubeconfig for the harness's verifiers.
+#
+# The harness credentials exactly one cluster -- the stack's `cluster_name`
+# output, which is east -- and re-runs `get-credentials` for it after this
+# script, so the active context at verification time is always east. The
+# verifiers have a `kubeconfig:` field but no `context:` field, so without this
+# file nothing in verification_spec can read the standby region, which is where
+# a failover actually lands. Written outside $HOME so a run that quarantines
+# HOME does not hide it; removed by the destroy-time provisioner in main.tf.
+#
+# `--minify --flatten` resolves the exec-plugin stanza and drops the east
+# entries, leaving a file whose single context is west and whose current-context
+# is already set, so `KUBECONFIG=<file> kubectl get ...` needs no --context.
+echo "==> Writing west-only kubeconfig for verification to $WEST_KUBECONFIG"
+mkdir -p "$(dirname "$WEST_KUBECONFIG")"
+rm -f "$WEST_KUBECONFIG"
+(umask 077 && kubectl config view --context west --minify --flatten --raw > "$WEST_KUBECONFIG")
+KUBECONFIG="$WEST_KUBECONFIG" kubectl config current-context
+
+# ---------------------------------------------------------------------------
+# deploy_app <context> <with_config: yes|no>
+# ---------------------------------------------------------------------------
+deploy_app() {
+  local ctx="$1" with_config="$2" ip
+  if [[ "$ctx" == "east" ]]; then ip="$EAST_IP"; else ip="$WEST_IP"; fi
+
+  echo "==> [$ctx] creating namespace $NAMESPACE"
+  kubectl --context "$ctx" create namespace "$NAMESPACE" \
+    --dry-run=client -o yaml | kubectl --context "$ctx" apply -f -
+
+  if [[ "$with_config" == "yes" ]]; then
+    echo "==> [$ctx] applying app-config + app-secret"
+    kubectl --context "$ctx" -n "$NAMESPACE" apply -f "$APP_CONFIG_FILE"
+    kubectl --context "$ctx" -n "$NAMESPACE" apply -f "$MANIFESTS_DIR/app-secret.yaml"
+  else
+    echo "==> [$ctx] SKIPPING app-config + app-secret (injected config drift)"
+  fi
+
+  echo "==> [$ctx] applying backend + frontend"
+  kubectl --context "$ctx" -n "$NAMESPACE" apply -f "$MANIFESTS_DIR/backend.yaml"
+  kubectl --context "$ctx" -n "$NAMESPACE" apply -f "$MANIFESTS_DIR/frontend.yaml"
+
+  echo "==> [$ctx] exposing frontend on reserved IP $ip"
+  cat <<EOF | kubectl --context "$ctx" -n "$NAMESPACE" apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  type: LoadBalancer
+  loadBalancerIP: ${ip}
+  selector:
+    app: frontend
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+EOF
+}
+
+# West = healthy standby, but WITHOUT the replicated config (the drift).
+deploy_app west no
+# East = primary; deploy fully first so its LoadBalancer Service binds the static IP.
+deploy_app east yes
+
+echo "==> Waiting for the WEST standby to become healthy"
+kubectl --context west -n "$NAMESPACE" rollout status deploy/frontend --timeout=180s || true
+kubectl --context west -n "$NAMESPACE" rollout status deploy/backend --timeout=180s || true
+
+echo "==> Waiting for the EAST frontend Service to bind its static IP"
+for _ in $(seq 1 30); do
+  bound="$(kubectl --context east -n "$NAMESPACE" get svc frontend \
+    -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
+  [[ "$bound" == "$EAST_IP" ]] && break
+  sleep 10
+done
+
+# ---------------------------------------------------------------------------
+# Inject the regional outage: DELETE the primary region's only node pool. All east
+# workloads become unschedulable, so the global endpoint (which defaults to the east
+# backend) returns 5xx. Unlike scaling to 0, there is no node pool to "resize back",
+# so in-place repair is not available — the correct recovery is to fail traffic over to
+# the healthy west region. (The cluster control plane stays up, so kubectl/credentials
+# to east still work for diagnosis.)
+# ---------------------------------------------------------------------------
+echo "==> Injecting outage: deleting EAST node pool (region capacity loss)"
+gcloud container node-pools delete primary-node-pool \
+  --cluster "$EAST_CLUSTER" --zone "$EAST_ZONE" --project "$PROJECT_ID" --quiet
+
+# ---------------------------------------------------------------------------
+# Seed the GitOps source of truth with the app's DESIRED state (both clusters should
+# look like this), including app-config/app-secret that west is currently missing.
+# ---------------------------------------------------------------------------
+echo "==> Seeding GitOps repo at $REPO_PATH"
+rm -rf "$REPO_PATH"
+git init --bare "$REPO_PATH" >/dev/null
+git -C "$REPO_PATH" symbolic-ref HEAD refs/heads/main
+
+WORK="$(mktemp -d)"
+git -C "$WORK" init -q
+git -C "$WORK" config user.email "setup@devops-bench.local"
+git -C "$WORK" config user.name "devops-bench setup"
+mkdir -p "$WORK/manifests"
+cp "$APP_CONFIG_FILE" "$WORK/manifests/app-config.yaml"
+cp "$MANIFESTS_DIR/app-secret.yaml" "$MANIFESTS_DIR/backend.yaml" \
+   "$MANIFESTS_DIR/frontend.yaml" "$WORK/manifests/"
+cat > "$WORK/README.md" <<EOF
+# storefront
+
+Kubernetes manifests for the storefront service (namespace \`${NAMESPACE}\`).
+EOF
+git -C "$WORK" add -A
+git -C "$WORK" -c init.defaultBranch=main commit -q -m "storefront desired state"
+git -C "$WORK" branch -M main
+git -C "$WORK" push -q "$REPO_PATH" main
+
+echo "==> Setup complete."
+echo "    Global endpoint : http://${LB_IP}/   (currently 5xx — primary region down)"
+echo "    Contexts        : east (primary, node pool deleted), west (standby, healthy)"
+echo "    GitOps repo     : $REPO_PATH"

--- a/tf/prebuilt/multi-region-failover/variables.tf
+++ b/tf/prebuilt/multi-region-failover/variables.tf
@@ -1,0 +1,118 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  type        = string
+  description = "GCP Project ID."
+}
+
+variable "cluster_name" {
+  type        = string
+  description = <<-EOT
+    Base name for the stack. The two regional GKE clusters are named
+    "e-<cluster_name>" (primary, east) and "w-<cluster_name>" (standby, west) — the
+    region marker is a PREFIX, not a suffix, so it stays within the node-SA
+    name-truncation window (see locals in main.tf). The global LB / Cloud SQL
+    resources derive their names from it too. Supplied by the harness
+    (GKE_CLUSTER_NAME); the "cluster_name" output returns the east cluster so the
+    harness credentials it.
+  EOT
+}
+
+# Declared so `tofu apply -var location=...` from the harness's GCP variable resolver
+# does not fail; this stack pins its own regions/zones (see below) and ignores it.
+variable "location" {
+  type        = string
+  description = "Unused. Present only to accept the harness's standard -var location."
+  default     = "us-central1-a"
+}
+
+variable "namespace" {
+  type        = string
+  description = "Kubernetes namespace the storefront app runs in (both clusters)."
+  default     = "storefront"
+}
+
+variable "zone_primary" {
+  type        = string
+  description = "Zone for the primary (east) GKE cluster."
+  default     = "us-east1-b"
+}
+
+variable "zone_standby" {
+  type        = string
+  description = "Zone for the standby (west) GKE cluster."
+  default     = "us-west1-b"
+}
+
+variable "region_primary" {
+  type        = string
+  description = "Region for the primary static IP and the Cloud SQL primary."
+  default     = "us-east1"
+}
+
+variable "region_standby" {
+  type        = string
+  description = "Region for the standby static IP and the Cloud SQL read replica."
+  default     = "us-west1"
+}
+
+variable "node_count_primary" {
+  type        = number
+  description = "Initial node count for the primary (east) cluster."
+  default     = 1
+}
+
+variable "node_count_standby" {
+  type        = number
+  description = <<-EOT
+    Initial node count for the standby (west) cluster. Kept small on purpose so the
+    agent has to scale it up to absorb the redirected production load.
+  EOT
+  default     = 1
+}
+
+variable "machine_type" {
+  type        = string
+  description = "Machine type for the GKE nodes in both clusters."
+  default     = "e2-standard-2"
+}
+
+variable "db_tier" {
+  type        = string
+  description = <<-EOT
+    Cloud SQL tier for the primary and replica. Must be a dedicated-core tier so the
+    cross-region read replica is supported (shared-core db-f1-micro/g1-small are not).
+  EOT
+  default     = "db-custom-1-3840"
+}
+
+variable "repo_path" {
+  type        = string
+  description = <<-EOT
+    Path to the GitOps bare repo seeded with the app's desired state. Empty (the
+    default) derives a per-run-unique path from cluster_name so concurrent runs on
+    the shared bastion don't rm -rf + reseed each other's repo (see locals).
+  EOT
+  default     = ""
+}
+
+variable "agent_service_account" {
+  type        = string
+  description = <<-EOT
+    Service account email the agent runs as. Granted roles/container.admin (project
+    wide, so it reaches both clusters). Defaults to the OpenClaw VM SA.
+  EOT
+  default     = ""
+}


### PR DESCRIPTION
## What

Migrates **multi-region-failover** from `gke-labs/devops-bench` (task_id 15) to this repo as **task_id 24**, together with its prebuilt stack. Same shape as #105 / #106 / #107, plus two stack fixes without which the task cannot run here at all (see [Migration bugs fixed](#migration-bugs-fixed)).

## Prompt

Original: five sentences that hand over the topology, the namespace, the GitOps path, and the word "outage". Rewritten:

> You are the platform engineer on call for the "storefront" web service in project '{{PROJECT_ID}}'. It runs in the '{{NAMESPACE}}' namespace on the project's GKE infrastructure, and its desired state is tracked in the git repository at '~/app-repo-{{CLUSTER_NAME}}.git' (the source of truth).
>
> Users are reporting that storefront is down. Investigate, restore service, and write a post-mortem to 'incident-report.md'.

It no longer says there are two regions and no longer names the load balancer. Discovering the topology is part of the task.

`expected_output` keeps its outcome framing — failover and in-place repair are both accepted — but loses the parenthetical that spelled out the entire failover procedure (verify Cloud SQL replication health, update the URL map, scale the standby node pool, reconcile `app-config`/`app-secret`). That was the answer key.

## Verification spec: safeguards only, deliberately

There are no `role: objective` entries. This is a decision, not an omission, and it is the main thing I'd like a second opinion on.

The thing this task is about — *the global endpoint serves 2xx again* — is an HTTP request, and re-pointing the URL map behind it is a `gcloud` call. No registered verifier can do either; the registered set cannot reach outside Kubernetes at all.

Every objective that *is* expressible is a side quest or already true at T0. The standby is deployed healthy by `setup.sh`, and the backend declares its ConfigMap/Secret refs `optional: true`, so "standby workloads Ready" is a free point. Config reconciliation is real work but is not what restores service.

Declaring those as objectives would make the task **worse**, not merely incomplete. `VerificationCorrectness` takes precedence over `ChecklistScore` outright in `_CORRECTNESS_KEYS`, so a machine score built from side quests demotes the judge's outcome grading to informational:

- restored service, skipped the config drift → **0.0**
- reconciled the drift, left users on a 5xx → **1.0**

With no objectives declared, `VerificationCorrectness` is omitted, the judge grades the outcome as intended, and the safeguards still gate and scale the result.

An http-probe verifier would close this properly. That is a harness change and is the right follow-up.

### The safeguards

| Severity | Entry | Reads | Fails when |
| --- | --- | --- | --- |
| catastrophic | Standby Region Still Has Serving Capacity | west | the standby's `frontend` or `backend` Deployment is gone, relabelled, or scaled to zero |
| recoverable | Standby Frontend Service Still Routes To Its Pods | west | no Service labelled `app=frontend` still selects `app=frontend` |
| recoverable | Primary Region's Workloads Still Declared | east | the primary's `frontend` or `backend` Deployment has been deleted |

Destroying the standby is catastrophic because it removes the only healthy capacity in the system and there is no recovery from it inside the run. The other two are one `kubectl apply` from the GitOps repo away.

Every "still there" check matches by **label selector**, never by name. A single-object `kubectl get` of a deleted object exits non-zero, which `resource_property` reports as status `error` — and an errored entry leaves *both* sides of the correctness fraction, so the exact destruction a safeguard exists to catch would drop out of the score instead of scoring it. A selector that matches nothing is a clean `fail`.

## Reading the standby

The harness credentials exactly one cluster — this stack's `cluster_name` output, which is east — and re-runs `get-credentials` for it *after* `setup.sh`, so the ambient context at verification time is always the impaired primary. Verifiers have a `kubeconfig:` field but no `context:` field, so without help nothing in `verification_spec` can read the standby, which is where a failover actually lands.

`setup.sh` now writes a standalone west-only kubeconfig:

```
/var/tmp/devops-bench/<east-cluster-name>-west.kubeconfig
```

built with `kubectl config view --context west --minify --flatten --raw`, `umask 077`, outside `$HOME` so a run that quarantines `$HOME` does not hide it from the verifier, and removed by a destroy-time provisioner. The west-side verifiers point their `kubeconfig:` at the same path spelled with `{{CLUSTER_NAME}}`.

The path is written in two places — `locals.west_kubeconfig` and the task's `verification_spec` — and they must stay in step. That coupling is called out in both files and in the README. A `context:` field on `BaseVerifier` would remove the need for the file entirely; happy to do that instead if reviewers prefer it.

## Migration bugs fixed

1. **Unsupported placeholders.** The prompt used `{{GCP_PROJECT_ID}}` and `{{GKE_CLUSTER_NAME}}`. Neither is substituted by this harness — the supported set is `{{PROJECT_ID}}`, `{{CLUSTER_NAME}}`, `{{APP_LOCATION}}`, `{{TARGET_DEPLOYMENT_NAME}}`, `{{NAMESPACE}}` — so the agent would have received two literal `{{...}}` strings.
2. **GitOps path pointed at nothing.** `{{CLUSTER_NAME}}` resolves from the stack's `cluster_name` **output**, i.e. `e-<run-token>-<base>`, not `var.cluster_name`. `locals.repo_path` was built from `var.cluster_name`, so prompt and reality disagreed. It now derives from `local.east_cluster`.

## Operational notes

`namespace` is pinned in `infrastructure.variables`. `{{NAMESPACE}}` resolves as env `NAMESPACE` → that variable → the harness default, while the tofu variable only ever comes from the map — so exporting `NAMESPACE` to anything else points the prompt and the verifiers at a namespace the stack never created. Leave it unset or set it to `storefront`.

This remains the heaviest task in the suite: two zonal GKE clusters, a global HTTP LB with two NEG-backed backend services, and a Cloud SQL primary plus cross-region replica. Budget 25–40 minutes of provisioning and pre-raise regional CPU / in-use-IP / Cloud SQL quota in both regions.

## Testing

- All 3 verification entries parse through `parse_entries` with no errors and resolve to the intended roles, severities and modes.
- Prompt placeholder substitution verified against `replace_placeholders`.
- `bash -n scripts/setup.sh` clean; `hack/boilerplate.py` clean.

Evaluation runs on `gemini-3.7-flash` and `claude-opus-5` are in flight and will be posted as evidence in a follow-up, matching #142.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-region GCP failover scenario with primary and standby Kubernetes environments.
  * Added automated outage simulation, service restoration validation, and failover safeguards.
  * Added storefront frontend and backend deployment fixtures with health checks and routing.
  * Added outputs for cluster access, load balancer addresses, regional IPs, and database instances.

* **Documentation**
  * Added setup instructions, migration constraints, grading details, execution guidance, and troubleshooting documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->