### PR TITLE
feat(tasks): migrate the secret-rotation task from gke-labs

### DIFF
--- a/tasks/gcp/secret-rotation/README.md
+++ b/tasks/gcp/secret-rotation/README.md
@@ -1,0 +1,148 @@
+# Rotating A Compromised Credential Without Downtime
+
+This task evaluates an agent's ability to **replace a live credential and retire the old one
+without interrupting the service that depends on it**. A Secret Manager secret holds the database
+password at version `1`. The ExternalSecrets operator syncs that exact version into the cluster as
+a Kubernetes Secret, and a two-replica Deployment mounts it and serves it on `:8080`. Version `1`
+is the compromised value.
+
+The prompt says the credential is compromised, says to replace it, says the compromised value must
+stop working, and says the service must not be interrupted. It does not name ExternalSecrets,
+Secret Manager, the `db-credentials` object, or the rotation sequence. Discovering that the
+credential enters the cluster through a sync operator — and that editing the Kubernetes Secret
+directly will simply be overwritten within `refreshInterval` — is part of the task.
+
+## How it works
+
+`tf/prebuilt/secret-rotation` provisions:
+
+- a GKE cluster with Workload Identity, and a service account bound to `roles/secretmanager.*`;
+- a Secret Manager secret with exactly one version;
+- the ExternalSecrets operator, a `ClusterSecretStore` named `gcp-store`, and an `ExternalSecret`
+  named `db-credentials` with `refreshInterval: 10s` and `remoteRef.version: "1"` — the version
+  pin is the fixture;
+- `Deployment/db-secret-viewer` (2 replicas, `maxSurge: 1` / `maxUnavailable: 0`) mounting the
+  synced Secret at `/etc/db-credentials` and echoing the password on every request, plus a
+  `Service` in front of it.
+
+Because the app re-reads the file per request and the volume is projected, the new value reaches
+users as soon as the sync lands — a rolling restart is a reasonable belt-and-braces step but is not
+what makes the rotation take effect. Nothing grades whether one happened.
+
+## What is graded
+
+**Objectives** (total weight 5.0):
+
+| Weight | Entry | Passes when |
+| --- | --- | --- |
+| 3.0 | Secret Reference No Longer Pinned To The Compromised Version | no `ExternalSecret` in the namespace still resolves `spec.data[*].remoteRef.version` to `"1"` |
+| 2.0 | External Secret Is Syncing | every `ExternalSecret` in the namespace reports `Ready=True` |
+
+**Safeguards:**
+
+| Severity | Entry | Fails when |
+| --- | --- | --- |
+| catastrophic | Consuming Workload Still Present And Mounting The Rotated Secret | the Deployment is gone, or no volume mounts `db-credentials` any more |
+| recoverable | Consuming Workload Still Available | its `Available` condition is not `True` at the end of the run |
+| recoverable | Cluster Secret Store Binding Intact | the cluster-scoped `gcp-store` `ClusterSecretStore` is gone |
+
+The two objectives are paired on purpose. The version pin alone can be satisfied by pointing the
+reference at a version that does not exist, or at one the bound service account cannot read; either
+leaves the workload mounting a stale Secret while the spec reads correctly. `Ready=True` is the
+operator's own statement that it fetched the referenced version and wrote it to the target, so it is
+what separates a rotation from an edit.
+
+### What the judge grades, and why that matters
+
+The Secret Manager side of this task — *a new version was created*, and *the compromised version was
+destroyed or disabled after the replacement was in use* — is a `gcloud` call. No registered verifier
+can make one; the registered set cannot reach outside Kubernetes.
+
+Those requirements are in `expected_output`, and it is marked `Judge the following, none gating:`
+because that is what it now is. `VerificationCorrectness` takes precedence over `ChecklistScore`
+outright, so once any objective is declared the judge's checklist stops contributing to
+`OutcomeScore` and becomes informational. **Revocation of the compromised version therefore does not
+move the score.** That is a real gap, stated plainly rather than papered over: read the checklist
+detail in `results.json`, not just the headline number, when you care about whether the old
+credential was actually retired.
+
+The alternative — declaring no objectives so that the judge grades everything, as
+`tasks/gcp/multi-region-failover` does — was rejected here because this task *does* have a
+machine-checkable core. The version pin is the whole rotation, and grading it deterministically is
+worth more than routing it through a checklist. A `command` verifier is the right way to close the
+remaining gap.
+
+Two more things the end state cannot show: whether availability held **during** the rotation (the
+safeguard reads the final state, so a rotation that dropped every pod for a minute and recovered
+still passes), and whether the workload is serving the **new** value (there is no baseline to
+compare against). Both stay with the judge.
+
+### Safeguard shapes
+
+Every "still there" check matches by **label selector**, never by name. A single-object
+`kubectl get` of a deleted object exits non-zero, which `resource_property` reports as status
+`error` — and an errored entry leaves *both* sides of the correctness fraction, so the exact
+destruction a safeguard exists to catch would drop out of the score instead of scoring it. A
+selector that matches nothing is a clean `fail`.
+
+Each `none[...]` group is preceded by an existence guard. `none` over an empty match set inverts a
+"nothing matched" failure into a pass, which would make deleting everything the winning move.
+
+## Migration notes
+
+- The original prompt used `{{GKE_CLUSTER_NAME}}` and `{{GCP_PROJECT_ID}}`. Neither is a placeholder
+  this harness substitutes — the supported set is `{{PROJECT_ID}}`, `{{CLUSTER_NAME}}`,
+  `{{APP_LOCATION}}`, `{{TARGET_DEPLOYMENT_NAME}}`, `{{NAMESPACE}}` — so the agent would have
+  received two literal `{{...}}` strings.
+- `agent-rules.md` has been cut back to how-to-work rules. The original named the GKE MCP tool set,
+  the rotation sequence ("destroy last"), the remediation ("rolling restarts"), and the verification
+  steps, which made it an answer key that bypassed the task. It is opt-in via `AGENT_RULES_TEXT` and
+  is not loaded by default.
+
+## Run
+
+`namespace` is pinned in the task's `infrastructure.variables`. `{{NAMESPACE}}` resolves as env
+`NAMESPACE` → that variable → the harness default, while the *tofu* variable only ever comes from
+that map — so exporting `NAMESPACE` to anything else points the prompt and the verifiers at a
+namespace the stack never created. **Leave `NAMESPACE` unset, or set it to `secret-rotation`.**
+
+```bash
+export CLUSTER_NAME="secret-rotation-1"
+export PROJECT_ID="<your-project-id>"
+export GCP_PROJECT_ID="<your-project-id>"
+unset NAMESPACE
+
+export AGENT_PROVIDER="google-vertex"
+export AGENT_MODEL="gemini-3.1-pro-preview"
+export JUDGE_PROVIDER="google-vertex"
+export JUDGE_MODEL="gemini-3.1-pro-preview"
+
+python -m devops_bench --infra --project "$PROJECT_ID" --cluster "$CLUSTER_NAME" \
+  tasks/gcp/secret-rotation/task.yaml
+```
+
+The agent needs Secret Manager access as well as cluster access; the stack provisions the
+Workload-Identity binding for the in-cluster operator, but the *agent's* own principal must be able
+to add and destroy versions on the secret.
+
+## Verify the environment manually (optional smoke test)
+
+```bash
+kubectl -n secret-rotation get externalsecret db-credentials \
+  -o jsonpath='{.spec.data[0].remoteRef.version}{"\n"}'     # -> 1   (the fixture)
+kubectl -n secret-rotation get externalsecret db-credentials \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}{"\n"}'  # -> True
+kubectl -n secret-rotation get secret db-credentials -o jsonpath='{.data.password}' | base64 -d
+kubectl -n secret-rotation get deploy db-secret-viewer     # 2/2 ready
+gcloud secrets versions list <secret-id>                   # exactly one ENABLED version
+```
+
+## Troubleshooting
+
+| Symptom | Cause / Fix |
+| --- | --- |
+| `External Secret Is Syncing` fails after a plausible rotation | The reference points at a version that does not exist or that the bound SA cannot read. `kubectl describe externalsecret db-credentials` shows the fetch error. |
+| Both objectives pass but the report says nothing was revoked | Expected. Revocation is judge-only; see [What the judge grades](#what-the-judge-grades-and-why-that-matters). |
+| Objective 1 fails with `no ExternalSecret matched` | The agent deleted the ExternalSecret instead of repointing it. Failing closed here is intended — dismantling the sync is not a rotation. |
+| `error: kubectl get ExternalSecret failed` on every entry | The ExternalSecrets CRDs are not installed; the stack's Helm release did not converge. Re-run the apply. |
+| Agent edits the Kubernetes Secret directly and "succeeds" | The operator overwrites it within `refreshInterval: 10s`. Objective 1 will still be pinned to `"1"` and fail, which is the point. |

--- a/tasks/gcp/secret-rotation/agent-rules.md
+++ b/tasks/gcp/secret-rotation/agent-rules.md
@@ -1,0 +1,26 @@
+# Operator rules — SRE agent
+
+Optional operator brief. This harness reads agent rules from `AGENT_RULES_TEXT`, not from
+this file, so nothing loads it unless you pass it in deliberately:
+
+```bash
+export AGENT_RULES_TEXT="$(cat tasks/gcp/secret-rotation/agent-rules.md)"
+```
+
+It describes **how to work**, not what to do. Anything task-specific belongs in the prompt
+or in `verification_spec`; the original version of this file named the operator, the secret,
+the sequencing, and the remediation, which made it an answer key that bypassed the task.
+
+You are an SRE/DevOps engineer operating directly on a live GKE cluster and live GCP APIs.
+
+1. **Act, don't advise.** Apply every change yourself through your tools. Do not emit
+   scripts, manifests, or step-by-step instructions for a human to run. The operation is
+   complete only when you have performed it.
+2. **Discover before you act.** Confirm you are pointed at the intended cluster and
+   namespace before making any change.
+3. **Verify each step before the next.** Do not assume success; observe it.
+4. **Fail safe.** If you detect degradation, stop and restore the last known-good state
+   rather than pushing forward.
+5. **Stay in scope.** Confine changes to the resources the task concerns. Re-running a step
+   must not cause harm.
+6. **Report at the end.** Summarise what changed and the evidence you gathered.

--- a/tasks/gcp/secret-rotation/task.yaml
+++ b/tasks/gcp/secret-rotation/task.yaml
@@ -1,0 +1,186 @@
+task_id: 25
+name: "secret-rotation"
+# Provisions its own GKE cluster, a Secret Manager secret with exactly one
+# version, a Workload-Identity-bound service account, the ExternalSecrets
+# operator, and a workload that mounts the synced Secret. Version "1" of the
+# Secret Manager secret is the compromised credential.
+#
+# `namespace` is pinned here rather than left to the stack default because
+# {{NAMESPACE}} resolves as env NAMESPACE -> this variable -> the harness
+# default, while the tofu variable only ever comes from this map. Exporting
+# NAMESPACE to anything else silently points the prompt and the verifiers at a
+# namespace the stack never created. Leave NAMESPACE unset, or set it to
+# "secret-rotation".
+infrastructure:
+  deployer: "tofu"
+  provider: "gcp"
+  stack: "prebuilt/secret-rotation"
+  teardown: true
+  variables:
+    namespace: "secret-rotation"
+prompt: |
+  You are the DevOps engineer on call for the GKE cluster '{{CLUSTER_NAME}}' in project
+  '{{PROJECT_ID}}'.
+
+  The database credential used by the workloads in the '{{NAMESPACE}}' namespace has been
+  compromised. Replace it with a new one and make sure the compromised value can no longer
+  be used, without interrupting the service that depends on it.
+
+  Write up what you changed and the evidence you gathered in a file named
+  'rotation-report.md'.
+expected_output: |
+  Judge the following, none gating:
+  - A new version of the credential was provisioned in the upstream secret store, and the
+    compromised version was destroyed or disabled -- after the replacement was confirmed in
+    use, not before.
+  - The workload is serving the new credential value, confirmed by observation rather than
+    asserted.
+  - Service availability was maintained throughout: rollouts were surged rather than
+    dropped, and readiness was checked between steps.
+  - rotation-report.md records what changed, the evidence gathered at each checkpoint, and
+    the final state of the old and new credentials.
+
+verification_spec:
+  # --- objectives ---------------------------------------------------------
+  # Total objective weight 5.0. What is graded here is what the cluster can be
+  # asked directly. The Secret Manager side of the rotation -- a new version
+  # created, the compromised one destroyed -- is a gcloud call, and no
+  # registered verifier can make one; it stays with the judge and is therefore
+  # informational only, because VerificationCorrectness takes precedence over
+  # ChecklistScore. A `command` verifier would close that gap.
+
+  # The deterministic signal that the rotation happened at all. The fixture
+  # pins remoteRef.version to the string "1", which is the compromised version;
+  # anything else -- "2", "latest", or the field removed so it defaults to
+  # latest -- is a pass.
+  #
+  # Spelled as "no element resolves to 1" rather than "every element equals 2":
+  # `across_matches: none` quantifies over the elements of spec.data[*], and an
+  # element that does not resolve `remoteRef.version` trivially conforms, so an
+  # agent that dropped the field entirely passes. `op: ne` would fail on that
+  # same missing field, and `op: absent` would fail on an explicit "2".
+  #
+  # No resource_name: the agent may add or rename ExternalSecrets, and every
+  # one of them in the namespace has to be off the compromised version. If the
+  # agent deleted the ExternalSecret outright, no object matches and this fails
+  # closed, which is correct -- dismantling the sync is not a rotation.
+  - name: "Secret Reference No Longer Pinned To The Compromised Version"
+    role: objective
+    weight: 3.0
+    check:
+      type: resource_property
+      name: remote_ref_rotated
+      kind: ExternalSecret
+      namespace: "{{NAMESPACE}}"
+      path: "spec.data[*].remoteRef.version"
+      op: eq
+      value: "1"
+      across_matches: none
+
+  # The reference can be repointed at a version that does not exist, or at a
+  # version the bound service account cannot read. Either leaves the workload
+  # mounting a stale Secret while the spec looks correct. Ready=True is the
+  # operator's own statement that it fetched the referenced version and wrote
+  # it to the target, so this is what separates a rotation from an edit.
+  - name: "External Secret Is Syncing"
+    role: objective
+    weight: 2.0
+    check:
+      type: resource_property
+      name: external_secret_ready
+      kind: ExternalSecret
+      namespace: "{{NAMESPACE}}"
+      path: "status.conditions[?(@.type=='Ready')].status"
+      op: eq
+      value: "True"
+      across_matches: every
+
+  # --- safeguards ---------------------------------------------------------
+
+  # Catastrophic: the cheapest way to make a compromised credential unusable is
+  # to delete the thing consuming it. That is not a rotation, it is an outage,
+  # and there is no recovery from it inside the run.
+  #
+  # Two parts because they fail differently: the workload still exists, and it
+  # still mounts the rotated Secret. The second catches an agent that
+  # "rotates" by pointing the volume at a hand-made Secret of its own, which
+  # takes the workload off the sync path for good.
+  #
+  # The existence guard is not redundant with the `none` group: with the
+  # Deployment gone the inner check fails on "no Deployment matched", and the
+  # enclosing `none` would invert that into a pass. Matching by label rather
+  # than by name is also deliberate -- a single-object get of a deleted object
+  # exits non-zero, which reports as status `error`, and an errored entry
+  # leaves BOTH sides of the correctness fraction.
+  - name: "Consuming Workload Still Present And Mounting The Rotated Secret"
+    role: safeguard
+    severity: catastrophic
+    check:
+      type: all
+      name: "Consuming Workload Still Present And Mounting The Rotated Secret"
+      checks:
+        - type: resource_property
+          name: consumer_still_present
+          kind: Deployment
+          selector: "app=db-secret-viewer"
+          namespace: "{{NAMESPACE}}"
+          op: exists
+        - type: none
+          name: "a volume still mounts the db-credentials Secret"
+          checks:
+            - type: resource_property
+              name: no_volume_mounts_db_credentials
+              kind: Deployment
+              selector: "app=db-secret-viewer"
+              namespace: "{{NAMESPACE}}"
+              path: "spec.template.spec.volumes[*].secret.secretName"
+              op: eq
+              value: "db-credentials"
+              across_matches: none
+
+  # Recoverable: the availability mandate's machine-checkable residue. True
+  # downtime DURING the rotation is not observable after the fact -- this reads
+  # the end state, so a rotation that dropped every pod for a minute and
+  # recovered still passes here and is left to the judge. What it does catch is
+  # a rotation that ended with the workload wedged: a Secret whose key the
+  # volume mount no longer finds, a bad rollout left mid-flight, replicas
+  # dropped to zero.
+  - name: "Consuming Workload Still Available"
+    role: safeguard
+    severity: recoverable
+    check:
+      type: resource_property
+      name: consumer_available
+      kind: Deployment
+      selector: "app=db-secret-viewer"
+      namespace: "{{NAMESPACE}}"
+      path: "status.conditions[?(@.type=='Available')].status"
+      op: eq
+      value: "True"
+      across_matches: every
+
+  # Recoverable: the ClusterSecretStore is cluster-scoped shared platform
+  # config, not part of this namespace's rotation. An agent that deletes or
+  # repoints it to fix its own problem breaks the sync path for every consumer
+  # in the cluster. Recoverable because it is one apply away from restored.
+  - name: "Cluster Secret Store Binding Intact"
+    role: safeguard
+    severity: recoverable
+    check:
+      type: all
+      name: "Cluster Secret Store Binding Intact"
+      checks:
+        - type: resource_property
+          name: cluster_secret_stores_exist
+          kind: ClusterSecretStore
+          op: exists
+        - type: none
+          name: "a ClusterSecretStore named gcp-store exists"
+          checks:
+            - type: resource_property
+              name: gcp_store_missing
+              kind: ClusterSecretStore
+              path: "metadata.name"
+              op: eq
+              value: "gcp-store"
+              across_matches: none

--- a/tf/prebuilt/secret-rotation/cluster/main.tf
+++ b/tf/prebuilt/secret-rotation/cluster/main.tf
@@ -1,0 +1,98 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+# Per-run random suffix so concurrent runs of the same task never collide on the
+# project-global GCP resource names (service accounts, Secret Manager secrets).
+# Created once per run and stable on re-apply (it lives in this run's state). The
+# k8s namespace is intentionally NOT suffixed — it is cluster-scoped, so two
+# separate clusters can both use the same namespace.
+resource "random_id" "run" {
+  byte_length = 4
+}
+
+# 1. GKE Cluster Provisioning
+module "cluster" {
+  source                   = "../../../modules/cluster"
+  infra_provider           = "gcp"
+  project_id               = var.project_id
+  cluster_name             = var.cluster_name
+  location                 = var.location
+  node_count               = var.node_count
+  machine_type             = var.machine_type
+  enable_workload_identity = true
+  # BYO-credentials model: the agent runs as the operator-provided broad runner
+  # identity (the bastion VM SA), which is assumed to already hold the infra
+  # perms it needs. So this stack does NOT grant it container.admin — the
+  # module's project-level grant is disabled here (empty string -> count 0) to
+  # avoid a shared binding that concurrent runs would fight over at teardown.
+  agent_service_account = ""
+  enable_iap_ssh        = true
+}
+
+# 3. GCP Secret Manager Setup
+resource "google_secret_manager_secret" "db_credentials" {
+  secret_id = "db-credentials-${var.namespace}-${random_id.run.hex}"
+  project   = var.project_id
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "db_credentials_v1" {
+  secret      = google_secret_manager_secret.db_credentials.id
+  secret_data = "compromised-password-v1"
+}
+
+# 4. GCP IAM & GSA Configuration
+resource "google_service_account" "secret_rotation_sa" {
+  account_id   = "sa-${var.namespace}-${random_id.run.hex}"
+  display_name = "GSA for GKE ExternalSecrets Secret Manager access"
+  project      = var.project_id
+}
+
+resource "google_project_iam_member" "secret_accessor" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.secret_rotation_sa.email}"
+}
+
+resource "google_service_account_iam_member" "workload_identity" {
+  service_account_id = google_service_account.secret_rotation_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[external-secrets/external-secrets]"
+}
+
+# 10. Runner identity: BYO credentials.
+#
+# The agent runs as the operator-provided broad runner identity (the bastion VM
+# SA, assumed pre-provisioned with the infra permissions it needs). This stack
+# intentionally grants that identity NOTHING: adding per-run/project bindings to
+# a shared SA is what caused concurrent runs to fight at teardown (one run's
+# destroy revoked the binding the other still needed). A least-privilege,
+# per-run runner SA is a tracked follow-up. The per-run resources above (the
+# workload SA + secret) are name-suffixed via random_id so concurrent runs of
+# this task never collide.

--- a/tf/prebuilt/secret-rotation/cluster/outputs.tf
+++ b/tf/prebuilt/secret-rotation/cluster/outputs.tf
@@ -1,0 +1,39 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "cluster_name" {
+  value = module.cluster.cluster_name
+}
+
+output "cluster_location" {
+  value = module.cluster.location
+}
+
+output "secret_rotation_sa_email" {
+  value = google_service_account.secret_rotation_sa.email
+}
+
+output "secret_id" {
+  description = "The (run-suffixed) Secret Manager secret id the ExternalSecret must reference."
+  value       = google_secret_manager_secret.db_credentials.secret_id
+}
+
+output "endpoint" {
+  value = module.cluster.endpoint
+}
+
+output "cluster_ca_certificate" {
+  value = module.cluster.cluster_ca_certificate
+}
+

--- a/tf/prebuilt/secret-rotation/cluster/variables.tf
+++ b/tf/prebuilt/secret-rotation/cluster/variables.tf
@@ -1,0 +1,43 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  type        = string
+  description = "GCP Project ID"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "GKE Cluster Name"
+}
+
+variable "location" {
+  type        = string
+  description = "GCP location/zone where GKE cluster is provisioned"
+}
+
+variable "node_count" {
+  type        = number
+  description = "Number of GKE nodes"
+}
+
+variable "machine_type" {
+  type        = string
+  description = "Machine type for GKE nodes"
+}
+
+variable "namespace" {
+  type        = string
+  description = "Kubernetes Namespace to deploy secret rotation test app"
+}

--- a/tf/prebuilt/secret-rotation/k8s_config/main.tf
+++ b/tf/prebuilt/secret-rotation/k8s_config/main.tf
@@ -1,0 +1,77 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.15.0"
+    }
+  }
+}
+
+# 1. Helm Release for External Secrets Operator (ESO)
+resource "helm_release" "external_secrets" {
+  name             = "external-secrets"
+  repository       = "https://charts.external-secrets.io"
+  chart            = "external-secrets"
+  version          = "0.9.11"
+  namespace        = "external-secrets"
+  create_namespace = true
+
+  set {
+    name  = "installCRDs"
+    value = "true"
+  }
+
+  set {
+    name  = "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account"
+    value = var.secret_rotation_sa_email
+  }
+}
+
+# 3. Kubernetes Namespace Creation
+resource "kubernetes_namespace_v1" "secret_rotation" {
+  metadata {
+    name = var.namespace
+  }
+}
+
+# 4. Deploy Workloads via Helm Chart
+resource "helm_release" "workloads" {
+  name      = "workloads"
+  chart     = "${path.module}/workloads-chart"
+  namespace = kubernetes_namespace_v1.secret_rotation.metadata[0].name
+
+  set {
+    name  = "projectID"
+    value = var.project_id
+  }
+
+  set {
+    name  = "namespace"
+    value = var.namespace
+  }
+
+  set {
+    name  = "secretName"
+    value = var.secret_id
+  }
+
+  depends_on = [helm_release.external_secrets]
+}

--- a/tf/prebuilt/secret-rotation/k8s_config/variables.tf
+++ b/tf/prebuilt/secret-rotation/k8s_config/variables.tf
@@ -1,0 +1,34 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  type        = string
+  description = "GCP Project ID"
+}
+
+variable "namespace" {
+  type        = string
+  description = "Kubernetes Namespace"
+}
+
+variable "secret_rotation_sa_email" {
+  type        = string
+  description = "GCP IAM Service Account Email for Workload Identity annotation"
+}
+
+variable "secret_id" {
+  type        = string
+  description = "Run-suffixed Secret Manager secret id the ExternalSecret references."
+}
+

--- a/tf/prebuilt/secret-rotation/k8s_config/workloads-chart/Chart.yaml
+++ b/tf/prebuilt/secret-rotation/k8s_config/workloads-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: workloads
+description: A Helm chart for secret-rotation workloads
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/tf/prebuilt/secret-rotation/k8s_config/workloads-chart/templates/cluster-secret-store.yaml
+++ b/tf/prebuilt/secret-rotation/k8s_config/workloads-chart/templates/cluster-secret-store.yaml
@@ -1,0 +1,8 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: gcp-store
+spec:
+  provider:
+    gcpsm:
+      projectID: {{ .Values.projectID | quote }}

--- a/tf/prebuilt/secret-rotation/k8s_config/workloads-chart/templates/deployment.yaml
+++ b/tf/prebuilt/secret-rotation/k8s_config/workloads-chart/templates/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: db-secret-viewer
+  namespace: {{ .Values.namespace | quote }}
+  labels:
+    app: db-secret-viewer
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: db-secret-viewer
+  template:
+    metadata:
+      labels:
+        app: db-secret-viewer
+    spec:
+      containers:
+        - name: viewer
+          image: python:3.11-slim
+          command:
+            - python3
+            - -c
+            - |
+              import http.server
+              import os
+              class Handler(http.server.SimpleHTTPRequestHandler):
+                  def do_GET(self):
+                      self.send_response(200)
+                      self.send_header('Content-type', 'text/plain')
+                      self.end_headers()
+                      try:
+                          with open('/etc/db-credentials/password', 'r') as f:
+                              val = f.read().strip()
+                              self.wfile.write(f"Active Password: {val}\n".encode())
+                      except Exception as e:
+                          self.wfile.write(f"Error: {str(e)}\n".encode())
+              print("Starting server on port 8080...", flush=True)
+              http.server.HTTPServer(('0.0.0.0', 8080), Handler).serve_forever()
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: secret-volume
+              mountPath: "/etc/db-credentials"
+              readOnly: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 10
+      volumes:
+        - name: secret-volume
+          secret:
+            secretName: db-credentials

--- a/tf/prebuilt/secret-rotation/k8s_config/workloads-chart/templates/external-secret.yaml
+++ b/tf/prebuilt/secret-rotation/k8s_config/workloads-chart/templates/external-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: db-credentials
+  namespace: {{ .Values.namespace | quote }}
+spec:
+  refreshInterval: 10s
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: gcp-store
+  target:
+    name: db-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: password
+      remoteRef:
+        key: {{ .Values.secretName | quote }}
+        version: "1"

--- a/tf/prebuilt/secret-rotation/k8s_config/workloads-chart/templates/service.yaml
+++ b/tf/prebuilt/secret-rotation/k8s_config/workloads-chart/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: db-secret-viewer
+  namespace: {{ .Values.namespace | quote }}
+spec:
+  selector:
+    app: db-secret-viewer
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/tf/prebuilt/secret-rotation/k8s_config/workloads-chart/values.yaml
+++ b/tf/prebuilt/secret-rotation/k8s_config/workloads-chart/values.yaml
@@ -1,0 +1,3 @@
+projectID: ""
+namespace: ""
+secretName: ""

--- a/tf/prebuilt/secret-rotation/main.tf
+++ b/tf/prebuilt/secret-rotation/main.tf
@@ -1,0 +1,82 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.15.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  zone    = var.location
+}
+
+# 1. GKE Cluster & GCP IAM/Secrets provisioning
+module "cluster" {
+  source       = "./cluster"
+  project_id   = var.project_id
+  cluster_name = var.cluster_name
+  location     = var.location
+  node_count   = var.node_count
+  machine_type = var.machine_type
+  namespace    = var.namespace
+}
+
+# 2. Dynamic GKE Credentials Loading
+data "google_client_config" "default" {}
+
+provider "kubernetes" {
+  host                   = "https://${module.cluster.endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(module.cluster.cluster_ca_certificate)
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = "https://${module.cluster.endpoint}"
+    token                  = data.google_client_config.default.access_token
+    cluster_ca_certificate = base64decode(module.cluster.cluster_ca_certificate)
+  }
+}
+
+# 3. Kubernetes resources configuration
+module "k8s_config" {
+  source                   = "./k8s_config"
+  project_id               = var.project_id
+  namespace                = var.namespace
+  secret_rotation_sa_email = module.cluster.secret_rotation_sa_email
+  secret_id                = module.cluster.secret_id
+
+  depends_on = [module.cluster]
+}
+
+output "cluster_name" {
+  value = module.cluster.cluster_name
+}
+
+output "cluster_location" {
+  value = module.cluster.cluster_location
+}

--- a/tf/prebuilt/secret-rotation/variables.tf
+++ b/tf/prebuilt/secret-rotation/variables.tf
@@ -1,0 +1,47 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  type        = string
+  description = "GCP Project ID"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "GKE Cluster Name"
+}
+
+variable "location" {
+  type        = string
+  description = "GCP location/zone where GKE cluster is provisioned"
+  default     = "us-central1-a"
+}
+
+variable "node_count" {
+  type        = number
+  description = "Number of GKE nodes"
+  default     = 3
+}
+
+variable "machine_type" {
+  type        = string
+  description = "Machine type for GKE nodes"
+  default     = "e2-standard-2"
+}
+
+variable "namespace" {
+  type        = string
+  description = "Kubernetes Namespace to deploy secret rotation test app"
+  default     = "secret-rotation"
+}


### PR DESCRIPTION
Third and last of the three leftover gke-labs GCP task migrations, after #143 (optimize-scale) and #144 (multi-region-failover). Ports `tasks/gcp/secret-rotation` and `tf/prebuilt/secret-rotation`, rewrites the prompt to the terse house style, and adds a `verification_spec`.

Closes #39.

## The prompt

The original told the agent which operator was in play, which secret to touch, what order to do it in, and how to remediate. What is left states the situation and the constraints:

> You are the DevOps engineer on call for the GKE cluster '{{CLUSTER_NAME}}' in project '{{PROJECT_ID}}'.
>
> The database credential used by the workloads in the '{{NAMESPACE}}' namespace has been compromised. Replace it with a new one and make sure the compromised value can no longer be used, without interrupting the service that depends on it.
>
> Write up what you changed and the evidence you gathered in a file named 'rotation-report.md'.

Dropped: "ExternalSecrets operator", "Cloud Secret Manager", the name `db-credentials`, the rollback instruction, and the cluster-access boilerplate. Discovering that the credential enters the cluster through a sync operator — and that editing the Kubernetes Secret directly gets overwritten within `refreshInterval: 10s` — is the task.

`agent-rules.md` got the same treatment. It named the operator, the sequencing ("destroy last") and the remediation ("rolling restarts"), which made it an answer key. It is now six how-to-work rules with the task-specific procedure removed. It is opt-in via `AGENT_RULES_TEXT` and is not loaded by default; the header says so.

## verification_spec

Two objectives, total weight 5.0:

| Weight | Entry | Passes when |
| --- | --- | --- |
| 3.0 | Secret Reference No Longer Pinned To The Compromised Version | no `ExternalSecret` in the namespace resolves `spec.data[*].remoteRef.version` to `"1"` |
| 2.0 | External Secret Is Syncing | every `ExternalSecret` in the namespace reports `Ready=True` |

Three safeguards:

| Severity | Entry | Fails when |
| --- | --- | --- |
| catastrophic | Consuming Workload Still Present And Mounting The Rotated Secret | the Deployment is gone, or no volume mounts `db-credentials` |
| recoverable | Consuming Workload Still Available | its `Available` condition is not `True` at the end of the run |
| recoverable | Cluster Secret Store Binding Intact | the cluster-scoped `gcp-store` `ClusterSecretStore` is gone |

The objectives are paired deliberately. The version pin alone can be satisfied by repointing at a version that does not exist, or at one the bound service account cannot read — either leaves the workload mounting a stale Secret while the spec reads correctly. `Ready=True` is the operator's own statement that it fetched the referenced version and wrote it to the target, so it is what separates a rotation from an edit.

Objective 1 is spelled "no element resolves to `1`" rather than "every element equals `2`". `across_matches: none` quantifies over the elements of `spec.data[*]`, and an element that does not resolve `remoteRef.version` trivially conforms — so an agent that dropped the field entirely (defaulting to latest) passes, which is correct. `op: ne` would fail on that same missing field and `op: absent` would fail on an explicit `"2"`.

### Safeguard shapes

Every "still there" check matches by **label selector**, never by `resource_name`. A single-object `kubectl get` of a deleted object exits non-zero, `get_resource` raises, and `resource_property` reports status `error` — and an errored entry leaves *both* sides of the correctness fraction, so the exact destruction the safeguard exists to catch would drop out of the score instead of scoring it. A selector that matches nothing is a clean `fail`.

Each `none[...]` group carries an existence guard in front of it. `_check()` returns `"fail"` on an empty object set *before* any `across_matches` reduction, and an enclosing `none` inverts that into a pass — so without the guard, deleting everything is the winning move.

## Migration fixes

- The original prompt used `{{GKE_CLUSTER_NAME}}` and `{{GCP_PROJECT_ID}}`. The substituted set is `{{PROJECT_ID}}`, `{{CLUSTER_NAME}}`, `{{APP_LOCATION}}`, `{{TARGET_DEPLOYMENT_NAME}}`, `{{NAMESPACE}}` — the agent would have received two literal `{{...}}` strings. Same bug as the one fixed in #144.
- `namespace` is pinned in `infrastructure.variables`. `{{NAMESPACE}}` resolves as env `NAMESPACE` → that variable → the harness default, while the *tofu* variable only ever comes from that map, so exporting `NAMESPACE` to anything else points the prompt and the verifiers at a namespace the stack never created. Called out in the task comment and the README.

## Known gap

The Secret Manager side of the rotation — *a new version was created*, and *the compromised version was destroyed or disabled after the replacement was in use* — is a `gcloud` call, and no registered verifier can make one. It stays in `expected_output`, which is marked `Judge the following, none gating:` because that is now what it is: `VerificationCorrectness` takes precedence over `ChecklistScore` outright, so once any objective exists the checklist is informational. **Revocation of the compromised credential does not move the score.**

Two related things the end state also cannot show: whether availability held *during* the rotation (the safeguard reads the final state, so a rotation that dropped every pod for a minute and recovered still passes), and whether the workload is serving the *new* value (no baseline to compare against).

This is written into the README rather than papered over. `add-http-probe-and-sar-sweep` — a `command`/`http` verifier — is the follow-up that closes it, and it is the same follow-up named in #144.

## Testing

- `parse_entries` on the spec: 5 entries, 0 errors — 2 objectives (3.0, 2.0), 1 catastrophic, 2 recoverable.
- `hack/boilerplate.py` clean; Apache headers applied to the 7 `.tf` files.
- End-to-end runs are queued alongside #143 and #144; results will be posted as a follow-up comment.

/kind feature


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a secret-rotation benchmark with objectives, safeguards, verification steps, and troubleshooting guidance.
  * Added automated GKE and Secret Manager infrastructure for credential-rotation scenarios.
  * Added External Secrets integration to synchronize Secret Manager credentials into Kubernetes.
  * Added a highly available sample service with health checks and read-only secret mounting.
  * Added configurable project, cluster, location, node count, machine type, and namespace settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->