### PR TITLE
feat(verification): add the pod_exec verifier

### DIFF
--- a/devops_bench/k8s/__init__.py
+++ b/devops_bench/k8s/__init__.py
@@ -17,6 +17,7 @@
 from devops_bench.k8s.conditions import poll_until
 from devops_bench.k8s.kubectl import (
     apply,
+    exec_pod,
     get_resource,
     is_not_found,
     port_forward,
@@ -26,6 +27,7 @@ from devops_bench.k8s.kubectl import (
 
 __all__ = [
     "apply",
+    "exec_pod",
     "get_resource",
     "is_not_found",
     "poll_until",

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -29,6 +29,7 @@ from devops_bench.core.subprocess import CompletedProcess, _build_env, run
 
 __all__ = [
     "apply",
+    "exec_pod",
     "get_resource",
     "is_not_found",
     "port_forward",
@@ -209,6 +210,53 @@ def get_resource(
     ]
     completed = _run_kubectl(argv, kubeconfig, timeout=timeout)
     return json.loads(completed.stdout)
+
+
+def exec_pod(
+    pod: str,
+    command: list[str],
+    *,
+    container: str | None = None,
+    namespace: str | None = None,
+    kubeconfig: KubeconfigSource = None,
+    timeout: float | None = None,
+) -> CompletedProcess:
+    """Run a command inside a running pod via ``kubectl exec``.
+
+    Reads real in-container state (a served HTTP response, a binary's own
+    version output, an appended log file) that no ``kubectl get`` field can
+    see, which is the point: a Deployment's declared spec and even its
+    ``status`` conditions can look fully healthy while the workload actually
+    serving traffic is something else entirely (see
+    ``devops_bench.verification.verifiers.pod_exec``).
+
+    Args:
+        pod: Exact pod name to exec into (no selector; the caller resolves one).
+        command: Argv to run inside the container, never a shell string
+            (callers needing shell features pass ``["sh", "-c", "..."]``
+            explicitly).
+        container: Optional container name, required when the pod has more
+            than one container.
+        namespace: Optional namespace (``-n``).
+        kubeconfig: Kubeconfig path or context-like object.
+        timeout: Optional seconds before the subprocess is killed.
+
+    Returns:
+        The completed process; ``stdout`` carries the command's output.
+
+    Raises:
+        SubprocessError: If kubectl exits non-zero or times out.
+    """
+    argv = [
+        "kubectl",
+        "exec",
+        pod,
+        *(["-c", container] if container else []),
+        *_namespace_args(namespace),
+        "--",
+        *command,
+    ]
+    return _run_kubectl(argv, kubeconfig, timeout=timeout)
 
 
 def apply(

--- a/devops_bench/verification/verifiers/__init__.py
+++ b/devops_bench/verification/verifiers/__init__.py
@@ -14,6 +14,7 @@
 
 """Concrete single-condition verifiers."""
 
+from devops_bench.verification.verifiers.pod_exec import PodExecVerifier
 from devops_bench.verification.verifiers.pod_healthy import PodHealthyVerifier
 from devops_bench.verification.verifiers.resource_property import (
     ResourcePropertyVerifier,
@@ -21,6 +22,7 @@ from devops_bench.verification.verifiers.resource_property import (
 from devops_bench.verification.verifiers.scaling_complete import ScalingCompleteVerifier
 
 __all__ = [
+    "PodExecVerifier",
     "PodHealthyVerifier",
     "ResourcePropertyVerifier",
     "ScalingCompleteVerifier",

--- a/devops_bench/verification/verifiers/pod_exec.py
+++ b/devops_bench/verification/verifiers/pod_exec.py
@@ -1,0 +1,141 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Assert a property of a command's output run inside a live pod.
+
+``resource_property`` answers "what does the cluster say the state is"; this
+verifier answers "what is actually happening inside the running container",
+which a Deployment's spec and even its own ``status`` conditions cannot show:
+a rollout can report ``Available=True`` on the declared, correct image tag
+while the real service behind it is a stale binary (an old, unmanaged pod
+still receiving traffic through the same Service) or a config regression only
+observable by asking the workload itself (a tailed log, a served response). A
+single ``kubectl exec`` captures that live signal; everything else (matching
+one of several candidate pods, applying an operator to the captured text) is
+shared with :mod:`resource_property` on purpose so the two checks read the
+same way in a task's ``verification_spec``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import Field, model_validator
+
+from devops_bench.k8s import exec_pod, get_resource
+from devops_bench.verification.base import (
+    VERIFIERS,
+    BaseVerifier,
+    VerificationResult,
+    VerificationStatus,
+    single_call_timeout,
+)
+from devops_bench.verification.verifiers.resource_property import _apply_op, _object_name
+
+__all__ = ["PodExecVerifier"]
+
+_VALUE_OPS = ("eq", "ne", "gt", "gte", "lt", "lte", "contains", "matches")
+
+
+@VERIFIERS.register("pod_exec")
+class PodExecVerifier(BaseVerifier):
+    """Run a command inside a pod and compare its (trimmed) stdout.
+
+    Exactly one pod is targeted per evaluation. ``resource_name`` addresses it
+    directly; ``selector`` resolves to the first pod (by name, for determinism)
+    among the matches, which is the common case for a task fixture that only
+    ever runs one replica of the thing being probed (a dedicated prober pod, a
+    sidecar's own pod). A selector matching a multi-replica Deployment checks
+    one representative pod, not all of them — tasks that need every replica
+    probed should declare one entry per pod name instead.
+
+    Attributes:
+        type: Discriminator literal, always ``"pod_exec"``.
+        resource_name: Exact pod name. Mutually exclusive with ``selector``.
+        selector: Label selector resolving to one or more pods; the first
+            (by name) is used.
+        namespace: Optional namespace; defaults to the active one.
+        container: Optional container name, required when the pod runs more
+            than one container.
+        command: Argv executed inside the container, never a shell string
+            (pass ``["sh", "-c", "..."]`` explicitly for shell features).
+        op: Comparison applied to the command's stripped stdout.
+        value: Right-hand side of the comparison.
+    """
+
+    type: Literal["pod_exec"] = "pod_exec"
+    resource_name: str | None = None
+    selector: str | None = None
+    namespace: str | None = None
+    container: str | None = None
+    command: list[str] = Field(min_length=1)
+    op: Literal["eq", "ne", "gt", "gte", "lt", "lte", "contains", "matches"]
+    value: Any = None
+
+    @model_validator(mode="after")
+    def _check_shape(self) -> PodExecVerifier:
+        """Reject combinations that cannot mean anything at evaluation time."""
+        if bool(self.resource_name) == bool(self.selector):
+            msg = "pod_exec takes exactly one of 'resource_name' or 'selector'"
+            raise ValueError(msg)
+        if self.op in _VALUE_OPS and self.value is None:
+            raise ValueError(f"op {self.op!r} requires 'value'")
+        return self
+
+    def verify(self, timeout_sec: float) -> VerificationResult:
+        """Poll the exec'd command's output until it satisfies ``op`` or times out."""
+        return self._poll_to_result(lambda: self._check(timeout_sec), timeout_sec)
+
+    def _resolve_pod_name(self, timeout_sec: float) -> tuple[str | None, str | None]:
+        """Return ``(pod_name, error)``; exactly one is non-``None``."""
+        if self.resource_name:
+            return self.resource_name, None
+        try:
+            payload = get_resource(
+                "pods",
+                selector=self.selector,
+                namespace=self.namespace,
+                kubeconfig=self.kubeconfig,
+                timeout=single_call_timeout(timeout_sec),
+            )
+        except Exception as exc:  # noqa: BLE001 - a kubectl failure is a check error
+            return None, f"kubectl get pods failed: {exc}"
+        items = payload.get("items") or []
+        if not items:
+            return None, f"no pod matched selector {self.selector!r}"
+        names = sorted(_object_name(item) for item in items)
+        return names[0], None
+
+    def _check(self, timeout_sec: float) -> tuple[VerificationStatus, str, dict[str, Any] | None]:
+        """One evaluation pass: resolve the pod, exec the command, apply the operator."""
+        pod_name, resolve_error = self._resolve_pod_name(timeout_sec)
+        if pod_name is None:
+            return "error", resolve_error or "could not resolve a target pod", None
+
+        try:
+            completed = exec_pod(
+                pod_name,
+                self.command,
+                container=self.container,
+                namespace=self.namespace,
+                kubeconfig=self.kubeconfig,
+                timeout=single_call_timeout(timeout_sec),
+            )
+        except Exception as exc:  # noqa: BLE001 - a kubectl exec failure is a check error
+            return "error", f"kubectl exec {pod_name!r} failed: {exc}", None
+
+        output = completed.stdout.strip()
+        raw = {"pod": pod_name, "command": self.command, "output": output}
+        ok, reason = _apply_op(self.op, output, self.value)
+        return ("pass" if ok else "fail"), f"{pod_name}: {reason}", raw

--- a/tests/unit/k8s/test_k8s_kubectl.py
+++ b/tests/unit/k8s/test_k8s_kubectl.py
@@ -358,3 +358,43 @@ def test_is_not_found_matches_both_renderings_only(stderr: str, expected: bool) 
 
 def test_is_not_found_tolerates_an_exception_without_stderr() -> None:
     assert kubectl.is_not_found(RuntimeError("boom")) is False
+
+
+def test_exec_pod_builds_argv_and_returns_the_completed_process(mocker: MockerFixture) -> None:
+    mock_run = mocker.patch(
+        "devops_bench.k8s.kubectl.run",
+        return_value=_completed(stdout="v2\n"),
+    )
+
+    result = kubectl.exec_pod(
+        "prober",
+        ["cat", "/etc/version"],
+        container="sidecar",
+        namespace="shop",
+    )
+
+    assert result.stdout == "v2\n"
+    assert mock_run.call_args.args[0] == [
+        "kubectl",
+        "exec",
+        "prober",
+        "-c",
+        "sidecar",
+        "-n",
+        "shop",
+        "--",
+        "cat",
+        "/etc/version",
+    ]
+
+
+def test_exec_pod_separates_the_command_from_kubectl_flags(mocker: MockerFixture) -> None:
+    # Without the `--` terminator, a command carrying its own flags would be
+    # parsed by kubectl instead of being passed into the container.
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+
+    kubectl.exec_pod("prober", ["curl", "-s", "http://orders-api/health"])
+
+    argv = mock_run.call_args.args[0]
+    assert argv[: argv.index("--")] == ["kubectl", "exec", "prober"]
+    assert argv[argv.index("--") + 1 :] == ["curl", "-s", "http://orders-api/health"]

--- a/tests/unit/verification/test_pod_exec.py
+++ b/tests/unit/verification/test_pod_exec.py
@@ -1,0 +1,169 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``PodExecVerifier``.
+
+``kubectl`` is stubbed at the module boundary; no pod is ever exec'd.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from devops_bench.verification.verifiers import PodExecVerifier
+
+_EXEC = "devops_bench.verification.verifiers.pod_exec.exec_pod"
+_GET = "devops_bench.verification.verifiers.pod_exec.get_resource"
+
+
+def _completed(stdout: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout)
+
+
+def _pods(*names: str) -> dict[str, Any]:
+    return {"items": [{"metadata": {"name": n}} for n in names]}
+
+
+def _verifier(**kwargs: Any) -> PodExecVerifier:
+    base = {"type": "pod_exec", "command": ["cat", "/etc/version"], "op": "eq"}
+    base.update(kwargs)
+    return PodExecVerifier(**base)
+
+
+# -- shape --------------------------------------------------------------
+
+
+def test_a_target_is_required() -> None:
+    with pytest.raises(ValidationError, match="exactly one of"):
+        _verifier(value="v2")
+
+
+def test_naming_a_pod_and_a_selector_at_once_is_rejected() -> None:
+    with pytest.raises(ValidationError, match="exactly one of"):
+        _verifier(resource_name="prober", selector="app=prober", value="v2")
+
+
+def test_a_value_op_requires_a_value() -> None:
+    with pytest.raises(ValidationError, match="requires 'value'"):
+        _verifier(resource_name="prober")
+
+
+def test_an_empty_command_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _verifier(resource_name="prober", value="v2", command=[])
+
+
+# -- behaviour ----------------------------------------------------------
+
+
+def test_output_matching_the_expected_value_passes() -> None:
+    with patch(_EXEC, return_value=_completed("v2\n")):
+        result = _verifier(resource_name="prober", value="v2").verify(0.0)
+    assert result.success is True
+    assert result.status == "pass"
+    assert result.raw == {"pod": "prober", "command": ["cat", "/etc/version"], "output": "v2"}
+
+
+def test_surrounding_whitespace_is_not_part_of_the_comparison() -> None:
+    # Nearly every command a probe runs ends in a newline; comparing against it
+    # verbatim would make every eq check fail for a reason no task author means.
+    with patch(_EXEC, return_value=_completed("  v2  \n")):
+        result = _verifier(resource_name="prober", value="v2").verify(0.0)
+    assert result.success is True
+
+
+def test_output_differing_from_the_expected_value_fails() -> None:
+    with patch(_EXEC, return_value=_completed("v1")):
+        result = _verifier(resource_name="prober", value="v2").verify(0.0)
+    assert result.success is False
+    assert result.status == "fail"
+    assert "prober" in result.reason
+
+
+def test_contains_matches_a_substring_of_the_output() -> None:
+    with patch(_EXEC, return_value=_completed("Server: nginx/1.27.1")):
+        result = _verifier(resource_name="prober", op="contains", value="nginx/1.27").verify(0.0)
+    assert result.success is True
+
+
+def test_matches_applies_a_regex_to_the_output() -> None:
+    with patch(_EXEC, return_value=_completed("HTTP/1.1 200 OK")):
+        result = _verifier(resource_name="prober", op="matches", value=r"^HTTP/1\.1 2\d\d").verify(
+            0.0
+        )
+    assert result.success is True
+
+
+# -- target resolution --------------------------------------------------
+
+
+def test_a_selector_resolves_to_the_first_pod_by_name() -> None:
+    # Sorted rather than in apiserver order so a rerun probes the same pod and
+    # the check does not flap between replicas.
+    with (
+        patch(_GET, return_value=_pods("prober-zz", "prober-aa")),
+        patch(_EXEC, return_value=_completed("v2")) as mock_exec,
+    ):
+        result = _verifier(selector="app=prober", value="v2").verify(0.0)
+    assert result.success is True
+    assert mock_exec.call_args.args[0] == "prober-aa"
+
+
+def test_a_selector_matching_nothing_is_an_error() -> None:
+    with patch(_GET, return_value=_pods()):
+        result = _verifier(selector="app=prober", value="v2").verify(0.0)
+    assert result.success is False
+    assert result.status == "error"
+    assert "no pod matched" in result.reason
+
+
+def test_naming_a_pod_skips_the_lookup_entirely() -> None:
+    with patch(_GET) as mock_get, patch(_EXEC, return_value=_completed("v2")):
+        _verifier(resource_name="prober", value="v2").verify(0.0)
+    mock_get.assert_not_called()
+
+
+# -- failure handling ---------------------------------------------------
+
+
+def test_a_failed_pod_lookup_is_an_error_not_a_crash() -> None:
+    with patch(_GET, side_effect=RuntimeError("connection refused")):
+        result = _verifier(selector="app=prober", value="v2").verify(0.0)
+    assert result.success is False
+    assert result.status == "error"
+    assert "connection refused" in result.reason
+
+
+def test_a_failed_exec_is_an_error_not_a_crash() -> None:
+    # The pod exists but the command could not run (no shell, container
+    # restarting). That is a failure to observe, not an observed mismatch.
+    with patch(_EXEC, side_effect=RuntimeError("container not running")):
+        result = _verifier(resource_name="prober", value="v2").verify(0.0)
+    assert result.success is False
+    assert result.status == "error"
+    assert "container not running" in result.reason
+
+
+def test_the_container_is_threaded_through_to_kubectl() -> None:
+    with patch(_EXEC, return_value=_completed("v2")) as mock_exec:
+        _verifier(resource_name="prober", value="v2", container="sidecar", namespace="shop").verify(
+            0.0
+        )
+    assert mock_exec.call_args.kwargs["container"] == "sidecar"
+    assert mock_exec.call_args.kwargs["namespace"] == "shop"


### PR DESCRIPTION
## What this adds

A `pod_exec` verifier and the `kubectl.exec_pod` wrapper it sits on: run a command inside a running
pod and assert on its output.

Needed by #105, which uses it twice.

## Why

A Deployment's declared spec — and even its `status` conditions — can look fully healthy while the
workload actually serving traffic is something else entirely. Every verifier we have today reads
what the API server was *told*. This reads what is actually running: a served HTTP response, a
binary's own version output, an appended log file. No `kubectl get` field can see any of those.

On #105 specifically, this is what distinguishes "the image tag says it is patched" from "the
process answering requests is the patched one".

## Design notes worth reviewing

- **`exec_pod` is argv-only and `--`-terminated.** It takes `list[str]`, never a shell string.
  Without the `--` terminator a command carrying its own flags (`curl -s http://...`) gets parsed by
  kubectl instead of being passed into the container. Callers who genuinely need shell features pass
  `["sh", "-c", "..."]` explicitly, so that choice is visible in the task YAML rather than implicit
  in a string join.
- **Exact pod name, no selector.** The caller resolves one pod; the verifier does not silently pick
  among replicas.
- It reuses `_apply_op` and `_object_name` from `resource_property` so the operator semantics match
  every other check.

## Testing

15 new tests for the verifier, plus 2 for the argv construction — the `--` placement is the part
most likely to regress silently, so it is asserted on both sides of the terminator rather than by
comparing one flat list.

Full suite green: 1317 passed. `ruff check` and `ruff format --check` clean.

## Dependencies

None. This branches off `main` and touches no existing behaviour — it only adds `exec_pod` to the
k8s wrapper and registers one new verifier. It is independent of #74 and of the `identity_preserved`
PR; #105 needs all three, but they can merge in any order.

/kind feature

```release-note
Add a `pod_exec` verifier and a `kubectl.exec_pod` wrapper, so tasks can grade what a workload actually serves rather than only what its spec declares.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for executing commands inside Kubernetes pods, with optional container, namespace, kubeconfig, and timeout settings.
  - Added a `pod_exec` verifier that checks command output using equality, comparison, substring, or regular-expression matching.
  - Supports targeting pods directly or selecting them by resource labels, with clear handling of unavailable pods and command execution errors.

- **Tests**
  - Added coverage for command construction, flag handling, pod selection, output matching, failures, and configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->