### PR TITLE
feat(verification): add the identity_preserved verifier

### DIFF
--- a/devops_bench/verification/verifiers/__init__.py
+++ b/devops_bench/verification/verifiers/__init__.py
@@ -14,6 +14,9 @@
 
 """Concrete single-condition verifiers."""
 
+from devops_bench.verification.verifiers.identity_preserved import (
+    IdentityPreservedVerifier,
+)
 from devops_bench.verification.verifiers.pod_healthy import PodHealthyVerifier
 from devops_bench.verification.verifiers.resource_property import (
     ResourcePropertyVerifier,
@@ -21,6 +24,7 @@ from devops_bench.verification.verifiers.resource_property import (
 from devops_bench.verification.verifiers.scaling_complete import ScalingCompleteVerifier
 
 __all__ = [
+    "IdentityPreservedVerifier",
     "PodHealthyVerifier",
     "ResourcePropertyVerifier",
     "ScalingCompleteVerifier",

--- a/devops_bench/verification/verifiers/identity_preserved.py
+++ b/devops_bench/verification/verifiers/identity_preserved.py
@@ -1,0 +1,137 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Assert that a resource is the SAME object a run started with, not a replacement.
+
+``kubectl delete && kubectl apply`` (or an equivalent "erase and rebuild")
+produces a Deployment that looks byte-identical to the original in every
+spec/status field, including the image tag a naive check would grade — but
+Kubernetes assigns a brand-new, server-generated ``metadata.uid`` on every
+create, and it can never be set by a client. That makes ``uid`` (and
+``creationTimestamp``, which moves in lockstep) the one field a "just erase
+and replace" shortcut cannot fake, which is exactly why it is the metric here
+rather than anything the agent's own edits could touch.
+
+The fixture records the pre-run ``uid``/``creationTimestamp`` as annotations
+on the object itself during setup (see ``scripts/setup.sh``), before the agent
+starts. Comparing the live object's own metadata fields against its own
+baseline annotations needs no second resource fetch and no new harness-level
+"capture a pre-run baseline" concept — the baseline travels with the object.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from devops_bench.k8s import get_resource, is_not_found
+from devops_bench.verification.base import (
+    VERIFIERS,
+    BaseVerifier,
+    VerificationResult,
+    VerificationStatus,
+    single_call_timeout,
+)
+
+__all__ = ["IdentityPreservedVerifier"]
+
+_DEFAULT_UID_KEY = "devops-bench.io/original-uid"
+_DEFAULT_CREATED_KEY = "devops-bench.io/original-creation-timestamp"
+
+
+@VERIFIERS.register("identity_preserved")
+class IdentityPreservedVerifier(BaseVerifier):
+    """Verify a resource's live identity still matches its recorded baseline.
+
+    Attributes:
+        type: Discriminator literal, always ``"identity_preserved"``.
+        kind: Resource kind, e.g. ``"Deployment"``.
+        resource_name: Exact resource name.
+        namespace: Optional namespace; defaults to the active one.
+        uid_annotation_key: Annotation key the baseline ``metadata.uid`` was
+            recorded under.
+        creation_timestamp_annotation_key: Annotation key the baseline
+            ``metadata.creationTimestamp`` was recorded under. Checked
+            alongside ``uid`` (not as a substitute) since a client can forge an
+            annotation's value but not a server-assigned field: the two
+            together make it materially harder to reconstruct a fake match by
+            hand.
+    """
+
+    type: Literal["identity_preserved"] = "identity_preserved"
+    kind: str
+    resource_name: str
+    namespace: str | None = None
+    uid_annotation_key: str = _DEFAULT_UID_KEY
+    creation_timestamp_annotation_key: str = _DEFAULT_CREATED_KEY
+
+    def verify(self, timeout_sec: float) -> VerificationResult:
+        """Poll until the live object's identity matches its baseline or times out."""
+        return self._poll_to_result(lambda: self._check(timeout_sec), timeout_sec)
+
+    def _check(self, timeout_sec: float) -> tuple[VerificationStatus, str, dict[str, Any] | None]:
+        try:
+            obj = get_resource(
+                self.kind,
+                self.resource_name,
+                namespace=self.namespace,
+                kubeconfig=self.kubeconfig,
+                timeout=single_call_timeout(timeout_sec),
+            )
+        except Exception as exc:  # noqa: BLE001 - a kubectl failure is a check error
+            if is_not_found(exc):
+                # Deleted outright and never replaced. The identity is not
+                # merely unverifiable, it is observably gone, so this fails
+                # rather than dropping out of the score as an error.
+                return (
+                    "fail",
+                    f"{self.resource_name} no longer exists; it was deleted, not updated in place",
+                    None,
+                )
+            return "error", f"kubectl get {self.kind} {self.resource_name!r} failed: {exc}", None
+
+        metadata = obj.get("metadata") or {}
+        live_uid = metadata.get("uid")
+        live_created = metadata.get("creationTimestamp")
+        annotations = metadata.get("annotations") or {}
+        baseline_uid = annotations.get(self.uid_annotation_key)
+        baseline_created = annotations.get(self.creation_timestamp_annotation_key)
+        raw = {
+            "live_uid": live_uid,
+            "baseline_uid": baseline_uid,
+            "live_creationTimestamp": live_created,
+            "baseline_creationTimestamp": baseline_created,
+        }
+
+        if not baseline_uid or not baseline_created:
+            return (
+                "fail",
+                f"{self.resource_name} carries no baseline identity annotation "
+                f"({self.uid_annotation_key!r} / {self.creation_timestamp_annotation_key!r}); "
+                "a resource created fresh (e.g. deleted and reapplied from the GitOps repo, "
+                "which never carried this annotation) never gets one back",
+                raw,
+            )
+        if live_uid != baseline_uid or live_created != baseline_created:
+            return (
+                "fail",
+                f"{self.resource_name} identity changed: uid {baseline_uid!r} -> {live_uid!r}, "
+                f"creationTimestamp {baseline_created!r} -> {live_created!r} "
+                "(the object was deleted and recreated, not updated in place)",
+                raw,
+            )
+        return (
+            "pass",
+            f"{self.resource_name} uid and creationTimestamp match the pre-run baseline",
+            raw,
+        )

--- a/tests/unit/verification/test_identity_preserved.py
+++ b/tests/unit/verification/test_identity_preserved.py
@@ -1,0 +1,163 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``IdentityPreservedVerifier``.
+
+``kubectl`` is stubbed at the module boundary; no cluster is contacted.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from devops_bench.core import SubprocessError
+from devops_bench.verification.verifiers import IdentityPreservedVerifier
+
+_GET = "devops_bench.verification.verifiers.identity_preserved.get_resource"
+_UID_KEY = "devops-bench.io/original-uid"
+_CREATED_KEY = "devops-bench.io/original-creation-timestamp"
+
+_UID = "9f1c2e44-0d0e-4a6b-9a1f-2b3c4d5e6f70"
+_CREATED = "2026-01-02T03:04:05Z"
+
+
+def _deployment(
+    uid: str = _UID,
+    created: str = _CREATED,
+    annotations: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    if annotations is None:
+        annotations = {_UID_KEY: _UID, _CREATED_KEY: _CREATED}
+    return {
+        "kind": "Deployment",
+        "metadata": {
+            "name": "orders-api",
+            "namespace": "shop",
+            "uid": uid,
+            "creationTimestamp": created,
+            "annotations": annotations,
+        },
+    }
+
+
+def _verifier(**kwargs: Any) -> IdentityPreservedVerifier:
+    base = {
+        "type": "identity_preserved",
+        "kind": "Deployment",
+        "resource_name": "orders-api",
+    }
+    base.update(kwargs)
+    return IdentityPreservedVerifier(**base)
+
+
+# -- the object survived ------------------------------------------------
+
+
+def test_an_object_updated_in_place_keeps_its_identity() -> None:
+    with patch(_GET, return_value=_deployment()):
+        result = _verifier().verify(0.0)
+    assert result.success is True
+    assert result.status == "pass"
+    assert result.raw["live_uid"] == result.raw["baseline_uid"] == _UID
+
+
+# -- the object was replaced --------------------------------------------
+
+
+def test_a_recreated_object_is_caught_by_its_new_uid() -> None:
+    # The whole point: delete-and-reapply produces a Deployment identical in
+    # every field a spec check looks at, but the apiserver assigns a fresh uid
+    # that no client can set.
+    replaced = _deployment(uid="00000000-1111-2222-3333-444444444444")
+    with patch(_GET, return_value=replaced):
+        result = _verifier().verify(0.0)
+    assert result.success is False
+    assert result.status == "fail"
+    assert "deleted and recreated" in result.reason
+
+
+def test_a_moved_creation_timestamp_alone_is_enough_to_fail() -> None:
+    with patch(_GET, return_value=_deployment(created="2026-06-30T12:00:00Z")):
+        result = _verifier().verify(0.0)
+    assert result.success is False
+    assert result.status == "fail"
+
+
+def test_an_object_rebuilt_from_a_manifest_has_no_baseline_to_match() -> None:
+    # Recreating from the GitOps repo yields an object that never carried the
+    # setup-time annotation, so there is nothing to compare against. That is a
+    # failure, not a skip: the absence is itself the evidence of a rebuild.
+    with patch(_GET, return_value=_deployment(annotations={})):
+        result = _verifier().verify(0.0)
+    assert result.success is False
+    assert result.status == "fail"
+    assert "no baseline identity annotation" in result.reason
+
+
+def test_a_half_recorded_baseline_still_fails() -> None:
+    with patch(_GET, return_value=_deployment(annotations={_UID_KEY: _UID})):
+        result = _verifier().verify(0.0)
+    assert result.success is False
+    assert result.status == "fail"
+
+
+def test_missing_metadata_does_not_crash_the_check() -> None:
+    with patch(_GET, return_value={"kind": "Deployment"}):
+        result = _verifier().verify(0.0)
+    assert result.success is False
+    assert result.status == "fail"
+
+
+# -- configuration ------------------------------------------------------
+
+
+def test_the_annotation_keys_are_overridable() -> None:
+    obj = _deployment(annotations={"acme.io/uid": _UID, "acme.io/created": _CREATED})
+    with patch(_GET, return_value=obj):
+        result = _verifier(
+            uid_annotation_key="acme.io/uid",
+            creation_timestamp_annotation_key="acme.io/created",
+        ).verify(0.0)
+    assert result.success is True
+
+
+def test_the_namespace_is_threaded_through_to_kubectl() -> None:
+    with patch(_GET, return_value=_deployment()) as mock_get:
+        _verifier(namespace="shop").verify(0.0)
+    assert mock_get.call_args.kwargs["namespace"] == "shop"
+
+
+# -- failure handling ---------------------------------------------------
+
+
+def test_a_kubectl_failure_is_an_error_not_a_crash() -> None:
+    with patch(_GET, side_effect=RuntimeError("connection refused")):
+        result = _verifier().verify(0.0)
+    assert result.success is False
+    assert result.status == "error"
+    assert "connection refused" in result.reason
+
+
+def test_a_deleted_object_fails_rather_than_erroring() -> None:
+    exc = SubprocessError(
+        cmd=["kubectl", "get", "Deployment", "orders-api"],
+        returncode=1,
+        stderr='Error from server (NotFound): deployments.apps "orders-api" not found',
+    )
+    with patch(_GET, side_effect=exc):
+        result = _verifier().verify(0.0)
+    assert result.success is False
+    assert result.status == "fail"
+    assert "no longer exists" in result.reason


### PR DESCRIPTION
## What this adds

An `identity_preserved` verifier: assert that a resource is the **same object** the run started
with, not a replacement that looks like it.

Needed by #105, which uses it five times.

## Why

`kubectl delete && kubectl apply` — or any equivalent "erase and rebuild" — produces a Deployment
that is byte-identical to the original in every spec and status field a naive check would grade,
including the image tag. Every remediation check we have passes on it.

This is not hypothetical. On three separate `migration-and-upgrade` runs the agent destroyed the
production cluster it was asked to upgrade, rebuilt it, and scored 0.7–0.8 with `success: True`.
Nothing in the pipeline could see it.

Kubernetes assigns a new server-generated `metadata.uid` on every create, and a client can never set
it. That makes `uid` — and `creationTimestamp`, which moves in lockstep — the one field an
erase-and-replace shortcut cannot fake, which is why it is the metric here rather than anything the
agent's own edits could touch.

## Design notes worth reviewing

- **The baseline travels with the object.** The fixture records the pre-run `uid` and
  `creationTimestamp` as annotations on the resource itself during setup, before the agent starts.
  Comparing the live object's own metadata against its own baseline annotations needs no second
  fetch and no new harness-level "capture a pre-run baseline" concept.
- **NotFound is a fail, not an error.** If the resource is gone the check returns `fail` with
  `"…no longer exists; it was deleted, not updated in place"`. Returning `error` would drop the
  entry out of the correctness fraction entirely — an agent that deleted the resource outright would
  score better than one that replaced it, which inverts the whole point of the check.

## Testing

10 new tests. Full suite green: 1320 passed. `ruff check` and `ruff format --check` clean.

## Dependencies

None. #74 has merged, so the stacked commit is gone and this is a single-commit PR against `main`.


/kind feature

```release-note
Add an `identity_preserved` verifier that detects a resource being deleted and recreated rather than updated in place, using the server-generated `metadata.uid` a client cannot fake.
```

