### PR TITLE
feat(agents/openclaw): shell exec mode, denied delegation tools, plugin paths, and memory off

### DIFF
--- a/devops_bench/agents/cli/openclaw/agent.py
+++ b/devops_bench/agents/cli/openclaw/agent.py
@@ -321,6 +321,15 @@ def _build_openclaw_config(config: AgentConfig, mcp_servers: tuple[McpBinding, .
         "codeMode": _code_mode_enabled(),
         "deny": list(_DENIED_TOOLS),
     }
+    # openclaw 2026.8.x ships a memory subsystem that is ON by default. It has
+    # no place in a benchmark run for two reasons. It embeds every transcript
+    # through an OpenAI embeddings call, adding an outbound dependency (and
+    # spend) on a provider the run never selected and that the sandbox does not
+    # expect; and `rememberAcrossConversations` defaults on, so a second run of
+    # the same task can recall the first one's transcript and score on recall
+    # rather than on the cluster. Disabling the master toggle makes each run
+    # stateless, which is the only defensible baseline for scoring.
+    payload["memory"] = {"search": {"enabled": False}}
     # openclaw only discovers plugins bundled in its own dist/extensions or
     # named in plugins.load.paths, so an externally installed provider
     # package (e.g. anthropic-vertex) has to be named explicitly here.

--- a/devops_bench/agents/cli/openclaw/agent.py
+++ b/devops_bench/agents/cli/openclaw/agent.py
@@ -237,13 +237,44 @@ def _build_model_override(config: AgentConfig) -> dict:
     }
 
 
+# The bench always launches openclaw as ``oc agent --local``, which is embedded
+# mode with no gateway (see :func:`_build_local_command`). ``sessions_spawn``
+# hands work off to a subagent whose completion is normally reported back by
+# the gateway; without one, the spawn call still reports success, but the
+# ``sessions_yield`` call that awaits the result waits on an event the gateway
+# never sends. The one-shot process then exits with no work done and the run
+# scores 0.0. Denying both tools keeps the model doing the work itself in its
+# own turn instead of delegating into a dead end.
+_DENIED_TOOLS: tuple[str, ...] = ("sessions_spawn", "sessions_yield")
+
+
+def _code_mode_enabled() -> bool:
+    """Read ``BENCH_OPENCLAW_CODE_MODE``, defaulting to shell mode (False).
+
+    Parsed permissively: ``"1"``/``"true"``/``"yes"`` (any case) are truthy,
+    anything else, including an unset env var, is False.
+    """
+    raw = os.environ.get("BENCH_OPENCLAW_CODE_MODE", "")
+    return raw.strip().lower() in ("1", "true", "yes")
+
+
+def _plugin_paths() -> list[str]:
+    """Read ``BENCH_OPENCLAW_PLUGIN_PATHS``, an os.pathsep-separated list.
+
+    Empty when unset or blank. Each entry is stripped; empty entries are
+    dropped.
+    """
+    raw = os.environ.get("BENCH_OPENCLAW_PLUGIN_PATHS", "")
+    return [p.strip() for p in raw.split(os.pathsep) if p.strip()]
+
+
 def _build_openclaw_config(config: AgentConfig, mcp_servers: tuple[McpBinding, ...]) -> dict:
     """Assemble the isolated ``openclaw.json`` payload for a run.
 
-    Merges the two per-run config concerns the harness owns: command-bearing MCP
-    bindings (``mcp.servers``) and a catalog entry for a model openclaw doesn't
-    ship by default (``models``/``agents``; see :func:`_build_model_override`).
-    Their key spaces are disjoint, so either, both, or neither may be present.
+    Merges the per-run config concerns the harness owns: command-bearing MCP
+    bindings (``mcp.servers``), a catalog entry for a model openclaw doesn't
+    ship by default (``models``/``agents``; see :func:`_build_model_override`),
+    and the ``exec`` tool's shell/code mode (``tools.codeMode``).
 
     Args:
         config: Resolved :class:`AgentConfig` (drives the model-catalog entry).
@@ -251,13 +282,16 @@ def _build_openclaw_config(config: AgentConfig, mcp_servers: tuple[McpBinding, .
             bindings are skipped by :func:`build_mcp_servers`).
 
     Returns:
-        A config mapping, or an empty dict when there is neither a launchable MCP
-        binding nor a model needing a catalog entry (caller then skips the config
-        write and leaves ``OPENCLAW_CONFIG_PATH`` unset).
+        A config mapping. ``tools.codeMode`` is always present, so the payload
+        is never empty and the caller always writes ``openclaw.json``.
 
     Each MCP server entry inherits the run's ``KUBECONFIG`` (set by ``RunEnv``) as
     an explicit ``env`` so the MCP server (e.g. gke-mcp) reads the run-scoped
     cluster credentials directly instead of forcing the agent to re-fetch them.
+
+    ``tools.codeMode`` defaults to False (shell mode) so the ``exec`` tool takes
+    a plain shell command instead of JavaScript run in openclaw's code-mode
+    sandbox. Overridable with ``BENCH_OPENCLAW_CODE_MODE``.
     """
     payload: dict = {}
     servers = build_mcp_servers(mcp_servers)
@@ -268,6 +302,31 @@ def _build_openclaw_config(config: AgentConfig, mcp_servers: tuple[McpBinding, .
                 entry.setdefault("env", {})["KUBECONFIG"] = kubeconfig
         payload["mcp"] = {"servers": servers}
     payload.update(_build_model_override(config))
+    # Derive the runtime provider from the model id oc actually receives:
+    # oc's implicit codex routing keys off that id, so a full "openai/..."
+    # model with no explicit config.provider would otherwise resolve to the
+    # default provider and skip the pin below.
+    model_provider, _, _ = _oc_model_id(config).partition("/")
+    oc_provider = model_provider or resolve_provider(config.provider).oc_provider
+    if oc_provider == "openai":
+        # openclaw implicitly routes OpenAI "dual route" model ids (e.g.
+        # gpt-5.6-sol) to the "codex" agent harness runtime, which ships as a
+        # separate plugin not registered on the fleet image, so the run dies at
+        # startup. openclaw checks a configured agentRuntime.id before that
+        # implicit routing logic and short-circuits, so pinning it here to the
+        # built-in "openclaw" runtime avoids codex entirely.
+        providers = payload.setdefault("models", {}).setdefault("providers", {})
+        providers.setdefault(oc_provider, {})["agentRuntime"] = {"id": "openclaw"}
+    payload["tools"] = {
+        "codeMode": _code_mode_enabled(),
+        "deny": list(_DENIED_TOOLS),
+    }
+    # openclaw only discovers plugins bundled in its own dist/extensions or
+    # named in plugins.load.paths, so an externally installed provider
+    # package (e.g. anthropic-vertex) has to be named explicitly here.
+    plugin_paths = _plugin_paths()
+    if plugin_paths:
+        payload["plugins"] = {"load": {"paths": plugin_paths}}
     return payload
 
 

--- a/tests/unit/agents/test_agents_cli_openclaw.py
+++ b/tests/unit/agents/test_agents_cli_openclaw.py
@@ -599,6 +599,7 @@ def test_build_openclaw_config_wraps_servers_under_mcp() -> None:
     assert cfg == {
         "mcp": {"servers": {"gke": {"command": "gke-mcp"}}},
         "tools": {"codeMode": False, "deny": ["sessions_spawn", "sessions_yield"]},
+        "memory": {"search": {"enabled": False}},
     }
 
 
@@ -741,6 +742,7 @@ def test_execute_writes_mcp_servers_into_isolated_config(
     assert captured["config"] == {
         "mcp": {"servers": {"gke": {"command": "gke-mcp"}}},
         "tools": {"codeMode": False, "deny": ["sessions_spawn", "sessions_yield"]},
+        "memory": {"search": {"enabled": False}},
     }
 
 
@@ -885,6 +887,7 @@ def test_build_openclaw_config_carries_only_code_mode_without_launchable_server_
     """No MCP binding and a catalog-known model → only ``tools.codeMode``/``deny``."""
     expected = {
         "tools": {"codeMode": False, "deny": ["sessions_spawn", "sessions_yield"]},
+        "memory": {"search": {"enabled": False}},
     }
     assert _build_openclaw_config(AgentConfig(), ()) == expected
     assert (
@@ -963,6 +966,16 @@ def test_build_openclaw_config_pins_openai_runtime_for_full_model_id() -> None:
 # Model catalog override: models oc doesn't ship by default get registered in
 # the per-run isolated config, for both google-genai and google-vertex.
 # ---------------------------------------------------------------------------
+
+
+def test_build_openclaw_config_disables_memory_search() -> None:
+    """openclaw 2026.8.x enables memory search by default, which both calls an
+    OpenAI embeddings endpoint the run never selected and lets one run recall a
+    previous run of the same task. A benchmark run must be stateless."""
+    payload = _build_openclaw_config(AgentConfig(), ())
+    assert payload["memory"] == {"search": {"enabled": False}}
+
+
 def test_execute_writes_code_mode_config_when_no_launchable_server(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -993,4 +1006,5 @@ def test_execute_writes_code_mode_config_when_no_launchable_server(
     assert captured["cfg_path"]
     assert captured["config"] == {
         "tools": {"codeMode": False, "deny": ["sessions_spawn", "sessions_yield"]},
+        "memory": {"search": {"enabled": False}},
     }

--- a/tests/unit/agents/test_agents_cli_openclaw.py
+++ b/tests/unit/agents/test_agents_cli_openclaw.py
@@ -596,19 +596,10 @@ def test_execute_does_not_prepend_rules_when_empty(
 def test_build_openclaw_config_wraps_servers_under_mcp() -> None:
     """A launchable binding renders under the ``mcp.servers`` config path."""
     cfg = _build_openclaw_config(AgentConfig(), (McpBinding(name="gke", command=("gke-mcp",)),))
-    assert cfg == {"mcp": {"servers": {"gke": {"command": "gke-mcp"}}}}
-
-
-def test_build_openclaw_config_empty_without_launchable_server_or_override() -> None:
-    """No MCP binding and a catalog-known model → empty config (caller skips)."""
-    assert _build_openclaw_config(AgentConfig(), ()) == {}
-    assert (
-        _build_openclaw_config(
-            AgentConfig(model="gemini-3.1-pro-preview"),
-            (McpBinding(name="b", command=(), tools=("t",)),),
-        )
-        == {}
-    )
+    assert cfg == {
+        "mcp": {"servers": {"gke": {"command": "gke-mcp"}}},
+        "tools": {"codeMode": False, "deny": ["sessions_spawn", "sessions_yield"]},
+    }
 
 
 def test_build_openclaw_config_merges_mcp_and_model_override() -> None:
@@ -747,33 +738,10 @@ def test_execute_writes_mcp_servers_into_isolated_config(
     )
     OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"), capabilities=caps)).run("p")
     assert captured["cfg_path"], "OPENCLAW_CONFIG_PATH must be set when MCP is bound"
-    assert captured["config"] == {"mcp": {"servers": {"gke": {"command": "gke-mcp"}}}}
-
-
-def test_execute_writes_no_config_when_no_launchable_server(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """No command-bearing MCP binding and a catalog-known model → no isolated
-    config, env var unset."""
-    captured: dict = {}
-
-    def fake_bash(cmd, **kwargs):
-        env = kwargs.get("extra_env") or {}
-        captured["has_cfg"] = "OPENCLAW_CONFIG_PATH" in env
-        return _make_subprocess_result(stdout="ok", returncode=0)
-
-    _install_oc_run(monkeypatch, fake_bash, _empty_sessions_run)
-    caps = AllCapabilities(
-        mcp_servers=(McpBinding(name="builtin", command=(), tools=("alpha",)),),
-    )
-    OpenClawAgent(
-        AgentConfig(
-            target=str(tmp_path / "oc"),
-            model="gemini-3.1-pro-preview",
-            capabilities=caps,
-        )
-    ).run("p")
-    assert captured["has_cfg"] is False
+    assert captured["config"] == {
+        "mcp": {"servers": {"gke": {"command": "gke-mcp"}}},
+        "tools": {"codeMode": False, "deny": ["sessions_spawn", "sessions_yield"]},
+    }
 
 
 def test_execute_writes_model_override_config_without_mcp(
@@ -909,3 +877,120 @@ def test_execute_cleans_up_temp_working_dir_after_run(
     OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"))).run("p")
     assert captured["cwd"] is not None
     assert not os.path.exists(captured["cwd"])
+
+
+def test_build_openclaw_config_carries_only_code_mode_without_launchable_server_or_override() -> (
+    None
+):
+    """No MCP binding and a catalog-known model → only ``tools.codeMode``/``deny``."""
+    expected = {
+        "tools": {"codeMode": False, "deny": ["sessions_spawn", "sessions_yield"]},
+    }
+    assert _build_openclaw_config(AgentConfig(), ()) == expected
+    assert (
+        _build_openclaw_config(
+            AgentConfig(model="gemini-3.1-pro-preview"),
+            (McpBinding(name="b", command=(), tools=("t",)),),
+        )
+        == expected
+    )
+
+
+def test_build_openclaw_config_defaults_code_mode_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("BENCH_OPENCLAW_CODE_MODE", raising=False)
+    payload = _build_openclaw_config(AgentConfig(), ())
+    assert payload["tools"]["codeMode"] is False
+
+
+def test_build_openclaw_config_honors_code_mode_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BENCH_OPENCLAW_CODE_MODE", "1")
+    payload = _build_openclaw_config(AgentConfig(), ())
+    assert payload["tools"]["codeMode"] is True
+
+
+def test_build_openclaw_config_denies_delegation_tools() -> None:
+    """sessions_spawn/sessions_yield are denied regardless of provider: the bench
+    always runs embedded (``oc agent --local``), so a delegated subagent's
+    completion never arrives and the run would end having done no work."""
+    cfg = _build_openclaw_config(AgentConfig(), ())
+    assert set(cfg["tools"]["deny"]) == {"sessions_spawn", "sessions_yield"}
+
+
+def test_build_openclaw_config_deny_does_not_clobber_code_mode() -> None:
+    """The deny list coexists with ``tools.codeMode``; neither overwrites the other."""
+    cfg = _build_openclaw_config(AgentConfig(), ())
+    assert cfg["tools"] == {
+        "codeMode": False,
+        "deny": ["sessions_spawn", "sessions_yield"],
+    }
+
+
+def test_build_openclaw_config_pins_openai_to_builtin_agent_runtime() -> None:
+    """openai provider gets an explicit agentRuntime so oc skips the codex route."""
+    cfg = _build_openclaw_config(AgentConfig(model="gpt-5.6-sol", provider="openai"), ())
+    assert cfg["models"]["providers"]["openai"]["agentRuntime"] == {"id": "openclaw"}
+
+
+def test_build_openclaw_config_omits_agent_runtime_for_non_openai_provider() -> None:
+    """A gemini/google-vertex config gets no agentRuntime override; it's inert today."""
+    cfg = _build_openclaw_config(AgentConfig(model="gemini-2.5-pro", provider="google-vertex"), ())
+    assert "models" not in cfg or "openai" not in cfg["models"].get("providers", {})
+
+
+def test_build_openclaw_config_agent_runtime_does_not_clobber_model_override() -> None:
+    """The openai agentRuntime merge coexists with a catalog override for another provider."""
+    cfg = _build_openclaw_config(AgentConfig(model="gemini-3.5-flash", provider="google"), ())
+    assert cfg["models"]["providers"]["google"]["models"] == [
+        {"id": "gemini-3.5-flash", "name": "gemini-3.5-flash"}
+    ]
+    assert "openai" not in cfg["models"]["providers"]
+
+
+def test_build_openclaw_config_pins_openai_runtime_for_full_model_id() -> None:
+    """A full ``openai/...`` id selects the openai runtime with no explicit
+    provider set. Reading ``config.provider`` alone resolves to the default
+    provider, drops the pin, and lets oc route the run to the absent codex
+    runtime."""
+    cfg = _build_openclaw_config(AgentConfig(model="openai/gpt-5.6-sol"), ())
+    assert cfg["models"]["providers"]["openai"]["agentRuntime"] == {"id": "openclaw"}
+
+
+# ---------------------------------------------------------------------------
+# Model catalog override: models oc doesn't ship by default get registered in
+# the per-run isolated config, for both google-genai and google-vertex.
+# ---------------------------------------------------------------------------
+def test_execute_writes_code_mode_config_when_no_launchable_server(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No command-bearing MCP binding and a catalog-known model → the isolated
+    config still carries ``tools.codeMode``, so the env var is still set."""
+    captured: dict = {}
+
+    def fake_bash(cmd: str, **kwargs: Any) -> SimpleNamespace:
+        env = kwargs.get("extra_env") or {}
+        cfg_path = env.get("OPENCLAW_CONFIG_PATH")
+        captured["cfg_path"] = cfg_path
+        captured["config"] = (
+            json.loads(Path(cfg_path).read_text()) if cfg_path and Path(cfg_path).exists() else None
+        )
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    _install_oc_run(monkeypatch, fake_bash, _empty_sessions_run)
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="builtin", command=(), tools=("alpha",)),),
+    )
+    OpenClawAgent(
+        AgentConfig(
+            target=str(tmp_path / "oc"),
+            model="gemini-3.1-pro-preview",
+            capabilities=caps,
+        )
+    ).run("p")
+    assert captured["cfg_path"]
+    assert captured["config"] == {
+        "tools": {"codeMode": False, "deny": ["sessions_spawn", "sessions_yield"]},
+    }


### PR DESCRIPTION
Configures the openclaw agent adapter so a benchmark run is reproducible and
self-contained. Each item below shows up as a silently unusable run rather than
an error if left at openclaw's defaults.

**`tools.codeMode`** defaults to `False`, so the `exec` tool takes a plain shell
command instead of JavaScript in openclaw's code-mode sandbox. Overridable with
`BENCH_OPENCLAW_CODE_MODE`.

**`tools.deny`** drops `sessions_spawn` / `sessions_yield`. The bench always runs
embedded (`oc agent --local`) with no gateway to report a delegated subagent's
completion, so a `sessions_yield` that awaits a result waits on an event that
never arrives. The one-shot process then exits having done no work and the run
scores 0.0.

**`models.providers.openai.agentRuntime`** pins the built-in `openclaw` runtime.
openclaw implicitly routes OpenAI dual-route model ids to the `codex` harness
runtime, which ships as a separate plugin, so a run dies at startup unless a
configured runtime short-circuits that.

**`plugins.load.paths`** names externally installed provider packages, which
openclaw otherwise discovers only from its own `dist/extensions`. Set with
`BENCH_OPENCLAW_PLUGIN_PATHS`.

**`memory.search.enabled: false`** disables the memory subsystem that openclaw
2026.8.x ships on by default. This one affects scoring validity, not just
startup: it embeds every transcript through an OpenAI embeddings call, adding an
outbound dependency and spend on a provider the run never selected, and
`rememberAcrossConversations` defaults on, so a second run of the same task can
recall the first run's transcript and score on recall rather than on the cluster
under test. Disabling it makes each run stateless, which is the only defensible
baseline for scoring.

### Note on the empty-payload path

Because `tools.codeMode` is now always present, `_build_openclaw_config` never
returns an empty payload and the caller always writes `openclaw.json`. The two
tests that asserted the empty path are replaced by their positive counterparts.

### Testing

`pytest` full suite passing, `ruff check` and `ruff format --check` clean.

Thanks to @geojaz for the original change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - OpenClaw now consistently applies tool settings, including disabled memory search and restricted session controls.
  - Code mode can be enabled through configuration, with support for custom plugin paths.
  - OpenAI providers now explicitly use the OpenClaw runtime for more predictable execution.
  - Isolated configuration is created and applied even when no launchable server or model override is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->