### PR TITLE
fix(agents): read a remote ADK agent's answer from the A2A envelope

### DIFF
--- a/devops_bench/agents/adk/parsing.py
+++ b/devops_bench/agents/adk/parsing.py
@@ -30,6 +30,12 @@ Each event carries a ``content.parts`` list. Three part shapes matter:
 Calls and responses are correlated by the ``id`` ADK stamps on both sides, so a
 call and its result fold into one :class:`~devops_bench.agents.result.ToolCall`
 rather than two trajectory entries.
+
+An event from a remote A2A agent also carries the raw task envelope under
+``custom_metadata['a2a:response']``. That matters because the agent's actual
+answer lives in the task's ``status.message``, while the ``content.parts`` ADK
+builds alongside it hold a *mirror of the last artifact* — so the envelope, not
+the content, is what the judge should grade.
 """
 
 from __future__ import annotations
@@ -52,6 +58,15 @@ _USAGE_FIELDS: dict[str, str] = {
     "thoughts_token_count": "reasoning",
     "total_token_count": "total",
 }
+
+# Where ``RemoteA2aAgent`` stashes the raw task envelope on the event it builds.
+# ADK's converter does not export the key, so it is spelled out here.
+_A2A_RESPONSE_KEY = "a2a:response"
+
+# Terminal ``TaskState`` values meaning the remote agent never answered. The
+# proto types serialize the enum as ``TASK_STATE_FAILED`` and the pydantic types
+# as ``failed``, so states are normalized to the bare slug before the lookup.
+_A2A_FAILURE_STATES: frozenset[str] = frozenset({"failed", "canceled", "rejected"})
 
 
 def _int_or_none(value: object) -> int | None:
@@ -76,6 +91,45 @@ def _is_user_content(event: Mapping[str, Any]) -> bool:
     """
     content = event.get("content")
     return isinstance(content, Mapping) and content.get("role") == "user"
+
+
+def _a2a_task(event: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    """Return the A2A task envelope ``RemoteA2aAgent`` attached, if any."""
+    metadata = event.get("custom_metadata")
+    if not isinstance(metadata, Mapping):
+        return None
+    response = metadata.get(_A2A_RESPONSE_KEY)
+    return response if isinstance(response, Mapping) else None
+
+
+def _a2a_status(task: Mapping[str, Any]) -> tuple[str | None, str | None]:
+    """Pull the reported state and final message text out of a task envelope.
+
+    Returns:
+        A ``(state, text)`` tuple. ``state`` is normalized to the bare slug
+        (``"completed"``, not ``"TASK_STATE_COMPLETED"``). ``text`` is ``None``
+        when the task carried no status message, which is the case while a task
+        is still working.
+    """
+    status = task.get("status")
+    if not isinstance(status, Mapping):
+        return None, None
+
+    raw_state = status.get("state")
+    state = raw_state.lower().removeprefix("task_state_") if isinstance(raw_state, str) else None
+
+    message = status.get("message")
+    parts = message.get("parts") if isinstance(message, Mapping) else None
+    texts = (
+        [
+            part["text"]
+            for part in parts
+            if isinstance(part, Mapping) and isinstance(part.get("text"), str)
+        ]
+        if isinstance(parts, list)
+        else []
+    )
+    return state, ("".join(texts) or None)
 
 
 def _response_text(response: Any) -> tuple[str, bool]:
@@ -172,6 +226,10 @@ def parse_event_stream(
     the output text: the former would duplicate the text they are chunks of, and
     the latter is reasoning the judge should not grade as an answer.
 
+    An event carrying an A2A task envelope is read from the envelope instead: its
+    ``status.message`` is the remote agent's answer, and a terminal state other
+    than completed lands on ``errors``.
+
     Args:
         events: Serialized ``Event`` mappings in the order ADK yielded them.
 
@@ -207,6 +265,17 @@ def parse_event_stream(
         partial = bool(event.get("partial"))
         user_content = _is_user_content(event)
 
+        # A remote agent's answer is the A2A task's status message. Take it in
+        # place of the event's own text, which mirrors the trailing artifact.
+        a2a_text: str | None = None
+        task = _a2a_task(event)
+        if task is not None:
+            state, a2a_text = _a2a_status(task)
+            if state in _A2A_FAILURE_STATES:
+                errors.append(f"event {index}: remote A2A task {state}")
+            if a2a_text and not partial:
+                output_parts.append(a2a_text)
+
         for part in _parts(event):
             if not isinstance(part, Mapping):
                 continue
@@ -239,6 +308,7 @@ def parse_event_stream(
                 and not partial
                 and not user_content
                 and not part.get("thought")
+                and a2a_text is None
             ):
                 output_parts.append(text)
 

--- a/docs/components/agents.md
+++ b/docs/components/agents.md
@@ -213,6 +213,20 @@ persisted.
 > means `transfer_to_agent` hops and the delegate's own calls are flattened
 > together.
 
+### Remote agents
+
+A `RemoteA2aAgent` is a `BaseAgent`, so the harness drives one unmodified. What
+differs is where its answer lives. ADK attaches the raw A2A task envelope to the
+event under `custom_metadata['a2a:response']`, and the answer is that task's
+`status.message` — the `content.parts` built alongside it mirror the trailing
+artifact instead. The parser reads the envelope, and records a terminal task
+state other than completed (`failed`, `canceled`, `rejected`) on the result's
+errors, so a remote failure is not scored as an answer.
+
+The trajectory of a remote agent is empty and its token counts are `None`: the
+tool calls and LLM calls happen on the far side of the boundary and are never
+reported as ADK parts.
+
 The agent runs with the harness-owned workspace as the process working
 directory, matching the `cwd` the CLI harnesses hand their subprocess. An agent
 with filesystem tools that writes a relative path (`report.md`) therefore lands

--- a/tests/unit/agents/test_agents_adk.py
+++ b/tests/unit/agents/test_agents_adk.py
@@ -143,6 +143,52 @@ MCP_CALL_EVENT = {
     "id": "bb22",
 }
 
+# Recorded from a ``RemoteA2aAgent`` driven against a real A2A gRPC server. Note
+# that ``content.parts`` mirrors the *trailing artifact* while the answer sits in
+# ``status.message`` — the two disagree, which is the point of the fixture.
+A2A_EVENT = {
+    "content": {"parts": [{"text": "monarch node.mem = 0.97"}], "role": "model"},
+    "custom_metadata": {
+        "a2a:task_id": "494405c7-b9be-441f-beae-be07ba49b5b7",
+        "a2a:context_id": "64c847ad-f70e-42f2-b24e-2b88e3550780",
+        "a2a:request": {
+            "messageId": "6bbd7789-6c50-49bf-a713-6f83a37f4f58",
+            "role": "ROLE_USER",
+            "parts": [{"text": "Diagnose b/123", "metadata": {"is_user_input": True}}],
+        },
+        "a2a:response": {
+            "id": "494405c7-b9be-441f-beae-be07ba49b5b7",
+            "contextId": "64c847ad-f70e-42f2-b24e-2b88e3550780",
+            "status": {
+                "state": "TASK_STATE_COMPLETED",
+                "message": {
+                    "messageId": "587e9b357eb547629ef6d675a01d60b5",
+                    "role": "ROLE_AGENT",
+                    "parts": [{"text": "RCA: node memory pressure evicted the pod."}],
+                },
+                "timestamp": "2026-09-11T16:47:45.085206Z",
+            },
+            "artifacts": [
+                {
+                    "artifactId": "5d57761d-7b73-4100-8457-d26419e3b0a8",
+                    "name": "triage_agent",
+                    "parts": [{"text": "matched skill gke-node-pressure"}],
+                    "metadata": {"sub_agent": "triage_agent"},
+                },
+                {
+                    "artifactId": "c829905b-dccf-475f-8e22-f4368ee8fca9",
+                    "name": "diagnostic_agent",
+                    "parts": [{"text": "monarch node.mem = 0.97"}],
+                    "metadata": {"sub_agent": "diagnostic_agent"},
+                },
+            ],
+        },
+    },
+    "invocation_id": "e-efdd3f9c",
+    "author": "pathfinder_remote",
+    "id": "0a2db279",
+}
+
 
 # --------------------------------------------------------------------------
 # parse_event_stream
@@ -300,6 +346,60 @@ def test_parse_event_stream_clamps_over_reported_cache_read() -> None:
     _, _, tokens, _ = parsing.parse_event_stream([event])
 
     assert tokens["input"] == 0
+
+
+def test_parse_event_stream_prefers_the_a2a_status_message() -> None:
+    output, trajectory, _, errors = parsing.parse_event_stream([A2A_EVENT])
+
+    assert output == "RCA: node memory pressure evicted the pod."
+    assert trajectory == []
+    assert errors == []
+
+
+def test_parse_event_stream_reports_a_failed_a2a_task() -> None:
+    event = copy.deepcopy(A2A_EVENT)
+    status = event["custom_metadata"]["a2a:response"]["status"]
+    status["state"] = "TASK_STATE_FAILED"
+    status["message"]["parts"] = [{"text": "monarch is unreachable"}]
+
+    output, _, _, errors = parsing.parse_event_stream([event])
+
+    assert output == "monarch is unreachable"
+    assert errors == ["event 0: remote A2A task failed"]
+
+
+def test_parse_event_stream_accepts_a_lowercase_a2a_state() -> None:
+    """The pydantic A2A types spell the enum ``rejected``, the proto ones don't."""
+    event = copy.deepcopy(A2A_EVENT)
+    event["custom_metadata"]["a2a:response"]["status"]["state"] = "rejected"
+
+    _, _, _, errors = parsing.parse_event_stream([event])
+
+    assert errors == ["event 0: remote A2A task rejected"]
+
+
+def test_parse_event_stream_falls_back_to_content_without_a_status_message() -> None:
+    """A task still working carries no status message; the event text is all there is."""
+    event = copy.deepcopy(A2A_EVENT)
+    event["custom_metadata"]["a2a:response"]["status"] = {"state": "TASK_STATE_WORKING"}
+
+    output, _, _, errors = parsing.parse_event_stream([event])
+
+    assert output == "monarch node.mem = 0.97"
+    assert errors == []
+
+
+def test_parse_event_stream_still_folds_tool_calls_on_an_a2a_event() -> None:
+    event = copy.deepcopy(A2A_EVENT)
+    event["content"]["parts"].append(CALL_EVENT["content"]["parts"][0])
+
+    output, trajectory, _, errors = parsing.parse_event_stream([event, RESPONSE_EVENT])
+
+    assert output == "RCA: node memory pressure evicted the pod."
+    assert errors == []
+    assert [(entry["name"], entry["status"]) for entry in trajectory] == [
+        ("scale_deployment", "completed")
+    ]
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What

For a remote agent (`RemoteA2aAgent`), `AgentResult.output` was the **last artifact's** text rather than the agent's answer. The bench graded the wrong text — silently, with `errors: []` and `status: success`.

The answer lives in the A2A task envelope ADK attaches at `custom_metadata['a2a:response']`, as `status.message`. The `content.parts` ADK builds alongside it mirror the trailing artifact. The parser only read `content.parts`.

In the recorded event the two disagree:

| Field | Text |
| --- | --- |
| `status.message.parts[0].text` | `RCA: node memory pressure evicted the pod.` — the answer |
| `content.parts[0].text` | `node-1 mem = 0.97` — the trailing artifact |

Reproduced with `use_legacy` both true and false, so this is consistent behaviour rather than a legacy quirk.

## Change

Parser-only, in `devops_bench/agents/adk/parsing.py`. The task's state now decides what reaches `output`:

| Task state | What becomes the answer |
| --- | --- |
| `completed` | `status.message` — falling back to the event text when the task carries no message |
| `failed` / `canceled` / `rejected` | Nothing. The failure is recorded on `errors` instead |
| anything else (`working`, `input_required`, …) | The event's own text, as before |

`function_call` / `function_response` parts on the same event are still folded into the trajectory normally.

## Compatibility

A local agent's events carry no `a2a:response`, so nothing about them changes.

<details>
<summary><b>Why the state has to gate both halves of the event</b></summary>

**Only `completed` carries an answer.** ADK also emits streaming updates with a status message — `working` most often, and `input_required` / `auth_required` are no more final — and that text is progress commentary. Appending it would put narration ahead of the real answer in the output the judge grades.

**A failure needs both halves suppressed, not just the status message.** The message is a failure notice, and the `content.parts` mirror the trailing artifact — so letting the event text fall through as usual would reinstate the original bug for exactly the runs that have no answer at all. The record is still written as `status: "success"` and scored, so whatever reaches `output` is graded as the response.

**States are normalized before the lookup.** The proto types spell the enum `TASK_STATE_FAILED`; the pydantic ones spell it `failed`.

</details>

## Testing

`uv run pytest -q` — 1379 passed. Seven tests cover this path: the status message preferred over the artifact, each failure state contributing nothing (parametrized over all three), a completed task with no status message falling back to the event text, a lowercase state spelling, a `working` event left alone, and tool calls still folded on an A2A event. Four fail on `main`.

The fixture is shaped after a real `RemoteA2aAgent` run against an A2A gRPC server (`GrpcHandler` + `grpc.aio`, AgentCard advertising the GRPC binding), with the payload text replaced by neutral stand-ins.

`docs/components/agents.md` gains a "Remote agents" subsection: where the answer lives, and why a remote agent's trajectory is normally empty with token counts `None`.

`uv run ruff check devops_bench tests` and `ruff format --check` clean.

## Context

First of the follow-ups tracked in #138, and the only one that silently corrupts results. The rest — declaring the `a2a` extra (#171), building the A2A client from config (#172), and sub-agent attribution (#165) — are separate PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Completed remote agent tasks now use the authoritative task status message when available.
  - Non-terminal updates use regular event content instead of being treated as final answers.
  - Failed, canceled, and rejected tasks are reported as errors, with their artifacts excluded from output.
  - Completed tasks fall back to event content when no status message is provided.
  - Tool-call details remain supported during remote agent event processing.

- **Documentation**
  - Added guidance on remote agent responses, task statuses, trajectories, and token reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
