### PR TITLE
fix(agents): send agy a model id it accepts

### DIFF
--- a/devops_bench/agents/cli/antigravity/agent.py
+++ b/devops_bench/agents/cli/antigravity/agent.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import os
 import pathlib
+import re
 import shutil
 import time
 from typing import TYPE_CHECKING
@@ -77,12 +78,81 @@ def _read_db_tokens(db_path: pathlib.Path) -> dict | None:
     return None
 
 
-def _resolve_model_name(model: str) -> str:
-    """Resolve a provider-qualified model id to the bare name ``agy`` expects.
+# agy names the reasoning tier separately from the model: every selection in its
+# catalogue is a base model plus one of these, and there is no untiered form --
+# a bare slug is refused with "requires --effort".
+_AGY_EFFORT_TIERS = ("low", "medium", "high")
 
-    e.g. ``"google/gemini-3.5-flash"`` -> ``"gemini-3.5-flash"``.
+# Vertex publishes preview model ids with this suffix. agy's catalogue does not
+# carry it and rejects the suffixed id outright, with or without --effort.
+_VERTEX_PREVIEW_SUFFIX = "-preview"
+
+# A display-name selection ("Gemini 3.1 Pro (Low)") already names its tier, and
+# agy errors if --effort is passed alongside one. Recognize it so it survives
+# untouched: it is the spelling ``agy --help`` steers operators towards.
+_DISPLAY_TIER_RE = re.compile(r"\((?:low|medium|high)\)\s*$", re.IGNORECASE)
+
+# The tier is a scoring variable, not a formatting detail -- `low` and `high`
+# are materially different agents. `high` is the least surprising default
+# because the other harnesses run their model with no reasoning throttle, so
+# anything lower would hand the agy arm a handicap that reads as a capability
+# gap in the results rather than as the configuration choice it is.
+_DEFAULT_AGY_EFFORT = "high"
+_EFFORT_ENV = "AGENT_MODEL_EFFORT"
+
+
+def _default_effort() -> str:
+    """Resolve the reasoning tier to request when the model id names none.
+
+    Returns:
+        The tier from ``AGENT_MODEL_EFFORT``, or ``high``.
+
+    Raises:
+        core.ConfigError: If ``AGENT_MODEL_EFFORT`` names an unknown tier.
+            Rejected here rather than passed through, so a typo fails on the
+            misconfiguration itself instead of surfacing seconds later as agy's
+            own startup error in the middle of a scored arm.
     """
-    return model.split("/")[-1]
+    effort = os.environ.get(_EFFORT_ENV, "").strip()
+    if not effort:
+        return _DEFAULT_AGY_EFFORT
+    if effort.lower() not in _AGY_EFFORT_TIERS:
+        raise core.ConfigError(
+            f"{_EFFORT_ENV}={effort!r} is not a reasoning tier agy accepts "
+            f"(known: {', '.join(_AGY_EFFORT_TIERS)})"
+        )
+    return effort.lower()
+
+
+def _resolve_model_name(model: str) -> tuple[str, str | None]:
+    """Resolve a matrix model id to the ``(model, effort)`` pair ``agy`` expects.
+
+    ``AGENT_MODEL`` is one value shared by every arm and by the judge, and it is
+    spelled for Vertex -- ``google/gemini-3.1-pro-preview``. agy accepts neither
+    the provider prefix nor the ``-preview`` suffix, and refuses any selection
+    that does not name a reasoning tier exactly once. Normalizing here confines
+    the quirk to the one harness that has it; respelling ``AGENT_MODEL`` instead
+    would desynchronize the agy arm's label from every other arm in the matrix.
+
+    e.g. ``"google/gemini-3.1-pro-preview"`` -> ``("gemini-3.1-pro", "high")``.
+
+    Args:
+        model: The configured model id, optionally provider-qualified.
+
+    Returns:
+        The id to pass as ``--model``, and the tier to pass as ``--effort`` --
+        or ``None`` for the tier when the id already names its own, in which
+        case ``--effort`` must be omitted or agy rejects the pair.
+    """
+    name = model.split("/")[-1].strip()
+    if _DISPLAY_TIER_RE.search(name):
+        return name, None
+    if name.endswith(_VERTEX_PREVIEW_SUFFIX):
+        name = name[: -len(_VERTEX_PREVIEW_SUFFIX)]
+    for tier in _AGY_EFFORT_TIERS:
+        if name.lower().endswith(f"-{tier}"):
+            return name[: -len(tier) - 1], tier
+    return name, _default_effort()
 
 
 def _build_settings(
@@ -93,7 +163,16 @@ def _build_settings(
     *,
     skills_enabled: bool = False,
 ) -> dict:
-    """Assemble the Antigravity ``settings.json`` payload for a run."""
+    """Assemble the Antigravity ``settings.json`` payload for a run.
+
+    ``model`` must already be the resolved spelling from
+    ``_resolve_model_name``, identical to the one passed as ``--model``. agy
+    does not validate ``defaultModel`` -- an unknown value there is ignored in
+    silence and the run falls back to a default model -- so the flag's loud
+    validation is the only guard, and it only guards a value settings agrees
+    with. The tier is deliberately not written here: it rides on ``--effort``,
+    and agy exposes no verified settings key for it.
+    """
     settings: dict = {}
     servers = cli_capabilities.build_mcp_servers(mcp_servers)
     if servers:
@@ -101,7 +180,7 @@ def _build_settings(
     if skills_enabled:
         settings["experimental"] = {"skills": True}
     if model:
-        settings["modelConfigs"] = {"defaultModel": _resolve_model_name(model)}
+        settings["modelConfigs"] = {"defaultModel": model}
 
     # Add GCP block if project/location are provided (needed for GCA/GKE tools)
     if project or location:
@@ -132,8 +211,11 @@ def _build_env(config: agents_config.AgentConfig) -> dict[str, str]:
     if config.api_key:
         overlay["GEMINI_API_KEY"] = config.api_key
         overlay["GOOGLE_API_KEY"] = config.api_key
-    if config.model:
-        overlay["GEMINI_MODEL"] = _resolve_model_name(config.model)
+
+    # No GEMINI_MODEL here. It is a Gemini CLI variable; agy ignores it
+    # entirely -- verified against 1.2.0, where a garbage value raises no error
+    # and a valid one does not change the model the run reports. The model
+    # travels on --model, which is also the only spelling agy validates.
 
     if config.extra_env:
         overlay.update(config.extra_env)
@@ -206,6 +288,21 @@ class AgyCliAgent(base.AgentHarness):
         caps = self.config.capabilities
         binary = self._resolve_binary()
 
+        # Resolved once so the --model flag and settings.json cannot disagree,
+        # and before any workspace is built so a bad AGENT_MODEL_EFFORT fails
+        # here rather than after the run has started costing something.
+        model_name: str | None = None
+        effort: str | None = None
+        if self.config.model:
+            model_name, effort = _resolve_model_name(self.config.model)
+            if model_name != self.config.model:
+                _log.warning(
+                    "agy does not accept the configured model id %r; running --model %s%s",
+                    self.config.model,
+                    model_name,
+                    f" --effort {effort}" if effort else "",
+                )
+
         env_overlay = _build_env(self.config)
 
         with cli_capabilities.agent_workdir(workspace_path, prefix="agy-run-") as workdir:
@@ -246,8 +343,12 @@ class AgyCliAgent(base.AgentHarness):
             ]
             if project:
                 argv.append(f"--project={project}")
-            if self.config.model:
-                argv.append(f"--model={_resolve_model_name(self.config.model)}")
+            if model_name:
+                argv.append(f"--model={model_name}")
+                # Omitted when the id already names its tier: agy rejects the
+                # two spellings together.
+                if effort:
+                    argv.append(f"--effort={effort}")
             if self.config.extra_flags:
                 argv.extend(self.config.extra_flags)
             argv.append(f"--prompt={prompt}")
@@ -267,7 +368,7 @@ class AgyCliAgent(base.AgentHarness):
 
             settings = _build_settings(
                 caps.mcp_servers,
-                self.config.model,
+                model_name,
                 project,
                 location,
                 skills_enabled=bool(skill_names),

--- a/docs/components/agents.md
+++ b/docs/components/agents.md
@@ -92,7 +92,8 @@ each harness maps them onto its target.
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `AGENT_MODEL` | unset | Model id; flows to the harness's target. |
+| `AGENT_MODEL` | unset | Model id; flows to the harness's target. See [agy model ids](#agy-model-ids) for the one harness that rewrites it. |
+| `AGENT_MODEL_EFFORT` | `high` | Reasoning tier for `antigravity`; ignored by every other harness. One of `low`, `medium`, `high` — an unknown value is rejected rather than passed through. |
 | `AGENT_PROVIDER` | unset | Provider key (e.g. `gemini`, `anthropic`, `google-vertex`). |
 | `AGENT_API_KEY` | unset | Routed onto the provider's key env var(s) via the shared contract; omitted for keyless backends (Vertex/Bedrock ADC). |
 | `AGENT_TARGET` | unset | Path to the CLI binary (`gemini` / `oc`). For `adk`, the **import target** of the agent to run (see below); required there. Ignored by `api`. |
@@ -108,6 +109,29 @@ each harness maps them onto its target.
 | `AGENT_ALLOWED_TOOLS` | unset | CSV of pre-approved tool names. |
 | `AGENT_SKILLS_PATHS` | unset | CSV of directories to discover `SKILL.md` files under. |
 | `AGENT_RULES_TEXT` | unset | Operator-brief text handed to the agent. |
+
+### agy model ids
+
+`AGENT_MODEL` is a single value shared by every arm and by the judge, and it is
+normally spelled for Vertex — `gemini-3.1-pro-preview`. The `antigravity`
+harness is the one exception: `agy` does not recognise the `-preview` suffix,
+and it refuses any selection that does not name a reasoning tier exactly once.
+Left alone it exits with `invalid model selection` before the run starts.
+
+So the harness rewrites the id rather than requiring the matrix to respell it —
+respelling `AGENT_MODEL` for that one arm would desynchronise its label from
+every other arm in the same run. `google/gemini-3.1-pro-preview` becomes
+`--model gemini-3.1-pro --effort high`, and the rewrite is logged.
+
+The tier is a scoring variable, not a formatting detail: `low` and `high` are
+materially different agents. `high` is the default because the other harnesses
+run their model with no reasoning throttle. Override it with
+`AGENT_MODEL_EFFORT`.
+
+A tier already spelled into `AGENT_MODEL` is honoured and nothing is added —
+both `gemini-3.1-pro-low` and the display-name form `Gemini 3.1 Pro (Low)`
+work. In that case `AGENT_MODEL_EFFORT` is ignored and no `--effort` is passed,
+because `agy` rejects a tiered id and the flag together.
 
 ### Example: gemini CLI with MCP + skills
 

--- a/tests/unit/agents/test_agents_cli_antigravity.py
+++ b/tests/unit/agents/test_agents_cli_antigravity.py
@@ -22,12 +22,14 @@ import sqlite3
 from types import SimpleNamespace
 from unittest import mock
 
+import pytest
+
 from devops_bench.agents import capabilities
 from devops_bench.agents import config as agents_config
 from devops_bench.agents.cli.antigravity import agent as agy_mod
 from devops_bench.agents.cli.antigravity import parsing
 from devops_bench.core import subprocess as devops_subprocess
-from devops_bench.core.errors import SubprocessError
+from devops_bench.core.errors import ConfigError, SubprocessError
 
 
 def _jsonl(*records: dict) -> str:
@@ -300,7 +302,7 @@ def test_parse_transcript_jsonl_marks_trailing_pending_calls_as_interrupted():
 def test_build_settings_renders_mcp_and_model():
     mcp = capabilities.McpBinding(name="gke", command=("gke-mcp", "run"))
     settings = agy_mod._build_settings(
-        (mcp,), "google/gemini-3.5-flash", "my-project", "us-east1", skills_enabled=True
+        (mcp,), "gemini-3.5-flash", "my-project", "us-east1", skills_enabled=True
     )
 
     assert settings["experimental"]["skills"] is True
@@ -316,7 +318,7 @@ def test_build_settings_renders_mcp_and_model():
 
 
 def test_build_settings_omits_skills_block_when_disabled():
-    settings = agy_mod._build_settings((), "google/gemini-3.5-flash")
+    settings = agy_mod._build_settings((), "gemini-3.5-flash")
 
     assert "experimental" not in settings
     # No mcp servers, project, or location either: only modelConfigs remains.
@@ -334,17 +336,74 @@ def test_build_env_sets_auth_and_presets():
     assert env["GEMINI_CLI_TRUST_WORKSPACE"] == "true"
     assert env["GEMINI_API_KEY"] == "secret-key"
     assert env["GOOGLE_API_KEY"] == "secret-key"
-    assert env["GEMINI_MODEL"] == "gemini-3.5-flash"
     assert env["OTEL_SDK_DISABLED"] == "true"
 
 
-def test_build_env_resolves_provider_qualified_model_name():
-    # GEMINI_MODEL must match the bare id used by --model= and modelConfigs,
-    # not the raw "provider/model" form.
+def test_build_env_does_not_set_gemini_model():
+    # GEMINI_MODEL is a Gemini CLI variable that agy ignores: setting it
+    # suggests a lever that does not exist. The model travels on --model.
     config = agents_config.AgentConfig(model="google/gemini-3.5-flash")
     env = agy_mod._build_env(config)
 
-    assert env["GEMINI_MODEL"] == "gemini-3.5-flash"
+    assert "GEMINI_MODEL" not in env
+
+
+class TestResolveModelName:
+    """agy takes an untiered slug plus --effort, and rejects Vertex spellings."""
+
+    def test_strips_provider_prefix_and_preview_suffix(self):
+        # What the matrix actually sends: one AGENT_MODEL shared with the
+        # judge, spelled for Vertex, which requires the -preview agy rejects.
+        assert agy_mod._resolve_model_name("google/gemini-3.1-pro-preview") == (
+            "gemini-3.1-pro",
+            "high",
+        )
+
+    def test_supplies_default_tier_when_id_names_none(self):
+        # agy has no untiered form; a bare slug is refused outright.
+        assert agy_mod._resolve_model_name("gemini-3.8-flash") == ("gemini-3.8-flash", "high")
+
+    def test_splits_a_tier_spelled_into_the_slug(self):
+        assert agy_mod._resolve_model_name("gemini-3.8-flash-medium") == (
+            "gemini-3.8-flash",
+            "medium",
+        )
+
+    def test_display_name_keeps_its_own_tier_and_takes_no_effort_flag(self):
+        # agy errors when --effort accompanies a parenthesised tier, so the
+        # resolver must report None rather than the default.
+        assert agy_mod._resolve_model_name("Gemini 3.1 Pro (Low)") == (
+            "Gemini 3.1 Pro (Low)",
+            None,
+        )
+
+    def test_display_name_tier_match_is_case_insensitive(self):
+        assert agy_mod._resolve_model_name("GEMINI 3.1 PRO (HIGH)") == (
+            "GEMINI 3.1 PRO (HIGH)",
+            None,
+        )
+
+
+class TestDefaultEffort:
+    """The tier is a scoring variable, so it is explicit and validated."""
+
+    def test_defaults_to_high(self, monkeypatch):
+        monkeypatch.delenv(agy_mod._EFFORT_ENV, raising=False)
+
+        assert agy_mod._default_effort() == "high"
+
+    def test_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv(agy_mod._EFFORT_ENV, "Low")
+
+        assert agy_mod._default_effort() == "low"
+
+    def test_unknown_tier_is_rejected(self, monkeypatch):
+        # Fail on the typo, not seconds later on agy's own startup error in
+        # the middle of a scored arm.
+        monkeypatch.setenv(agy_mod._EFFORT_ENV, "maximum")
+
+        with pytest.raises(ConfigError, match="maximum"):
+            agy_mod._default_effort()
 
 
 @mock.patch.object(pathlib.Path, "home")


### PR DESCRIPTION
Every `agy` run dies at startup with `invalid model selection`. This is **not sandbox-specific** — an ambient, un-sandboxed run fails identically, and has since the harness was written. It stayed latent because agy had no exercised arm to fail in.

> Staged on the `pradeepvrd/devops-bench` integration fork as pradeepvrd/devops-bench#28. Independent of the sandbox stack and of the image PR #161.

## The incident

Sandbox validation run on the bastion, 2026-09-10 ~16:19Z, agy 1.2.0, sandboxed GKE run:

```
error: invalid model selection (--model "gemini-3.1-pro-preview" --effort ""):
model gemini-3.1-pro-preview is not recognized as a known model or custom model in settings
```

Exit 1 in roughly two seconds, no conversation DB, no transcript. That arm was then validated under the display-name spelling `AGENT_MODEL="Gemini 3.1 Pro (Low)"` as a workaround, which is why that run's model label does not match the rest of the matrix — and why it is evidence for the sandbox seam, not a comparable agent-quality result.

## Root cause

`AGENT_MODEL` is a single global value shared by every arm and by the judge (`scripts/bastion/vm-setup.sh:209` = `gemini-3.1-pro-preview`), spelled for Vertex, which *requires* the `-preview` suffix.

`_resolve_model_name` only stripped a provider prefix, so the Vertex id reached agy's command line verbatim.

## What agy 1.2.0 actually accepts

No `-preview` suffix, and a reasoning tier named **exactly once** — as `--effort`, a slug suffix, or a display-name parenthetical.

| spelling | result |
| --- | --- |
| `gemini-3.1-pro-preview` (what the matrix sends) | rejected — unrecognized |
| `gemini-3.1-pro-preview --effort=low` | rejected — `--effort is not supported` |
| `gemini-3.1-pro` | rejected — `requires --effort (available: low, high)` |
| `gemini-3.1-pro --effort=low` | **ok** — canonical form |
| `gemini-3.8-flash --effort=medium` | **ok** |
| `gemini-3.1-pro-low` | **ok** |
| `Gemini 3.1 Pro (Low)` | **ok**, case-insensitive |
| `Gemini 3.1 Pro (Low) --effort=low` | rejected — collides |

The catalogue is 11 selections: `Gemini 3.8/3.7/3.6 Flash (High|Medium|Low)` and `Gemini 3.1 Pro (High|Low)`. Everything is Flash except the two Pro entries. Any `gemini-2.5-*` id is rejected outright.

## The fix

Normalise inside the antigravity harness. Respelling `AGENT_MODEL` for the agy arm instead would desynchronise that arm's label from every other arm in the same matrix, and Vertex needs exactly the suffix agy rejects — so the quirk belongs in the one harness that has it.

`google/gemini-3.1-pro-preview` → `--model gemini-3.1-pro --effort high`, logged when the rewrite happens.

Emitting the bare slug plus `--effort`, rather than reassembling `gemini-3.1-pro-low`, is the one form that cannot collide. No lookup table, so nothing to maintain as the catalogue grows — agy validates the result and still fails loud on anything it does not know.

A tier already spelled into the id is honoured and nothing is added, so the display-name workaround above keeps working.

### The tier is a scoring variable

agy has no untiered form, so the harness must supply one when `AGENT_MODEL` carries none — which is always, today. `low` versus `high` is a materially different agent, so choosing quietly would make the agy arm a different experiment than the arm it is compared against.

Default `high`, since the other harnesses run their model with no reasoning throttle and anything lower would hand agy a handicap that reads as a capability gap. Overridable via `AGENT_MODEL_EFFORT`, with an unknown tier rejected on the spot rather than passed through to fail later as agy's own error mid-arm — reject at load, not at use.

### settings.json now agrees with the flag

`modelConfigs.defaultModel` carries the same resolved spelling as `--model`.

Worth stating plainly, because it is a trap: **agy does not validate `defaultModel`.** An unknown value there is ignored in silence and the run falls back to another model — verified, a garbage value runs happily and self-reports as Gemini 3.8 Flash. The `--model` flag is the only validation there is, so it should not be guarding a value that settings quietly contradicts, and it should not be dropped as redundant later.

### GEMINI_MODEL removed

`_build_env` set it; **agy ignores it entirely**. Verified: a garbage value raises no error, and a valid `gemini-3.1-pro-low` does not change the model the run reports — identical to the no-env control. Copy-paste from the gemini_cli harness. It looked like a lever and was not.

## Verification

Unit suite green on this branch (1364 passed), ruff check and format clean. New coverage over the resolver table above, including the collision case, the display-name pass-through, and load-time rejection of an unknown `AGENT_MODEL_EFFORT`.

Every spelling in the table was exercised against agy 1.2.0 on the bastion, in the pinned image from #161, under the sandbox executor's real invocation (`--user <uid>:<gid>`, `HOME` on the workspace mount, metadata endpoint unreachable).

## Not in this PR

The `_resolve_binary` host-path leak into container argv — that belongs with the sandbox boundary that creates it, and is held in the harness-wiring PR staged as pradeepvrd/devops-bench#14.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Antigravity now supports configurable model reasoning effort through `AGENT_MODEL_EFFORT`.
  * Provider-qualified and preview model IDs are normalized automatically for compatible CLI usage.
  * Explicit model tiers are preserved, with a default effort level applied when none is specified.
  * Invalid effort values are rejected with a configuration error.

* **Documentation**
  * Added guidance on supported effort values, validation behavior, and model ID rewriting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->