### PR TITLE
build(docker): add the Antigravity CLI sandbox image

### DIFF
--- a/docker/Dockerfile.antigravity
+++ b/docker/Dockerfile.antigravity
@@ -1,0 +1,94 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sandbox image for the Antigravity CLI agent harness (BENCH_SANDBOX_IMAGE).
+#
+# One image per harness: a CLI version bump here must not invalidate the A/B
+# baselines of the other agents under test, so the images are deliberately not
+# a shared multi-stage build with per-agent targets.
+#
+# Contents are the tools a task may legitimately need inside the boundary. The
+# agent's cluster credential, workspace, and fixtures are mounted at run time
+# by devops_bench/agents/sandbox.py — never baked in here. Nor is the OAuth
+# token the CLI authenticates with: the harness copies that into the per-run
+# workspace and points agy at it with --gemini_dir, so it arrives on the
+# workspace mount and is deleted when the run ends.
+
+# node, not plain debian: agy itself is a static-ish Go binary and needs no
+# runtime, but MCP server bindings are conventionally launched with npx, and a
+# task that declares one would otherwise fail inside the boundary.
+FROM node:22-slim
+
+# Versions are pinned so a rebuild reproduces the image an A/B arm was scored
+# with; bump them deliberately and re-baseline.
+ARG KUBECTL_VERSION=v1.31.0
+ARG HELM_VERSION=v3.16.3
+# AGY_BUILD is the build id that follows the version in the release path; the
+# two together address one immutable artifact.
+ARG AGY_VERSION=1.2.0
+ARG AGY_BUILD=5210873191596032
+ARG AGY_SHA512_AMD64=d190b25a04ed2a03b0587838476494ae59d0d324ee6373263cabe584352c254f9051f3689c79ac4add8817ff6eb34b11694acd77002c55e91bd1d28b6dfdae22
+ARG AGY_SHA512_ARM64=5ad72fba8c8e915c59c5505dc99116058352b8eba7f141d7ed220256788bada30df8b5af65c0d931ff10bbc661c0f5fe83931c58071fe3063a809bbeda7f59f9
+
+# Modern Git comes from backports for reftable support; ripgrep and jq are
+# what the agent's own search and JSON handling reach for.
+RUN echo "deb http://deb.debian.org/debian bookworm-backports main" > /etc/apt/sources.list.d/backports.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        jq \
+        ripgrep \
+    && apt-get install -y -t bookworm-backports --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+# kubectl and helm: resolve the arch from the build platform rather than
+# hardcoding amd64, so the image builds on an arm64 laptop as well as the
+# x86 bastion.
+RUN arch="$(dpkg --print-architecture)" \
+    && curl -fsSLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl \
+    && rm kubectl \
+    && curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-${arch}.tar.gz" \
+        | tar -xz -C /tmp \
+    && install -o root -g root -m 0755 "/tmp/linux-${arch}/helm" /usr/local/bin/helm \
+    && rm -rf "/tmp/linux-${arch}"
+
+# The upstream bootstrapper (https://antigravity.google/cli/install.sh) is
+# deliberately not piped to a shell here. It resolves whatever the release
+# manifest calls *latest*, which defeats the pinning above; it also installs
+# into $HOME and then rewrites shell profiles, both meaningless in an image
+# whose HOME is container-owned and replaced per run. What it does that we do
+# keep is the sha512 check, so a tampered or truncated payload fails the build
+# rather than silently scoring a run.
+#
+# Release paths are inconsistent between arches upstream (linux-x64 vs
+# linux-arm, cli_linux_x64 vs cli_linux_arm64), hence the explicit mapping
+# rather than a substitution. The archive member is named `antigravity`; it is
+# installed as `agy` because that is the name the harness invokes and, inside
+# the boundary, the image resolves argv[0].
+RUN arch="$(dpkg --print-architecture)" \
+    && case "${arch}" in \
+        amd64) agy_path="linux-x64/cli_linux_x64.tar.gz"; agy_sha="${AGY_SHA512_AMD64}" ;; \
+        arm64) agy_path="linux-arm/cli_linux_arm64.tar.gz"; agy_sha="${AGY_SHA512_ARM64}" ;; \
+        *) echo "unsupported architecture for the Antigravity CLI: ${arch}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL -o /tmp/agy.tar.gz \
+        "https://storage.googleapis.com/antigravity-public/antigravity-cli/${AGY_VERSION}-${AGY_BUILD}/${agy_path}" \
+    && echo "${agy_sha}  /tmp/agy.tar.gz" | sha512sum -c - \
+    && tar -xzf /tmp/agy.tar.gz -C /tmp antigravity \
+    && install -o root -g root -m 0755 /tmp/antigravity /usr/local/bin/agy \
+    && rm -f /tmp/agy.tar.gz /tmp/antigravity \
+    && agy --version
+
+WORKDIR /workspace


### PR DESCRIPTION
Adds `docker/Dockerfile.antigravity`. One file, no code changes.

> Staged on the `pradeepvrd/devops-bench` integration fork as pradeepvrd/devops-bench#27, where the sandbox seam it serves is already merged. The upstream PRs for that seam follow separately; this image is inert until they land, but it is independently reviewable and the pin is worth freezing now.

The sandbox seam documents an image contract — ship `docker/Dockerfile.<name>` carrying the shared tool floor with the CLI version-pinned and installed under **the exact binary name the harness invokes** — but no antigravity image existed, so `agy` had no sandboxed arm at all.

Deliberately not stacked on the harness-wiring PR (staged as pradeepvrd/devops-bench#14): it adds no Python and changes no behaviour, so it can land independently. `Dockerfile.openclaw` belongs to the openclaw image PR (staged as pradeepvrd/devops-bench#19) and is untouched here.

## Why the upstream installer is not piped to a shell

`curl -fsSL https://antigravity.google/cli/install.sh | bash` is the documented install path, and it is the wrong thing for an image:

- It resolves whatever the release manifest calls **latest**, which defeats pinning. A CLI bump would silently invalidate the A/B baseline a run was scored against.
- It installs into `$HOME` and rewrites shell profiles, both meaningless in an image whose `HOME` is container-owned and replaced per run.

What it does that is worth keeping is the sha512 check, so that is done inline against the pinned artifact: a tampered or truncated payload fails the build rather than quietly scoring a run.

Release paths are inconsistent between arches upstream (`linux-x64/cli_linux_x64.tar.gz` vs `linux-arm/cli_linux_arm64.tar.gz`), hence an explicit mapping rather than a substitution. The archive member is named `antigravity`; it is installed as `agy`, which is the name the harness spells.

`node:22-slim` rather than plain debian: agy is a Go binary and needs no runtime, but MCP server bindings are conventionally launched with `npx`, and a task declaring one would otherwise fail inside the boundary.

## Live validation

On the bastion, against the sandbox executor's real invocation — `--user <uid>:<gid>`, `HOME` on the workspace mount, and `GCE_METADATA_HOST` pointed at a dead port.

| stage | result |
| --- | --- |
| `DOCKER-USER` REJECT to `169.254.169.254` | present, rule 3 |
| metadata from inside a container | `http=000` |
| **control** — token removed from the mount | fails, `Authentication required` |
| **E2E** — OAuth token on the workspace mount | real completion |
| tool floor | `agy kubectl helm jq git rg node npx` all resolve |
| `npx` under the mapped uid | works |
| image size | 892 MB |

The control and the E2E differ only in whether the token is on the mount, so the pass exercises the credential path rather than an ambient one.

Two image requirements that were suspected and are **not** real, recorded so they are not re-litigated: the mapped uid needs no `/etc/passwd` entry (`getent passwd` returns `NONE` and agy does not care), and `node:22-slim` is missing no shared library agy needs.

## Not in this PR

- **The `_resolve_binary` fix.** `_resolve_binary()` returns the *host* path with no container-side counterpart to openclaw's `_CONTAINER_OC_BIN`, so a host path crosses into container argv. That belongs with the boundary that creates the problem and is held in the harness-wiring PR (staged as pradeepvrd/devops-bench#14).
- **The model-id bug.** The matrix sends agy `gemini-3.1-pro-preview` (`scripts/bastion/vm-setup.sh:209`); agy rejects the `-preview` suffix and requires a reasoning tier, so every agy run exits 1 at startup. Not sandbox-specific — an ambient run fails identically, and it is present on `main` today. Fixed in the companion PR #160.

Neither blocks this image; both are needed before an agy arm scores.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a container image for running the Antigravity CLI agent harness.
  * Includes preconfigured command-line tools such as kubectl, Helm, Git, jq, ripgrep, and curl.
  * Includes the Antigravity CLI and supports architecture-specific builds with verified tool downloads.
  * Uses pinned tool versions for consistent environments.
  * Configures `/workspace` as the working directory without embedding authentication or workspace data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->