### PR TITLE
fix(agents): default the CLI harnesses' Vertex location to global

### DIFF
--- a/devops_bench/agents/cli/antigravity/agent.py
+++ b/devops_bench/agents/cli/antigravity/agent.py
@@ -234,6 +234,10 @@ class AgyCliAgent(base.AgentHarness):
             # chain is empty.
             location = vertex_location(fallback=_get_gcloud_location)
             env_overlay["GOOGLE_CLOUD_LOCATION"] = location
+            # Written but deliberately not *read* back (see vertex_env): agy's
+            # own GCP tooling has always been handed this spelling, and dropping
+            # it is a behavior change for the binary, not a routing fix. It only
+            # ever reaches the agy subprocess, never the deployers.
             env_overlay["GCP_LOCATION"] = location
 
             # Explicit gemini_dir keeps agy on the workspace settings, not real HOME.

--- a/devops_bench/agents/cli/antigravity/agent.py
+++ b/devops_bench/agents/cli/antigravity/agent.py
@@ -29,6 +29,7 @@ from devops_bench.agents import config as agents_config
 from devops_bench.agents import result as agents_result
 from devops_bench.agents.cli.antigravity import parsing
 from devops_bench.agents.shared import cli_capabilities
+from devops_bench.agents.shared.vertex_env import vertex_location
 from devops_bench.core import subprocess as devops_subprocess
 
 if TYPE_CHECKING:
@@ -228,15 +229,12 @@ class AgyCliAgent(base.AgentHarness):
                 env_overlay["GOOGLE_CLOUD_PROJECT"] = project
                 env_overlay["GCP_PROJECT"] = project
 
-            location = (
-                os.environ.get("GOOGLE_CLOUD_LOCATION")
-                or os.environ.get("GCP_LOCATION")
-                or _get_gcloud_location()
-                or "us-central1"
-            )
-            if location:
-                env_overlay["GOOGLE_CLOUD_LOCATION"] = location
-                env_overlay["GCP_LOCATION"] = location
+            # Shared with the Gemini CLI harness so the two cannot drift; the
+            # gcloud lookup stays a lazy fallback, consulted only when the env
+            # chain is empty.
+            location = vertex_location(fallback=_get_gcloud_location)
+            env_overlay["GOOGLE_CLOUD_LOCATION"] = location
+            env_overlay["GCP_LOCATION"] = location
 
             # Explicit gemini_dir keeps agy on the workspace settings, not real HOME.
             argv = [

--- a/devops_bench/agents/cli/gemini_cli/agent.py
+++ b/devops_bench/agents/cli/gemini_cli/agent.py
@@ -47,6 +47,7 @@ from devops_bench.agents.shared.cli_capabilities import (
     build_mcp_servers,
     materialize_skills,
 )
+from devops_bench.agents.shared.vertex_env import vertex_location
 from devops_bench.core import SubprocessError, get_logger
 from devops_bench.core.model_providers import resolve_provider
 from devops_bench.core.subprocess import run
@@ -151,7 +152,13 @@ def _build_env(config: AgentConfig) -> dict[str, str]:
     ``config.model`` onto ``GEMINI_MODEL``. OTLP telemetry exporters are disabled
     so they don't hang on broken endpoints. The model is never hardcoded; it
     flows from ``config.model``. A keyless backend (e.g. Vertex/ADC) writes no
-    key.
+    key. A Vertex backend additionally writes the google-genai routing vars
+    (``GOOGLE_GENAI_USE_VERTEXAI`` plus project/location), since the SDK
+    otherwise talks to the Gemini API regardless of the configured provider. The
+    location comes from the shared
+    :func:`~devops_bench.agents.shared.vertex_env.vertex_location` chain, which
+    defaults to ``global`` — the only endpoint the ``-preview`` model ids are
+    published on.
 
     Args:
         config: Resolved :class:`AgentConfig` for this run.
@@ -173,6 +180,16 @@ def _build_env(config: AgentConfig) -> dict[str, str]:
         "OTEL_LOGS_EXPORTER": "none",
         "OTEL_SDK_DISABLED": "true",
     }
+    if spec.backend == "vertex":
+        # The google-genai SDK the CLI embeds reads these three; without the
+        # switch it defaults to the Gemini API and ignores the Vertex routing.
+        # Project/location env spellings follow the antigravity harness so an
+        # operator configures both agents the same way.
+        overlay["GOOGLE_GENAI_USE_VERTEXAI"] = "true"
+        project = os.environ.get("GOOGLE_CLOUD_PROJECT") or os.environ.get("GCP_PROJECT")
+        if project:
+            overlay["GOOGLE_CLOUD_PROJECT"] = project
+        overlay["GOOGLE_CLOUD_LOCATION"] = vertex_location()
     if config.api_key:
         for var in spec.api_key_envs:
             overlay[var] = config.api_key

--- a/devops_bench/agents/shared/vertex_env.py
+++ b/devops_bench/agents/shared/vertex_env.py
@@ -37,18 +37,23 @@ DEFAULT_VERTEX_LOCATION = "global"
 
 # Highest precedence first.
 #
+# ``GOOGLE_CLOUD_LOCATION`` is the native google-genai variable and stays on top
+# so an operator's own export always wins.
+#
 # ``GCP_VERTEX_LOCATION`` is the repo-wide spelling (models/gemini.py,
 # models/claude.py, the claude_code harness); it was missing from this chain, so
 # an operator who set the documented variable had it silently ignored here.
 #
-# ``GCP_LOCATION`` stays last and is deliberately *below* the Vertex-specific
-# name: deployers/factory.py reads it as a cluster **zone** (``us-central1-a``),
-# which is not a valid Vertex location at all. Anyone who set it for their
-# cluster should not thereby repoint model traffic.
+# ``GCP_LOCATION`` is deliberately NOT read. It belongs to the deployers, which
+# resolve it as a cluster **zone** — every place this repo sets it sets a zone
+# (scripts/bastion/vm-setup.sh, scripts/bastion/_matrix_lib.sh,
+# deployers/factory.py's ``us-central1-a`` default) and docs/components/infra.md
+# documents it as such. A zone is never a valid Vertex location, so honoring it
+# here could only ever route a run at an endpoint that does not exist. Operators
+# who want to pin a Vertex region set ``GCP_VERTEX_LOCATION``.
 VERTEX_LOCATION_ENVS = (
     "GOOGLE_CLOUD_LOCATION",
     "GCP_VERTEX_LOCATION",
-    "GCP_LOCATION",
 )
 
 

--- a/devops_bench/agents/shared/vertex_env.py
+++ b/devops_bench/agents/shared/vertex_env.py
@@ -1,0 +1,83 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Vertex routing env shared by the CLI agents (Gemini, antigravity).
+
+Both harnesses resolve the same question — which Vertex location to route a
+keyless run at — and drifted apart while doing it. One implementation here so
+they cannot drift again. Importing this module pulls no provider SDK.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from collections.abc import Callable
+
+__all__ = ["DEFAULT_VERTEX_LOCATION", "VERTEX_LOCATION_ENVS", "vertex_location"]
+
+# ``global`` rather than a region: the ``-preview`` Gemini ids this benchmark
+# defaults to (``gemini-3.1-pro-preview``) are only published on the global
+# endpoint and return 404 from a regional one. Matches the default already used
+# by devops_bench/models/{gemini,claude}.py and the claude_code harness.
+DEFAULT_VERTEX_LOCATION = "global"
+
+# Highest precedence first.
+#
+# ``GCP_VERTEX_LOCATION`` is the repo-wide spelling (models/gemini.py,
+# models/claude.py, the claude_code harness); it was missing from this chain, so
+# an operator who set the documented variable had it silently ignored here.
+#
+# ``GCP_LOCATION`` stays last and is deliberately *below* the Vertex-specific
+# name: deployers/factory.py reads it as a cluster **zone** (``us-central1-a``),
+# which is not a valid Vertex location at all. Anyone who set it for their
+# cluster should not thereby repoint model traffic.
+VERTEX_LOCATION_ENVS = (
+    "GOOGLE_CLOUD_LOCATION",
+    "GCP_VERTEX_LOCATION",
+    "GCP_LOCATION",
+)
+
+
+def vertex_location(
+    *,
+    fallback: Callable[[], str | None] | None = None,
+    default: str = DEFAULT_VERTEX_LOCATION,
+) -> str:
+    """Resolve the Vertex location for a keyless run.
+
+    Args:
+        fallback: Optional last-resort lookup (e.g. querying gcloud), consulted
+            only when every variable in :data:`VERTEX_LOCATION_ENVS` is unset.
+            Passed as a callable rather than a value so a caller whose lookup
+            shells out does not pay for it on the common configured path.
+        default: Value returned when neither the env chain nor ``fallback``
+            yields anything.
+
+    Returns:
+        The first non-empty value from :data:`VERTEX_LOCATION_ENVS`, else
+        ``fallback()``, else ``default``. Values are stripped, so a variable set
+        to whitespace is treated as unset rather than routing traffic at ``" "``.
+    """
+    for name in VERTEX_LOCATION_ENVS:
+        value = (os.environ.get(name) or "").strip()
+        if value:
+            return value
+    if fallback is not None:
+        value = (fallback() or "").strip()
+        if value:
+            return value
+    return default

--- a/docs/components/model_providers.md
+++ b/docs/components/model_providers.md
@@ -84,7 +84,7 @@ These variables still influence backend/transport details:
 | Variable | Effect |
 | --- | --- |
 | `GCP_PROJECT_ID` + `GCP_VERTEX_LOCATION` | Vertex project/region (`GCP_VERTEX_LOCATION` defaults to `global`). |
-| `GOOGLE_CLOUD_LOCATION` | Native Vertex-location override read by the Gemini CLI / antigravity harnesses; outranks `GCP_VERTEX_LOCATION`. |
+| `GOOGLE_CLOUD_LOCATION` | Native Vertex-location override read by the Gemini CLI / antigravity harnesses; outranks `GCP_VERTEX_LOCATION`. `GCP_LOCATION` is *not* read for routing — it is the deployers' cluster zone. |
 | `ANTHROPIC_BACKEND` | Forces the Claude backend (`api`/`vertex`/`bedrock`) for the bare `anthropic` provider. |
 | `AWS_REGION` / `AWS_DEFAULT_REGION` | Region for the Claude Bedrock backend. |
 | `OLLAMA_BASE_URL` | Endpoint for the Ollama server (defaults to `http://localhost:11434/v1`). |

--- a/docs/components/model_providers.md
+++ b/docs/components/model_providers.md
@@ -84,6 +84,7 @@ These variables still influence backend/transport details:
 | Variable | Effect |
 | --- | --- |
 | `GCP_PROJECT_ID` + `GCP_VERTEX_LOCATION` | Vertex project/region (`GCP_VERTEX_LOCATION` defaults to `global`). |
+| `GOOGLE_CLOUD_LOCATION` | Native Vertex-location override read by the Gemini CLI / antigravity harnesses; outranks `GCP_VERTEX_LOCATION`. |
 | `ANTHROPIC_BACKEND` | Forces the Claude backend (`api`/`vertex`/`bedrock`) for the bare `anthropic` provider. |
 | `AWS_REGION` / `AWS_DEFAULT_REGION` | Region for the Claude Bedrock backend. |
 | `OLLAMA_BASE_URL` | Endpoint for the Ollama server (defaults to `http://localhost:11434/v1`). |

--- a/tests/unit/agents/shared/test_vertex_env.py
+++ b/tests/unit/agents/shared/test_vertex_env.py
@@ -1,0 +1,101 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the shared Vertex location resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from devops_bench.agents.shared.vertex_env import (
+    DEFAULT_VERTEX_LOCATION,
+    VERTEX_LOCATION_ENVS,
+    vertex_location,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_location_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # An operator's ambient GCP_LOCATION must not decide these assertions.
+    for name in VERTEX_LOCATION_ENVS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_defaults_to_global() -> None:
+    # Not a region: the -preview model ids this benchmark runs are published
+    # only on the global endpoint and 404 from a regional one.
+    assert DEFAULT_VERTEX_LOCATION == "global"
+    assert vertex_location() == "global"
+
+
+def test_precedence_is_declaration_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Set every variable, then peel them off highest-first; each removal must
+    # hand off to exactly the next name in the tuple.
+    for index, name in enumerate(VERTEX_LOCATION_ENVS):
+        monkeypatch.setenv(name, f"loc-{index}")
+    for index, name in enumerate(VERTEX_LOCATION_ENVS):
+        assert vertex_location() == f"loc-{index}"
+        monkeypatch.delenv(name)
+    assert vertex_location() == DEFAULT_VERTEX_LOCATION
+
+
+def test_vertex_spelling_outranks_the_overloaded_gcp_location(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # deployers/factory.py owns GCP_LOCATION as a cluster *zone*, which is never
+    # a valid Vertex location. Setting the Vertex-specific name must win.
+    monkeypatch.setenv("GCP_LOCATION", "us-central1-a")
+    monkeypatch.setenv("GCP_VERTEX_LOCATION", "global")
+    assert vertex_location() == "global"
+
+
+def test_whitespace_only_value_is_treated_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Routing at " " yields an unresolvable endpoint; fall through instead.
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "   ")
+    monkeypatch.setenv("GCP_VERTEX_LOCATION", "europe-west4")
+    assert vertex_location() == "europe-west4"
+
+
+def test_value_is_stripped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", " europe-west4\n")
+    assert vertex_location() == "europe-west4"
+
+
+def test_fallback_runs_only_when_the_env_chain_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[int] = []
+
+    def _lookup() -> str | None:
+        calls.append(1)
+        return "asia-northeast1"
+
+    monkeypatch.setenv("GCP_LOCATION", "europe-west4")
+    assert vertex_location(fallback=_lookup) == "europe-west4"
+    # The antigravity caller's fallback shells out to gcloud; a configured host
+    # must not pay for that subprocess.
+    assert calls == []
+
+    monkeypatch.delenv("GCP_LOCATION")
+    assert vertex_location(fallback=_lookup) == "asia-northeast1"
+    assert calls == [1]
+
+
+@pytest.mark.parametrize("returned", [None, "", "  "])
+def test_empty_fallback_falls_through_to_the_default(returned: str | None) -> None:
+    assert vertex_location(fallback=lambda: returned) == DEFAULT_VERTEX_LOCATION
+
+
+def test_explicit_default_is_honored() -> None:
+    assert vertex_location(default="us-east5") == "us-east5"

--- a/tests/unit/agents/shared/test_vertex_env.py
+++ b/tests/unit/agents/shared/test_vertex_env.py
@@ -27,8 +27,8 @@ from devops_bench.agents.shared.vertex_env import (
 
 @pytest.fixture(autouse=True)
 def _clear_location_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    # An operator's ambient GCP_LOCATION must not decide these assertions.
-    for name in VERTEX_LOCATION_ENVS:
+    # An operator's ambient location env must not decide these assertions.
+    for name in (*VERTEX_LOCATION_ENVS, "GCP_LOCATION"):
         monkeypatch.delenv(name, raising=False)
 
 
@@ -50,14 +50,14 @@ def test_precedence_is_declaration_order(monkeypatch: pytest.MonkeyPatch) -> Non
     assert vertex_location() == DEFAULT_VERTEX_LOCATION
 
 
-def test_vertex_spelling_outranks_the_overloaded_gcp_location(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    # deployers/factory.py owns GCP_LOCATION as a cluster *zone*, which is never
-    # a valid Vertex location. Setting the Vertex-specific name must win.
+def test_the_deployers_cluster_zone_is_not_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    # GCP_LOCATION belongs to the deployers and holds a cluster *zone*
+    # (scripts/bastion/vm-setup.sh exports us-central1-a into the bastion
+    # profile). A zone is never a valid Vertex location, so it must not leak
+    # into model routing — the run falls through to the default instead.
     monkeypatch.setenv("GCP_LOCATION", "us-central1-a")
-    monkeypatch.setenv("GCP_VERTEX_LOCATION", "global")
     assert vertex_location() == "global"
+    assert "GCP_LOCATION" not in VERTEX_LOCATION_ENVS
 
 
 def test_whitespace_only_value_is_treated_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -81,13 +81,13 @@ def test_fallback_runs_only_when_the_env_chain_is_empty(
         calls.append(1)
         return "asia-northeast1"
 
-    monkeypatch.setenv("GCP_LOCATION", "europe-west4")
+    monkeypatch.setenv("GCP_VERTEX_LOCATION", "europe-west4")
     assert vertex_location(fallback=_lookup) == "europe-west4"
     # The antigravity caller's fallback shells out to gcloud; a configured host
     # must not pay for that subprocess.
     assert calls == []
 
-    monkeypatch.delenv("GCP_LOCATION")
+    monkeypatch.delenv("GCP_VERTEX_LOCATION")
     assert vertex_location(fallback=_lookup) == "asia-northeast1"
     assert calls == [1]
 

--- a/tests/unit/agents/test_agents_cli_antigravity.py
+++ b/tests/unit/agents/test_agents_cli_antigravity.py
@@ -429,11 +429,12 @@ def test_agy_cli_agent_execute_defaults_the_location_to_global(
 @mock.patch.object(agy_mod, "_get_gcloud_location", return_value="us-west9")
 @mock.patch.object(pathlib.Path, "home")
 @mock.patch.object(devops_subprocess, "run")
-def test_agy_cli_agent_execute_prefers_the_vertex_location_over_the_cluster_zone(
+def test_agy_cli_agent_execute_ignores_the_cluster_zone_for_routing(
     mock_run, mock_home, mock_gcloud_location, tmp_path
 ):
-    # GCP_LOCATION is the deployers' cluster *zone*; it must not outrank the
-    # Vertex-specific spelling and reroute model traffic at "us-central1-a".
+    # GCP_LOCATION is the deployers' cluster *zone* and is not read for routing;
+    # the Vertex-specific spelling decides. The overlay still *writes* the zone
+    # spelling for agy's own GCP tooling, now carrying the routed location.
     mock_home.return_value = tmp_path
     mock_run.return_value = SimpleNamespace(args=["agy"], returncode=0, stdout="", stderr="")
     mock_run.side_effect = lambda *args, **kwargs: (
@@ -446,7 +447,9 @@ def test_agy_cli_agent_execute_prefers_the_vertex_location_over_the_cluster_zone
     with mock.patch.dict(os.environ, env, clear=True):
         agy_mod.AgyCliAgent(config)._execute("run task")
 
-    assert mock_run.call_args.kwargs["extra_env"]["GOOGLE_CLOUD_LOCATION"] == "europe-west4"
+    overlay = mock_run.call_args.kwargs["extra_env"]
+    assert overlay["GOOGLE_CLOUD_LOCATION"] == "europe-west4"
+    assert overlay["GCP_LOCATION"] == "europe-west4"
     # A configured host must not pay for the gcloud subprocess at all.
     mock_gcloud_location.assert_not_called()
 

--- a/tests/unit/agents/test_agents_cli_antigravity.py
+++ b/tests/unit/agents/test_agents_cli_antigravity.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import sqlite3
 from types import SimpleNamespace
@@ -399,6 +400,55 @@ def test_agy_cli_agent_execute_flow(mock_run, mock_home, tmp_path):
     assert "--dangerously-skip-permissions" in args
     assert "--prompt=run task" in args
     assert any(a.startswith("--gemini_dir=") for a in args)
+
+
+@mock.patch.object(agy_mod, "_get_gcloud_location", return_value=None)
+@mock.patch.object(pathlib.Path, "home")
+@mock.patch.object(devops_subprocess, "run")
+def test_agy_cli_agent_execute_defaults_the_location_to_global(
+    mock_run, mock_home, _mock_gcloud_location, tmp_path
+):
+    # Nothing in the env chain and no gcloud default: the run must land on
+    # "global", not a region — the -preview model ids 404 on regional endpoints.
+    mock_home.return_value = tmp_path
+    mock_run.return_value = SimpleNamespace(args=["agy"], returncode=0, stdout="", stderr="")
+    mock_run.side_effect = lambda *args, **kwargs: (
+        _write_sample_transcript(kwargs.get("cwd") or tmp_path),
+        mock_run.return_value,
+    )[1]
+
+    config = agents_config.AgentConfig(target="/bin/agy", model="gemini-3.5-flash")
+    with mock.patch.dict(os.environ, {}, clear=True):
+        agy_mod.AgyCliAgent(config)._execute("run task")
+
+    overlay = mock_run.call_args.kwargs["extra_env"]
+    assert overlay["GOOGLE_CLOUD_LOCATION"] == "global"
+    assert overlay["GCP_LOCATION"] == "global"
+
+
+@mock.patch.object(agy_mod, "_get_gcloud_location", return_value="us-west9")
+@mock.patch.object(pathlib.Path, "home")
+@mock.patch.object(devops_subprocess, "run")
+def test_agy_cli_agent_execute_prefers_the_vertex_location_over_the_cluster_zone(
+    mock_run, mock_home, mock_gcloud_location, tmp_path
+):
+    # GCP_LOCATION is the deployers' cluster *zone*; it must not outrank the
+    # Vertex-specific spelling and reroute model traffic at "us-central1-a".
+    mock_home.return_value = tmp_path
+    mock_run.return_value = SimpleNamespace(args=["agy"], returncode=0, stdout="", stderr="")
+    mock_run.side_effect = lambda *args, **kwargs: (
+        _write_sample_transcript(kwargs.get("cwd") or tmp_path),
+        mock_run.return_value,
+    )[1]
+
+    config = agents_config.AgentConfig(target="/bin/agy", model="gemini-3.5-flash")
+    env = {"GCP_LOCATION": "us-central1-a", "GCP_VERTEX_LOCATION": "europe-west4"}
+    with mock.patch.dict(os.environ, env, clear=True):
+        agy_mod.AgyCliAgent(config)._execute("run task")
+
+    assert mock_run.call_args.kwargs["extra_env"]["GOOGLE_CLOUD_LOCATION"] == "europe-west4"
+    # A configured host must not pay for the gcloud subprocess at all.
+    mock_gcloud_location.assert_not_called()
 
 
 def _write_sample_transcript(

--- a/tests/unit/agents/test_agents_cli_gemini.py
+++ b/tests/unit/agents/test_agents_cli_gemini.py
@@ -201,22 +201,22 @@ def test_build_env_vertex_accepts_the_gcp_project_and_location_spellings(
     # matrix export, so a host configured for one agent works for the other.
     monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
     monkeypatch.delenv("GOOGLE_CLOUD_LOCATION", raising=False)
-    monkeypatch.delenv("GCP_VERTEX_LOCATION", raising=False)
     monkeypatch.setenv("GCP_PROJECT", "proj-a")
-    monkeypatch.setenv("GCP_LOCATION", "europe-west4")
+    monkeypatch.setenv("GCP_VERTEX_LOCATION", "europe-west4")
     env = _build_env(AgentConfig(model="gemini-2.5-pro", provider="google-vertex"))
     assert env["GOOGLE_CLOUD_PROJECT"] == "proj-a"
     assert env["GOOGLE_CLOUD_LOCATION"] == "europe-west4"
 
 
-def test_build_env_vertex_honors_the_repo_wide_vertex_location_spelling(
+def test_build_env_vertex_ignores_the_deployers_cluster_zone(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # GCP_VERTEX_LOCATION is what models/{gemini,claude}.py and the docs use;
-    # it outranks GCP_LOCATION, which deployers/factory.py owns as a cluster
-    # *zone* (us-central1-a) and which is never a valid Vertex location.
+    # GCP_LOCATION belongs to the deployers and holds a cluster *zone*;
+    # scripts/bastion/vm-setup.sh exports us-central1-a into the bastion
+    # profile. Routing model traffic there would hit an endpoint that does not
+    # exist, so it must not be read at all — fall through to the default.
     monkeypatch.delenv("GOOGLE_CLOUD_LOCATION", raising=False)
-    monkeypatch.setenv("GCP_VERTEX_LOCATION", "global")
+    monkeypatch.delenv("GCP_VERTEX_LOCATION", raising=False)
     monkeypatch.setenv("GCP_LOCATION", "us-central1-a")
     env = _build_env(AgentConfig(model="gemini-2.5-pro", provider="google-vertex"))
     assert env["GOOGLE_CLOUD_LOCATION"] == "global"
@@ -227,7 +227,6 @@ def test_build_env_vertex_prefers_google_cloud_spellings(monkeypatch: pytest.Mon
     monkeypatch.setenv("GCP_PROJECT", "proj-gcp")
     monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "asia-northeast1")
     monkeypatch.setenv("GCP_VERTEX_LOCATION", "europe-west1")
-    monkeypatch.setenv("GCP_LOCATION", "europe-west4")
     env = _build_env(AgentConfig(model="gemini-2.5-pro", provider="google-vertex"))
     assert env["GOOGLE_CLOUD_PROJECT"] == "proj-google"
     assert env["GOOGLE_CLOUD_LOCATION"] == "asia-northeast1"

--- a/tests/unit/agents/test_agents_cli_gemini.py
+++ b/tests/unit/agents/test_agents_cli_gemini.py
@@ -194,6 +194,83 @@ def test_build_env_keyless_writes_no_key_var() -> None:
     assert not {"GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_CLOUD_API_KEY"} & env.keys()
 
 
+def test_build_env_vertex_accepts_the_gcp_project_and_location_spellings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The GCP_* spellings are what the antigravity harness and the bastion
+    # matrix export, so a host configured for one agent works for the other.
+    monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+    monkeypatch.delenv("GOOGLE_CLOUD_LOCATION", raising=False)
+    monkeypatch.delenv("GCP_VERTEX_LOCATION", raising=False)
+    monkeypatch.setenv("GCP_PROJECT", "proj-a")
+    monkeypatch.setenv("GCP_LOCATION", "europe-west4")
+    env = _build_env(AgentConfig(model="gemini-2.5-pro", provider="google-vertex"))
+    assert env["GOOGLE_CLOUD_PROJECT"] == "proj-a"
+    assert env["GOOGLE_CLOUD_LOCATION"] == "europe-west4"
+
+
+def test_build_env_vertex_honors_the_repo_wide_vertex_location_spelling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # GCP_VERTEX_LOCATION is what models/{gemini,claude}.py and the docs use;
+    # it outranks GCP_LOCATION, which deployers/factory.py owns as a cluster
+    # *zone* (us-central1-a) and which is never a valid Vertex location.
+    monkeypatch.delenv("GOOGLE_CLOUD_LOCATION", raising=False)
+    monkeypatch.setenv("GCP_VERTEX_LOCATION", "global")
+    monkeypatch.setenv("GCP_LOCATION", "us-central1-a")
+    env = _build_env(AgentConfig(model="gemini-2.5-pro", provider="google-vertex"))
+    assert env["GOOGLE_CLOUD_LOCATION"] == "global"
+
+
+def test_build_env_vertex_prefers_google_cloud_spellings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "proj-google")
+    monkeypatch.setenv("GCP_PROJECT", "proj-gcp")
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "asia-northeast1")
+    monkeypatch.setenv("GCP_VERTEX_LOCATION", "europe-west1")
+    monkeypatch.setenv("GCP_LOCATION", "europe-west4")
+    env = _build_env(AgentConfig(model="gemini-2.5-pro", provider="google-vertex"))
+    assert env["GOOGLE_CLOUD_PROJECT"] == "proj-google"
+    assert env["GOOGLE_CLOUD_LOCATION"] == "asia-northeast1"
+
+
+def test_build_env_vertex_defaults_the_location_to_global(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No project anywhere: write nothing rather than an empty string, and let
+    # the SDK's own ADC-derived default apply. Location always gets a value —
+    # and that value is "global", not a region: the -preview model ids this
+    # benchmark runs are only published on the global endpoint and 404 from a
+    # regional one (docs/appendix/known_issues.md).
+    for var in (
+        "GOOGLE_CLOUD_PROJECT",
+        "GCP_PROJECT",
+        "GOOGLE_CLOUD_LOCATION",
+        "GCP_VERTEX_LOCATION",
+        "GCP_LOCATION",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    env = _build_env(AgentConfig(model="gemini-2.5-pro", provider="google-vertex"))
+    assert "GOOGLE_CLOUD_PROJECT" not in env
+    assert env["GOOGLE_CLOUD_LOCATION"] == "global"
+
+
+def test_build_env_non_vertex_writes_no_vertex_routing_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An ambient GOOGLE_CLOUD_* on the operator's shell must not leak into a
+    # Gemini-API run and silently reroute it at Vertex.
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "proj-a")
+    env = _build_env(AgentConfig(model="gemini-2.5-pro", api_key="abc"))
+    assert (
+        not {
+            "GOOGLE_GENAI_USE_VERTEXAI",
+            "GOOGLE_CLOUD_PROJECT",
+            "GOOGLE_CLOUD_LOCATION",
+        }
+        & env.keys()
+    )
+
+
 def test_build_env_unknown_provider_raises_even_when_keyless() -> None:
     # Validation is unconditional — a typoed provider fails loud on a keyless run.
     with pytest.raises(ConfigError):


### PR DESCRIPTION
> Staged on the `pradeepvrd/devops-bench` integration fork as pradeepvrd/devops-bench#24.

## The bug

`gemini_cli` and `antigravity` both defaulted an unconfigured Vertex run to `us-central1`:

```python
overlay["GOOGLE_CLOUD_LOCATION"] = (
    os.environ.get("GOOGLE_CLOUD_LOCATION")
    or os.environ.get("GCP_LOCATION")
    or "us-central1"
)
```

Every model id this benchmark routes at Vertex carries the `-preview` suffix, and those ids are published **only on the global endpoint** — a regional one answers `404 Publisher model ... not found`. `docs/appendix/known_issues.md` already says so:

> Use the **`global`** location (`GOOGLE_CLOUD_LOCATION=global` / `GCP_VERTEX_LOCATION=global`) and a `-preview` model id

So the default was the one value that cannot work. It also disagreed with `models/gemini.py`, `models/claude.py`, and the `claude_code` harness, which all default to `global`.

`scripts/bastion/_matrix_lib.sh:280` **already works around this at the shell layer**, exporting `GOOGLE_CLOUD_LOCATION=global` for Vertex matrix runs. That covers the matrix path only. A direct `run.py` invocation, a dev laptop, CI, and the sandboxed agent path all still got `us-central1`.

## The second half

Neither harness read `GCP_VERTEX_LOCATION` — the spelling the docs and the model adapters use. An operator who set the documented variable got `us-central1` anyway, silently.

## The fix

One shared `agents/shared/vertex_env.vertex_location()`, consumed by both harnesses, so the chain cannot drift apart again:

```
GOOGLE_CLOUD_LOCATION  ->  GCP_VERTEX_LOCATION  ->  (agy only: gcloud compute/region)  ->  "global"
```

### `GCP_LOCATION` is dropped, not demoted

I first demoted it below `GCP_VERTEX_LOCATION`. That wasn't enough. **Every** place this repo sets `GCP_LOCATION` sets a cluster **zone**:

| Source | Value |
| --- | --- |
| `scripts/bastion/vm-setup.sh` | `export GCP_LOCATION="us-central1-a"` — in the bastion profile |
| `scripts/bastion/_matrix_lib.sh` | `${GCP_LOCATION:-us-central1-a}` |
| `deployers/factory.py:30` | `_DEFAULT_LOCATION = "us-central1-a"` |
| `docs/components/infra.md` | documented as "Default region/zone" |

A zone is not a valid Vertex location, so reading it here could only ever route a run at an endpoint that does not exist. And because it is *always* set on the bastion, the corrected default was unreachable there. Measured on this branch:

```
GCP_LOCATION=us-central1-a, nothing else set
  demoted  -> us-central1-a      (invalid endpoint)
  dropped  -> global             (correct)
```

Operators pinning a Vertex region set `GCP_VERTEX_LOCATION`.

antigravity still **writes** `GCP_LOCATION` into its subprocess overlay — the `agy` binary's own GCP tooling has always been handed that spelling, so removing it changes the binary's inputs rather than fixing routing. That write only reaches the `agy` subprocess, never the deployers. Happy to drop it too if reviewers prefer.

### The gcloud fallback stays lazy

Passed as a callable, not a value, so a configured host never pays for the subprocess. Covered by a test.

## Deliberately not touched

`claude_code` already defaults to `global`, and its chain prefers the repo var over the native `CLOUD_ML_REGION` — the opposite order from these two. Reconciling that is a separate question from fixing a default that is wrong on its face, and that file is contended by other open PRs.

## Validation

- Unit suite green on this branch (1373 passed), ruff check and format clean. New `tests/unit/agents/shared/test_vertex_env.py` covers precedence, the zone-is-not-read rule, whitespace-only values, and fallback laziness. Two antigravity tests assert the wired behaviour end to end through `extra_env`.
- The **premise** was confirmed live on the bastion: `gemini-3.1-pro-preview` 404s at `us-central1`, returns 200 at `global`.
- **The default path has now run live** (2026-09-16, bastion): one ambient gemini_cli Vertex run on this branch's tip (`d481fd5`) with **both** `GOOGLE_CLOUD_LOCATION` and `GCP_VERTEX_LOCATION` unset via `env -u`, every API key unset (ADC only), invoked directly through `python3 -m devops_bench` — not the matrix scripts, which re-inject the location and had kept this path unreachable on the bastion until now. Run `run_20260915_222600_p4-default-loc-20260915`: status success, 24 trajectory steps, judged scores, on `gemini-3.1-pro-preview` — an id only the global endpoint serves, so the completion is itself the proof that `vertex_location()`'s in-code fallback supplied `global`. (The 404-at-`us-central1` premise measured above stands in as the negative control.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent Vertex location resolution across Gemini CLI and antigravity integrations.
  - Supports Google Cloud and Vertex-specific location settings, with a default of `global`.
  - Gemini CLI now configures Vertex routing and project settings when using the Vertex backend.
  - Cluster-zone settings are no longer used for Vertex routing.

- **Documentation**
  - Documented the `GOOGLE_CLOUD_LOCATION` environment variable and its precedence.

- **Bug Fixes**
  - Prevented non-Vertex runs from unintentionally inheriting settings that reroute traffic to Vertex.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->